### PR TITLE
refactor(quiz): R15 useQuizAnalytics + R16 useContentTree extractions

### DIFF
--- a/src/app/components/professor/QuizAnalyticsPanel.tsx
+++ b/src/app/components/professor/QuizAnalyticsPanel.tsx
@@ -6,14 +6,12 @@
 // type distribution, and question-level stats.
 //
 // Design: purple accent, recharts bar charts, collapsible.
+//
+// R15 refactor: data logic extracted to useQuizAnalytics hook.
+// This component is now pure UI (~170 lines).
 // ============================================================
 
-import React, { useState, useEffect, useMemo } from 'react';
-import * as quizApi from '@/app/services/quizApi';
-import type { QuizQuestion, QuizAttempt } from '@/app/services/quizApi';
-import { normalizeDifficulty, normalizeQuestionType } from '@/app/services/quizConstants';
-import type { Difficulty, QuestionType } from '@/app/services/quizConstants';
-import { DIFFICULTY_LABELS, QUESTION_TYPE_LABELS } from '@/app/services/quizConstants';
+import React from 'react';
 import { motion } from 'motion/react';
 import clsx from 'clsx';
 import {
@@ -24,8 +22,7 @@ import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
 } from 'recharts';
 import { MODAL_OVERLAY, MODAL_CARD, MODAL_HEADER, BTN_CLOSE, BANNER_ERROR } from '@/app/services/quizDesignTokens';
-import { logger } from '@/app/lib/logger';
-import { getErrorMsg } from '@/app/lib/error-utils';
+import { useQuizAnalytics } from '@/app/components/professor/useQuizAnalytics';
 
 // ── Props ────────────────────────────────────────────────
 
@@ -36,137 +33,12 @@ interface QuizAnalyticsPanelProps {
   onClose: () => void;
 }
 
-// ── Color maps ───────────────────────────────────────────
-
-const DIFF_CHART_COLORS: Record<Difficulty, string> = {
-  easy: '#10b981',
-  medium: '#f59e0b',
-  hard: '#ef4444',
-};
-
-const TYPE_CHART_COLORS: Record<QuestionType, string> = {
-  mcq: '#6366f1',
-  true_false: '#8b5cf6',
-  fill_blank: '#06b6d4',
-  open: '#f97316',
-};
-
 // ── Component ────────────────────────────────────────────
 
 export function QuizAnalyticsPanel({
   quizId, quizTitle, summaryId, onClose,
 }: QuizAnalyticsPanelProps) {
-  const [questions, setQuestions] = useState<QuizQuestion[]>([]);
-  const [attempts, setAttempts] = useState<QuizAttempt[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // ── Load data ──────────────────────────────────────────
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-
-    (async () => {
-      try {
-        // Load questions for this quiz
-        const res = await quizApi.getQuizQuestions(summaryId, { quiz_id: quizId, limit: 200 });
-        if (cancelled) return;
-        const items = res.items || [];
-        setQuestions(items);
-
-        // Load attempts for each question (parallel, fire-and-forget failures)
-        const attemptResults = await Promise.allSettled(
-          items.map(q => quizApi.getQuizAttempts({ quiz_question_id: q.id })),
-        );
-        if (cancelled) return;
-        const allAttempts: QuizAttempt[] = [];
-        for (const r of attemptResults) {
-          if (r.status === 'fulfilled') allAttempts.push(...r.value);
-        }
-        setAttempts(allAttempts);
-      } catch (err) {
-        if (!cancelled) setError(getErrorMsg(err));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-
-    return () => { cancelled = true; };
-  }, [quizId, summaryId]);
-
-  // ── Computed analytics ─────────────────────────────────
-
-  // Difficulty distribution
-  const diffData = useMemo(() => {
-    const counts: Record<Difficulty, number> = { easy: 0, medium: 0, hard: 0 };
-    for (const q of questions) {
-      const d = normalizeDifficulty(q.difficulty);
-      counts[d]++;
-    }
-    return (['easy', 'medium', 'hard'] as Difficulty[]).map(d => ({
-      name: DIFFICULTY_LABELS[d],
-      value: counts[d],
-      fill: DIFF_CHART_COLORS[d],
-    }));
-  }, [questions]);
-
-  // Type distribution
-  const typeData = useMemo(() => {
-    const counts: Record<QuestionType, number> = { mcq: 0, true_false: 0, fill_blank: 0, open: 0 };
-    for (const q of questions) {
-      const t = normalizeQuestionType(q.question_type);
-      counts[t]++;
-    }
-    return (['mcq', 'true_false', 'fill_blank', 'open'] as QuestionType[])
-      .filter(t => counts[t] > 0)
-      .map(t => ({
-        name: QUESTION_TYPE_LABELS[t],
-        value: counts[t],
-        fill: TYPE_CHART_COLORS[t],
-      }));
-  }, [questions]);
-
-  // Per-question stats
-  const questionStats = useMemo(() => {
-    const attemptsByQ = new Map<string, QuizAttempt[]>();
-    for (const a of attempts) {
-      const list = attemptsByQ.get(a.quiz_question_id) || [];
-      list.push(a);
-      attemptsByQ.set(a.quiz_question_id, list);
-    }
-    return questions.map((q, i) => {
-      const qAttempts = attemptsByQ.get(q.id) || [];
-      const totalAttempts = qAttempts.length;
-      const correctAttempts = qAttempts.filter(a => a.is_correct).length;
-      const avgTimeMs = qAttempts.length > 0
-        ? qAttempts.reduce((sum, a) => sum + (a.time_taken_ms || 0), 0) / qAttempts.length
-        : 0;
-      return {
-        question: q,
-        index: i + 1,
-        totalAttempts,
-        correctAttempts,
-        successRate: totalAttempts > 0 ? (correctAttempts / totalAttempts) * 100 : 0,
-        avgTimeSec: avgTimeMs / 1000,
-      };
-    }).sort((a, b) => a.successRate - b.successRate); // Hardest first
-  }, [questions, attempts]);
-
-  // Global stats
-  const globalStats = useMemo(() => {
-    const totalAttempts = attempts.length;
-    const correctAttempts = attempts.filter(a => a.is_correct).length;
-    const avgTimeMs = totalAttempts > 0
-      ? attempts.reduce((sum, a) => sum + (a.time_taken_ms || 0), 0) / totalAttempts
-      : 0;
-    return {
-      totalQuestions: questions.length,
-      totalAttempts,
-      globalSuccessRate: totalAttempts > 0 ? Math.round((correctAttempts / totalAttempts) * 100) : 0,
-      avgTimeSec: (avgTimeMs / 1000).toFixed(1),
-    };
-  }, [questions, attempts]);
+  const { loading, error, diffData, typeData, questionStats, globalStats } = useQuizAnalytics(quizId, summaryId);
 
   return (
     <motion.div
@@ -312,7 +184,7 @@ export function QuizAnalyticsPanel({
   );
 }
 
-// ── Stat Card ──────────────────────────────────────────
+// ── Stat Card ────────────────────────────────────────────
 
 function StatCard({ icon, label, value, color }: {
   icon: React.ReactNode; label: string; value: string; color: string;

--- a/src/app/components/professor/useQuizAnalytics.ts
+++ b/src/app/components/professor/useQuizAnalytics.ts
@@ -1,0 +1,184 @@
+// ============================================================
+// Axon — Professor: useQuizAnalytics Hook (R15 Extraction)
+//
+// Encapsulates data loading and computed analytics for a quiz:
+//   - Loads questions + attempts in parallel
+//   - Computes difficulty distribution, type distribution,
+//     per-question stats, and global stats
+//
+// Extracted from QuizAnalyticsPanel.tsx to separate concerns
+// (data logic vs UI) and make analytics reusable.
+// ============================================================
+
+import { useState, useEffect, useMemo } from 'react';
+import * as quizApi from '@/app/services/quizApi';
+import type { QuizQuestion, QuizAttempt } from '@/app/services/quizApi';
+import { normalizeDifficulty, normalizeQuestionType } from '@/app/services/quizConstants';
+import type { Difficulty, QuestionType } from '@/app/services/quizConstants';
+import { DIFFICULTY_LABELS, QUESTION_TYPE_LABELS } from '@/app/services/quizConstants';
+import { getErrorMsg } from '@/app/lib/error-utils';
+
+// ── Color maps ───────────────────────────────────────────
+
+export const DIFF_CHART_COLORS: Record<Difficulty, string> = {
+  easy: '#10b981',
+  medium: '#f59e0b',
+  hard: '#ef4444',
+};
+
+export const TYPE_CHART_COLORS: Record<QuestionType, string> = {
+  mcq: '#6366f1',
+  true_false: '#8b5cf6',
+  fill_blank: '#06b6d4',
+  open: '#f97316',
+};
+
+// ── Types ────────────────────────────────────────────────
+
+export interface ChartDatum {
+  name: string;
+  value: number;
+  fill: string;
+}
+
+export interface QuestionStat {
+  question: QuizQuestion;
+  index: number;
+  totalAttempts: number;
+  correctAttempts: number;
+  successRate: number;
+  avgTimeSec: number;
+}
+
+export interface GlobalStats {
+  totalQuestions: number;
+  totalAttempts: number;
+  globalSuccessRate: number;
+  avgTimeSec: string;
+}
+
+export interface UseQuizAnalyticsReturn {
+  loading: boolean;
+  error: string | null;
+  diffData: ChartDatum[];
+  typeData: ChartDatum[];
+  questionStats: QuestionStat[];
+  globalStats: GlobalStats;
+}
+
+// ── Hook ─────────────────────────────────────────────────
+
+export function useQuizAnalytics(
+  quizId: string,
+  summaryId: string,
+): UseQuizAnalyticsReturn {
+  const [questions, setQuestions] = useState<QuizQuestion[]>([]);
+  const [attempts, setAttempts] = useState<QuizAttempt[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // ── Load data ──────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const res = await quizApi.getQuizQuestions(summaryId, { quiz_id: quizId, limit: 200 });
+        if (cancelled) return;
+        const items = res.items || [];
+        setQuestions(items);
+
+        const attemptResults = await Promise.allSettled(
+          items.map(q => quizApi.getQuizAttempts({ quiz_question_id: q.id })),
+        );
+        if (cancelled) return;
+        const allAttempts: QuizAttempt[] = [];
+        for (const r of attemptResults) {
+          if (r.status === 'fulfilled') allAttempts.push(...r.value);
+        }
+        setAttempts(allAttempts);
+      } catch (err) {
+        if (!cancelled) setError(getErrorMsg(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [quizId, summaryId]);
+
+  // ── Difficulty distribution ────────────────────────────
+  const diffData = useMemo<ChartDatum[]>(() => {
+    const counts: Record<Difficulty, number> = { easy: 0, medium: 0, hard: 0 };
+    for (const q of questions) {
+      const d = normalizeDifficulty(q.difficulty);
+      counts[d]++;
+    }
+    return (['easy', 'medium', 'hard'] as Difficulty[]).map(d => ({
+      name: DIFFICULTY_LABELS[d],
+      value: counts[d],
+      fill: DIFF_CHART_COLORS[d],
+    }));
+  }, [questions]);
+
+  // ── Type distribution ─────────────────────────────────
+  const typeData = useMemo<ChartDatum[]>(() => {
+    const counts: Record<QuestionType, number> = { mcq: 0, true_false: 0, fill_blank: 0, open: 0 };
+    for (const q of questions) {
+      const t = normalizeQuestionType(q.question_type);
+      counts[t]++;
+    }
+    return (['mcq', 'true_false', 'fill_blank', 'open'] as QuestionType[])
+      .filter(t => counts[t] > 0)
+      .map(t => ({
+        name: QUESTION_TYPE_LABELS[t],
+        value: counts[t],
+        fill: TYPE_CHART_COLORS[t],
+      }));
+  }, [questions]);
+
+  // ── Per-question stats (sorted hardest first) ──────────
+  const questionStats = useMemo<QuestionStat[]>(() => {
+    const attemptsByQ = new Map<string, QuizAttempt[]>();
+    for (const a of attempts) {
+      const list = attemptsByQ.get(a.quiz_question_id) || [];
+      list.push(a);
+      attemptsByQ.set(a.quiz_question_id, list);
+    }
+    return questions.map((q, i) => {
+      const qAttempts = attemptsByQ.get(q.id) || [];
+      const totalAttempts = qAttempts.length;
+      const correctAttempts = qAttempts.filter(a => a.is_correct).length;
+      const avgTimeMs = qAttempts.length > 0
+        ? qAttempts.reduce((sum, a) => sum + (a.time_taken_ms || 0), 0) / qAttempts.length
+        : 0;
+      return {
+        question: q,
+        index: i + 1,
+        totalAttempts,
+        correctAttempts,
+        successRate: totalAttempts > 0 ? (correctAttempts / totalAttempts) * 100 : 0,
+        avgTimeSec: avgTimeMs / 1000,
+      };
+    }).sort((a, b) => a.successRate - b.successRate);
+  }, [questions, attempts]);
+
+  // ── Global stats ───────────────────────────────────────
+  const globalStats = useMemo<GlobalStats>(() => {
+    const totalAttempts = attempts.length;
+    const correctAttempts = attempts.filter(a => a.is_correct).length;
+    const avgTimeMs = totalAttempts > 0
+      ? attempts.reduce((sum, a) => sum + (a.time_taken_ms || 0), 0) / totalAttempts
+      : 0;
+    return {
+      totalQuestions: questions.length,
+      totalAttempts,
+      globalSuccessRate: totalAttempts > 0 ? Math.round((correctAttempts / totalAttempts) * 100) : 0,
+      avgTimeSec: (avgTimeMs / 1000).toFixed(1),
+    };
+  }, [questions, attempts]);
+
+  return { loading, error, diffData, typeData, questionStats, globalStats };
+}

--- a/src/app/components/roles/pages/professor/useQuizCascade.tsx
+++ b/src/app/components/roles/pages/professor/useQuizCascade.tsx
@@ -1,10 +1,10 @@
 // ============================================================
 // Axon — Professor: useQuizCascade Hook
 // C3 cleanup: kw.term → kw.name || kw.term
+// R16 refactor: content tree loading extracted to useContentTree
 // ============================================================
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useAuth } from '@/app/context/AuthContext';
 import { apiCall } from '@/app/lib/api';
 import type { CascadeLevelConfig } from '@/app/components/professor/CascadeSelector';
 import type { Summary, Keyword } from '@/app/types/platform';
@@ -12,6 +12,7 @@ import {
   BookOpen, FileText, ClipboardList, GraduationCap, Layers,
 } from 'lucide-react';
 import { logger } from '@/app/lib/logger';
+import { useContentTree } from '@/app/hooks/useContentTree';
 
 // ── Stable icon constants (fix H-1) ──
 
@@ -20,40 +21,6 @@ const ICON_SEMESTER = <GraduationCap size={12} className="text-gray-400 shrink-0
 const ICON_SECTION = <Layers size={12} className="text-gray-400 shrink-0" />;
 const ICON_TOPIC = <FileText size={12} className="text-gray-400 shrink-0" />;
 const ICON_SUMMARY = <ClipboardList size={12} className="text-purple-500 shrink-0" />;
-
-// ── Content-tree types ──
-
-interface ContentTreeTopic {
-  id: string;
-  name: string;
-  order_index?: number;
-}
-
-interface ContentTreeSection {
-  id: string;
-  name: string;
-  order_index?: number;
-  topics: ContentTreeTopic[];
-}
-
-interface ContentTreeSemester {
-  id: string;
-  name: string;
-  order_index?: number;
-  sections: ContentTreeSection[];
-}
-
-interface ContentTreeCourse {
-  id: string;
-  name: string;
-  semesters: ContentTreeSemester[];
-}
-
-interface MembershipLite {
-  id: string;
-  course_id: string;
-  role: string;
-}
 
 function extractItems<T>(res: { items: T[] } | T[]): T[] {
   return Array.isArray(res) ? res : res.items;
@@ -73,11 +40,9 @@ export interface UseQuizCascadeReturn {
 // ── Hook ──
 
 export function useQuizCascade(): UseQuizCascadeReturn {
-  const { selectedInstitution } = useAuth();
-  const institutionId = selectedInstitution?.id || null;
+  // R16: content tree loaded by shared hook
+  const { contentTree, treeLoading } = useContentTree();
 
-  const [contentTree, setContentTree] = useState<ContentTreeCourse[]>([]);
-  const [treeLoading, setTreeLoading] = useState(true);
   const [summaries, setSummaries] = useState<Summary[]>([]);
   const [summariesLoading, setSummariesLoading] = useState(false);
   const [keywords, setKeywords] = useState<Keyword[]>([]);
@@ -87,41 +52,6 @@ export function useQuizCascade(): UseQuizCascadeReturn {
   const [selectedSectionId, setSelectedSectionId] = useState('');
   const [selectedTopicId, setSelectedTopicId] = useState('');
   const [selectedSummaryId, setSelectedSummaryId] = useState<string | null>(null);
-
-  // 1. Load content-tree
-  useEffect(() => {
-    if (!institutionId) {
-      setContentTree([]);
-      setTreeLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setTreeLoading(true);
-    (async () => {
-      try {
-        const [tree, memberships] = await Promise.all([
-          apiCall<ContentTreeCourse[]>(`/content-tree?institution_id=${institutionId}`),
-          apiCall<MembershipLite[]>(`/memberships?institution_id=${institutionId}`),
-        ]);
-        if (cancelled) return;
-
-        const allCourses = Array.isArray(tree) ? tree : [];
-        const profCourseIds = (memberships || [])
-          .filter(m => m.role?.toLowerCase() === 'professor')
-          .map(m => m.course_id)
-          .filter(Boolean);
-
-        const professorCourses = allCourses.filter(c => profCourseIds.includes(c.id));
-        setContentTree(professorCourses.length > 0 ? professorCourses : allCourses);
-      } catch (err) {
-        logger.error('[Quiz] Content tree load error:', err);
-        if (!cancelled) setContentTree([]);
-      } finally {
-        if (!cancelled) setTreeLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [institutionId]);
 
   const courses = useMemo(() =>
     contentTree.map(c => ({ id: c.id, name: c.name })),
@@ -215,8 +145,6 @@ export function useQuizCascade(): UseQuizCascadeReturn {
   }, [selectedSummaryId]);
 
   // C3: kw.name || kw.term for DB column compatibility
-  // Type-safe cast: Keyword.name may exist in DB but isn't in
-  // the TS type yet. Avoids `as any` per Gemini review.
   const keywordMap = useMemo(() => {
     const map = new Map<string, string>();
     for (const kw of keywords) {

--- a/src/app/hooks/useContentTree.ts
+++ b/src/app/hooks/useContentTree.ts
@@ -1,0 +1,101 @@
+// ============================================================
+// Axon — Shared: useContentTree Hook (R16 Extraction)
+//
+// Loads the institution's content tree (courses → semesters →
+// sections → topics) and filters by professor memberships.
+//
+// Extracted from useQuizCascade.tsx to be reusable across
+// quiz, flashcard, summary, and other cascade selectors.
+// ============================================================
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/app/context/AuthContext';
+import { apiCall } from '@/app/lib/api';
+import { logger } from '@/app/lib/logger';
+
+// ── Content-tree types ───────────────────────────────────
+
+export interface ContentTreeTopic {
+  id: string;
+  name: string;
+  order_index?: number;
+}
+
+export interface ContentTreeSection {
+  id: string;
+  name: string;
+  order_index?: number;
+  topics: ContentTreeTopic[];
+}
+
+export interface ContentTreeSemester {
+  id: string;
+  name: string;
+  order_index?: number;
+  sections: ContentTreeSection[];
+}
+
+export interface ContentTreeCourse {
+  id: string;
+  name: string;
+  semesters: ContentTreeSemester[];
+}
+
+interface MembershipLite {
+  id: string;
+  course_id: string;
+  role: string;
+}
+
+// ── Return type ──────────────────────────────────────────
+
+export interface UseContentTreeReturn {
+  contentTree: ContentTreeCourse[];
+  treeLoading: boolean;
+}
+
+// ── Hook ─────────────────────────────────────────────────
+
+export function useContentTree(): UseContentTreeReturn {
+  const { selectedInstitution } = useAuth();
+  const institutionId = selectedInstitution?.id || null;
+
+  const [contentTree, setContentTree] = useState<ContentTreeCourse[]>([]);
+  const [treeLoading, setTreeLoading] = useState(true);
+
+  useEffect(() => {
+    if (!institutionId) {
+      setContentTree([]);
+      setTreeLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setTreeLoading(true);
+    (async () => {
+      try {
+        const [tree, memberships] = await Promise.all([
+          apiCall<ContentTreeCourse[]>(`/content-tree?institution_id=${institutionId}`),
+          apiCall<MembershipLite[]>(`/memberships?institution_id=${institutionId}`),
+        ]);
+        if (cancelled) return;
+
+        const allCourses = Array.isArray(tree) ? tree : [];
+        const profCourseIds = (memberships || [])
+          .filter(m => m.role?.toLowerCase() === 'professor')
+          .map(m => m.course_id)
+          .filter(Boolean);
+
+        const professorCourses = allCourses.filter(c => profCourseIds.includes(c.id));
+        setContentTree(professorCourses.length > 0 ? professorCourses : allCourses);
+      } catch (err) {
+        logger.error('[ContentTree] Load error:', err);
+        if (!cancelled) setContentTree([]);
+      } finally {
+        if (!cancelled) setTreeLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [institutionId]);
+
+  return { contentTree, treeLoading };
+}


### PR DESCRIPTION
## Resumen

Continuacion de la modularizacion del modulo quiz post-PR #38. Dos extracciones de hooks que separan logica de datos de UI.

## Cambios

### R15: `useQuizAnalytics` (NUEVO)
- **Archivo**: `src/app/components/professor/useQuizAnalytics.ts` (~160 lineas)
- Extrae de `QuizAnalyticsPanel.tsx` toda la logica de datos:
  - `useEffect` para cargar questions + attempts en paralelo
  - 4 `useMemo` computados: `diffData`, `typeData`, `questionStats`, `globalStats`
  - Color maps (`DIFF_CHART_COLORS`, `TYPE_CHART_COLORS`)
  - Tipos exportados: `ChartDatum`, `QuestionStat`, `GlobalStats`
- `QuizAnalyticsPanel.tsx` queda como **puro UI** (~170 lineas)
- El hook es reutilizable para futuros dashboards consolidados

### R16: `useContentTree` (NUEVO)
- **Archivo**: `src/app/hooks/useContentTree.ts` (~95 lineas)
- Extrae de `useQuizCascade.tsx` la carga del content-tree:
  - Tipos: `ContentTreeCourse`, `ContentTreeSemester`, `ContentTreeSection`, `ContentTreeTopic`
  - `useEffect` con `Promise.all` para tree + memberships
  - Filtrado por memberships de profesor
- `useQuizCascade.tsx` ahora consume `useContentTree()` y se enfoca solo en la logica de seleccion cascade (~200 lineas)
- Hook reutilizable para flashcards, resumenes, o cualquier cascade selector

## Archivos modificados
| Archivo | Accion | Lineas aprox |
|---|---|---|
| `src/app/components/professor/useQuizAnalytics.ts` | NUEVO | ~160 |
| `src/app/components/professor/QuizAnalyticsPanel.tsx` | ACTUALIZADO (solo UI) | ~170 |
| `src/app/hooks/useContentTree.ts` | NUEVO | ~95 |
| `src/app/components/roles/pages/professor/useQuizCascade.tsx` | ACTUALIZADO (usa useContentTree) | ~200 |

## Verificacion
- [ ] Todos los exports preservados (backward compatible)
- [ ] Sin cambios de funcionalidad
- [ ] Todos los archivos bajo 500 lineas (Architecture Practices)
- [ ] Solo archivos de quiz tocados (Guidelines)

## Notas
- R17 (quizTypes.ts) ya estaba implementado via el domain split de PR #38
- R18 (useQuizTakerInputs) ya estaba implementado como `useQuizNavigation.ts`
- Con esto se cierran las 4 oportunidades de modularizacion identificadas en la auditoria