### PR TITLE
feat(responsive): Phase 3 — Dashboard & Review views mobile responsive

### DIFF
--- a/src/app/components/content/KnowledgeHeatmapView.tsx
+++ b/src/app/components/content/KnowledgeHeatmapView.tsx
@@ -20,8 +20,8 @@ import {
 import clsx from 'clsx';
 import { AxonPageHeader } from '@/app/components/shared/AxonPageHeader';
 import { headingStyle, components, colors } from '@/app/design-system';
+import { MobileDrawer } from '@/app/components/layout/MobileDrawer';
 
-// Mock calendar data for the heatmap
 interface CalendarEvent {
   day: number;
   title: string;
@@ -51,22 +51,13 @@ const CALENDAR_EVENTS: CalendarEvent[] = [
 ];
 
 const HEAT_LEVELS: HeatLevel[] = [
-  { day: 4, level: 'med' },
-  { day: 6, level: 'high' },
-  { day: 10, level: 'med' },
-  { day: 18, level: 'med' },
-  { day: 25, level: 'high' },
+  { day: 4, level: 'med' }, { day: 6, level: 'high' }, { day: 10, level: 'med' }, { day: 18, level: 'med' }, { day: 25, level: 'high' },
 ];
 
-// Memory timeline data
 const TIMELINE_DATA = {
   activeSession: { subject: 'Fisiologia II: Integração', retentionBoost: 15, progress: 65 },
   overallRetention: 84,
-  criticalAlert: {
-    subject: 'Anatomia Patológica: Neoplasias',
-    retention: 45,
-    message: 'Você pulou a última revisão. A retenção caiu para 45%.',
-  },
+  criticalAlert: { subject: 'Anatomia Patológica: Neoplasias', retention: 45, message: 'Você pulou a última revisão. A retenção caiu para 45%.' },
 };
 
 const CATEGORY_STYLES = {
@@ -75,104 +66,125 @@ const CATEGORY_STYLES = {
   core: 'bg-emerald-500/15 border-l-4 border-l-emerald-500 text-emerald-900',
 };
 
+// ── Memory Timeline Sidebar Content (extracted for reuse in drawer) ──
+function MemoryTimelineSidebar({ navigateTo, isConnected, stats, bktStates, overallRetention, criticalTopic }: {
+  navigateTo: (route: string) => void; isConnected: boolean; stats: any; bktStates: any[]; overallRetention: number;
+  criticalTopic: { topicTitle: string; masteryPercent: number; flashcardsDue: number } | null;
+}) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 lg:px-6 py-4 lg:py-6 border-b border-gray-200/50 flex items-start justify-between shrink-0 bg-white/20">
+        <div>
+          <h2 className="text-gray-800 text-base lg:text-lg" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>Memory Timeline</h2>
+          <p className="text-gray-400 text-xs mt-1">Impacto do estudo de hoje na retenção</p>
+        </div>
+        <div className="w-10 h-10 flex items-center justify-center bg-white/50 rounded-xl shadow-sm border border-white"><Activity size={18} className="text-violet-500" /></div>
+      </div>
+      <div className="flex-1 overflow-y-auto custom-scrollbar-light px-4 lg:px-6 py-4 lg:py-6 space-y-6 lg:space-y-8">
+        <div className="relative pl-4 border-l-2 border-violet-500/30">
+          <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-violet-500 border-4 border-[#f5f6fa]" />
+          <div className="mb-6">
+            <h3 className="text-sm text-gray-700 mb-2" style={{ fontWeight: 700 }}>Agora (14 Fev)</h3>
+            <div className="bg-white rounded-xl p-3 lg:p-4 shadow-md ring-1 ring-violet-500/20 relative overflow-hidden">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center text-blue-600 shrink-0"><Brain size={18} /></div>
+                <div className="min-w-0">
+                  <div className="text-[10px] uppercase tracking-wider text-gray-400" style={{ fontWeight: 700 }}>{isConnected && stats ? 'Sessão Atual' : 'Sessão Ativa'}</div>
+                  <div className="text-sm text-gray-800 truncate" style={{ fontWeight: 700 }}>{isConnected && stats ? `${stats.totalSessions} sessões realizadas` : TIMELINE_DATA.activeSession.subject}</div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="flex justify-between text-xs"><span className="text-gray-400">{isConnected ? 'Retenção Média' : 'Aumento de Retenção Projetado'}</span><span className="text-emerald-600" style={{ fontWeight: 700 }}>{isConnected && bktStates.length > 0 ? `${Math.round(bktStates.reduce((s: number, b: any) => s + b.p_know, 0) / bktStates.length * 100)}%` : `+${TIMELINE_DATA.activeSession.retentionBoost}%`}</span></div>
+                <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden"><div className="h-full bg-gradient-to-r from-blue-400 to-emerald-400 rounded-full" style={{ width: `${isConnected && bktStates.length > 0 ? Math.round(bktStates.reduce((s: number, b: any) => s + b.p_know, 0) / bktStates.length * 100) : TIMELINE_DATA.activeSession.progress}%` }} /></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="relative pl-4 border-l-2 border-dashed border-gray-300">
+          <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-300 border-4 border-[#f5f6fa]" />
+          <div className="mb-6">
+            <h3 className="text-xs text-gray-400 uppercase tracking-wider mb-2" style={{ fontWeight: 700 }}>Amanhã (15 Fev)</h3>
+            <div className="bg-white/60 rounded-xl p-3 border border-white hover:bg-white transition-colors">
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-1 mb-1"><span className="text-sm text-gray-700" style={{ fontWeight: 700 }}>Primeira Revisão</span><span className="px-2 py-0.5 rounded text-[10px] bg-amber-100 text-amber-700 self-start" style={{ fontWeight: 500 }}>Prioridade Média</span></div>
+              <p className="text-xs text-gray-400 leading-relaxed">Completar a sessão de hoje agendará uma revisão curta para amanhã para solidificar os traços iniciais.</p>
+            </div>
+          </div>
+        </div>
+        <div className="relative pl-4 border-l-2 border-dashed border-gray-300">
+          <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-300 border-4 border-[#f5f6fa]" />
+          <div className="mb-6">
+            <h3 className="text-xs text-gray-400 uppercase tracking-wider mb-2" style={{ fontWeight: 700 }}>Em 3 Dias (17 Fev)</h3>
+            <div className="bg-white/40 rounded-xl p-3 border border-white/60">
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-1 mb-1"><span className="text-sm text-gray-700" style={{ fontWeight: 700 }}>Consolidação</span><span className="px-2 py-0.5 rounded text-[10px] bg-emerald-100 text-emerald-700 self-start" style={{ fontWeight: 500 }}>Baixo Esforço</span></div>
+              <p className="text-xs text-gray-400 leading-relaxed">Estabilidade da memória atinge 80%. Uma revisão rápida de 5 min estenderá a retenção para 2 semanas.</p>
+            </div>
+          </div>
+        </div>
+        <div className="relative pl-4 border-l-2 border-red-200">
+          <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-red-400 border-4 border-[#f5f6fa] animate-pulse" />
+          <div>
+            <h3 className="text-xs text-red-500 uppercase tracking-wider mb-2 flex items-center gap-1" style={{ fontWeight: 700 }}><AlertTriangle size={12} /> Queda Crítica</h3>
+            <div className="bg-gradient-to-br from-red-50 to-orange-50 rounded-xl p-3 lg:p-4 border border-red-100 shadow-sm">
+              <h4 className="text-sm text-red-900 mb-1" style={{ fontWeight: 700 }}>{criticalTopic ? criticalTopic.topicTitle : TIMELINE_DATA.criticalAlert.subject}</h4>
+              <p className="text-xs text-red-700/80 mb-3">{criticalTopic ? `Retenção caiu para ${criticalTopic.masteryPercent}%. ${criticalTopic.flashcardsDue} cards pendentes.` : TIMELINE_DATA.criticalAlert.message}</p>
+              <button onClick={() => navigateTo('review-session')} className="w-full py-2 bg-white border border-red-200 text-red-600 text-xs rounded shadow-sm hover:bg-red-50 transition-colors min-h-[44px]" style={{ fontWeight: 700 }}>Agendar Revisão de Emergência</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="p-3 lg:p-4 border-t border-gray-200/50 bg-white/30 backdrop-blur-md shrink-0">
+        <div className="bg-white/60 rounded-lg p-3 border border-white/60 flex items-center justify-between">
+          <div><div className="text-[10px] text-gray-400 uppercase tracking-wider" style={{ fontWeight: 700 }}>Retenção Geral</div><div className="text-2xl text-gray-800" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>{overallRetention}%</div></div>
+          <div className="h-10 w-24"><svg className="w-full h-full text-emerald-500" preserveAspectRatio="none" viewBox="0 0 100 40"><path d="M0 30 Q 10 35, 20 25 T 40 20 T 60 15 T 80 5 L 100 10 L 100 40 L 0 40 Z" fill="currentColor" opacity="0.2" /><path d="M0 30 Q 10 35, 20 25 T 40 20 T 60 15 T 80 5 L 100 10" fill="none" stroke="currentColor" strokeWidth="2" /></svg></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function KnowledgeHeatmapView() {
   const { navigateTo } = useStudentNav();
   const { dailyActivity, bktStates, stats, isConnected } = useStudentDataContext();
   const { tree } = useContentTree();
   const [selectedDay, setSelectedDay] = useState<number | null>(6);
   const [currentMonth] = useState('Fevereiro 2026');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Build topic lookup from content tree
   const topicLookup = useMemo(() => {
     const map = new Map<string, string>();
     if (!tree) return map;
-    for (const course of tree.courses) {
-      for (const semester of course.semesters) {
-        for (const section of semester.sections) {
-          for (const topic of section.topics) {
-            map.set(topic.id, topic.name);
-          }
-        }
-      }
-    }
+    for (const course of tree.courses) for (const semester of course.semesters) for (const section of semester.sections) for (const topic of section.topics) map.set(topic.id, topic.name);
     return map;
   }, [tree]);
 
   const daysOfWeek = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
-  
-  // Calendar grid: Feb 2026 starts on Sunday
-  const prevMonthDays = [26, 27, 28, 29, 30]; // from previous month
-  const daysInMonth = 28; // Feb 2026
+  const prevMonthDays = [26, 27, 28, 29, 30];
+  const daysInMonth = 28;
   const today = 14;
 
-  // Build heat levels from real daily activity data
   const activityMap = new Map<number, { minutes: number; cards: number; retention: number | null; sessions: number }>();
   if (isConnected && dailyActivity.length > 0) {
-    dailyActivity.forEach(d => {
-      const date = new Date(d.date + 'T12:00:00');
-      if (date.getMonth() === 1 && date.getFullYear() === 2026) { // February 2026
-        activityMap.set(date.getDate(), {
-          minutes: d.studyMinutes,
-          cards: d.cardsReviewed,
-          retention: d.retentionPercent ?? null,
-          sessions: d.sessionsCount,
-        });
-      }
-    });
+    dailyActivity.forEach(d => { const date = new Date(d.date + 'T12:00:00'); if (date.getMonth() === 1 && date.getFullYear() === 2026) activityMap.set(date.getDate(), { minutes: d.studyMinutes, cards: d.cardsReviewed, retention: d.retentionPercent ?? null, sessions: d.sessionsCount }); });
   }
 
   const getHeatLevel = (day: number): 'high' | 'med' | 'none' => {
-    // Use real activity data if connected
     const data = activityMap.get(day);
-    if (data && data.minutes > 0) {
-      if (data.minutes >= 80) return 'high';
-      if (data.minutes >= 30) return 'med';
-      return 'none';
-    }
-    // Fallback to mock heat levels when not connected
-    if (!isConnected || activityMap.size === 0) {
-      const mock = HEAT_LEVELS.find(h => h.day === day);
-      return mock?.level || 'none';
-    }
+    if (data && data.minutes > 0) { if (data.minutes >= 80) return 'high'; if (data.minutes >= 30) return 'med'; return 'none'; }
+    if (!isConnected || activityMap.size === 0) { const mock = HEAT_LEVELS.find(h => h.day === day); return mock?.level || 'none'; }
     return 'none';
   };
 
   const getEventsForDay = (day: number) => {
     const data = activityMap.get(day);
     const mockEvents = CALENDAR_EVENTS.filter(e => e.day === day);
-    if (isConnected && data && data.minutes > 0) {
-      // Build real activity event
-      const realEvent: CalendarEvent = {
-        day,
-        title: `${data.sessions} sessão(ões)`,
-        category: 'core' as const,
-        cards: data.cards > 0 ? data.cards : undefined,
-        noteText: `${data.minutes} min estudados`,
-      };
-      return mockEvents.length > 0 ? mockEvents : [realEvent];
-    }
+    if (isConnected && data && data.minutes > 0) { const realEvent: CalendarEvent = { day, title: `${data.sessions} sessão(ões)`, category: 'core', cards: data.cards > 0 ? data.cards : undefined, noteText: `${data.minutes} min estudados` }; return mockEvents.length > 0 ? mockEvents : [realEvent]; }
     return mockEvents;
   };
 
-  // Compute overall retention from BKT data
-  const overallRetention = isConnected && bktStates.length > 0
-    ? Math.round(
-        bktStates.reduce((sum, b) => sum + b.p_know, 0) / bktStates.length * 100
-      )
-    : TIMELINE_DATA.overallRetention;
+  const overallRetention = isConnected && bktStates.length > 0 ? Math.round(bktStates.reduce((sum, b) => sum + b.p_know, 0) / bktStates.length * 100) : TIMELINE_DATA.overallRetention;
 
-  // Find critical topics (lowest mastery from BKT)
   const criticalTopic = isConnected && bktStates.length > 0
-    ? (() => {
-        const sorted = [...bktStates].sort((a, b) => a.p_know - b.p_know);
-        const worst = sorted[0];
-        return worst ? {
-          topicId: worst.subtopic_id,
-          topicTitle: topicLookup.get(worst.subtopic_id) || `Subtópico ${worst.subtopic_id.slice(0, 8)}`,
-          masteryPercent: Math.round(worst.p_know * 100),
-          flashcardsDue: worst.total_attempts > 0 ? Math.max(1, 5 - worst.correct_attempts) : 5,
-        } : null;
-      })()
+    ? (() => { const sorted = [...bktStates].sort((a, b) => a.p_know - b.p_know); const worst = sorted[0]; return worst ? { topicId: worst.subtopic_id, topicTitle: topicLookup.get(worst.subtopic_id) || `Subtópico ${worst.subtopic_id.slice(0, 8)}`, masteryPercent: Math.round(worst.p_know * 100), flashcardsDue: worst.total_attempts > 0 ? Math.max(1, 5 - worst.correct_attempts) : 5 } : null; })()
     : null;
 
   const heatBg = (level: string) => {
@@ -183,344 +195,93 @@ export function KnowledgeHeatmapView() {
 
   return (
     <div className="h-full flex flex-col bg-[#f5f6fa]">
-      {/* Header */}
       <div className="shrink-0">
         <AxonPageHeader
           title="Knowledge Heatmap"
           subtitle="Mapa de calor de conhecimento"
           onBack={() => navigateTo('schedule')}
-          statsLeft={
-            <div className="flex items-center gap-2 text-xs text-gray-500 bg-white/60 px-3 py-1.5 rounded-full border border-gray-200/60">
-              <span className="w-2 h-2 rounded-full bg-red-500" /> Alta carga
-              <span className="w-2 h-2 rounded-full bg-orange-500 ml-2" /> Média
-              <span className="w-2 h-2 rounded-full bg-emerald-500 ml-2" /> Baixa
-            </div>
-          }
-          statsRight={
-            <div className="flex items-center gap-1 bg-white/60 rounded-lg p-1 border border-gray-200/60">
-              <button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400">
-                <ChevronLeft size={18} />
-              </button>
-              <button className="px-3 py-1 text-sm text-gray-700">{currentMonth}</button>
-              <button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400">
-                <ChevronRight size={18} />
-              </button>
-            </div>
-          }
+          statsLeft={<div className="flex items-center gap-1.5 lg:gap-2 text-[10px] lg:text-xs text-gray-500 bg-white/60 px-2 lg:px-3 py-1.5 rounded-full border border-gray-200/60 overflow-x-auto whitespace-nowrap"><span className="w-2 h-2 rounded-full bg-red-500 shrink-0" /> Alta carga<span className="w-2 h-2 rounded-full bg-orange-500 ml-1 lg:ml-2 shrink-0" /> Média<span className="w-2 h-2 rounded-full bg-emerald-500 ml-1 lg:ml-2 shrink-0" /> Baixa</div>}
+          statsRight={<div className="flex items-center gap-2"><button onClick={() => setSidebarOpen(true)} className="lg:hidden flex items-center gap-1.5 px-3 py-1.5 bg-white/60 rounded-lg border border-gray-200/60 text-gray-600 text-sm min-h-[44px]"><Activity size={16} className="text-violet-500" /><span className="hidden sm:inline">Timeline</span></button><div className="flex items-center gap-1 bg-white/60 rounded-lg p-1 border border-gray-200/60"><button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400 min-h-[44px] min-w-[44px] flex items-center justify-center"><ChevronLeft size={18} /></button><button className="px-2 lg:px-3 py-1 text-sm text-gray-700 whitespace-nowrap">{currentMonth}</button><button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400 min-h-[44px] min-w-[44px] flex items-center justify-center"><ChevronRight size={18} /></button></div></div>}
         />
       </div>
-
-      {/* Content: Calendar + Sidebar */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Main Calendar */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-          {/* Day headers */}
-          <div className="grid grid-cols-7 border-b border-gray-200 px-8 pb-2 pt-4 shrink-0">
-            {daysOfWeek.map(day => (
-              <div key={day} className="text-center text-xs font-mono text-gray-400 uppercase tracking-wider">
-                {day}
-              </div>
-            ))}
+        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+          <div className="grid grid-cols-7 border-b border-gray-200 px-4 lg:px-8 pb-2 pt-3 lg:pt-4 shrink-0">
+            {daysOfWeek.map(day => (<div key={day} className="text-center text-[10px] lg:text-xs font-mono text-gray-400 uppercase tracking-wider">{day}</div>))}
           </div>
-
-          {/* Calendar grid */}
-          <div className="flex-1 px-8 pb-8 overflow-y-auto custom-scrollbar-light relative">
-            <div className="grid grid-cols-7 h-full min-h-[600px] border-l border-t border-gray-200 rounded-bl-xl rounded-br-xl bg-white/30 backdrop-blur-sm relative">
-              
-              {/* Popover for selected day */}
+          <div className="flex-1 px-2 lg:px-8 pb-4 lg:pb-8 overflow-y-auto custom-scrollbar-light relative">
+            <div className="grid grid-cols-7 h-full min-h-[400px] lg:min-h-[600px] border-l border-t border-gray-200 rounded-bl-xl rounded-br-xl bg-white/30 backdrop-blur-sm relative">
               <AnimatePresence>
                 {selectedDay !== null && selectedDay > 0 && selectedDay <= daysInMonth && (() => {
                   const dayData = activityMap.get(selectedDay);
                   const dayEvents = getEventsForDay(selectedDay);
                   if (dayEvents.length === 0 && !dayData) return null;
-
-                  // Compute position (rough grid position)
+                  const retention = dayData?.retention ?? 72;
+                  const cards = dayData?.cards ?? dayEvents.reduce((s, e) => s + (e.cards || 0), 0);
+                  const pending = isConnected ? bktStates.filter(b => b.p_know < 0.5).length : 12;
                   const dayIndex = prevMonthDays.length + selectedDay - 1;
                   const row = Math.floor(dayIndex / 7);
                   const col = dayIndex % 7;
                   const topPx = 20 + row * 130;
                   const leftPx = Math.min(col * 140 + 60, 500);
-
-                  const retention = dayData?.retention ?? 72;
-                  const cards = dayData?.cards ?? dayEvents.reduce((s, e) => s + (e.cards || 0), 0);
-                  const pending = isConnected
-                    ? bktStates.filter(b => b.p_know < 0.5).length
-                    : 12;
-
                   return (
-                    <motion.div
-                      key={`popover-${selectedDay}`}
-                      initial={{ opacity: 0, scale: 0.95 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.95 }}
-                      className="absolute z-50 w-72 bg-white/90 backdrop-blur-xl rounded-xl shadow-xl border border-white/80 p-4"
-                      style={{ top: `${topPx}px`, left: `${leftPx}px` }}
-                    >
+                    <motion.div key={`popover-${selectedDay}`} initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }}
+                      className={clsx("absolute z-50 bg-white/90 backdrop-blur-xl rounded-xl shadow-xl border border-white/80 p-4", "left-2 right-2 bottom-2 lg:bottom-auto lg:left-auto lg:right-auto lg:w-72")}
+                      style={{ ...(window.matchMedia('(min-width: 1024px)').matches ? { top: `${topPx}px`, left: `${leftPx}px` } : {}) }}>
                       <div className="flex justify-between items-start mb-3">
-                        <h4 className="font-bold text-pink-700" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
-                          {dayEvents[0]?.title || `Dia ${selectedDay}`}
-                        </h4>
-                        <button onClick={() => setSelectedDay(null)} className="text-gray-400 hover:text-gray-600">
-                          <X size={14} />
-                        </button>
+                        <h4 className="text-pink-700" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>{dayEvents[0]?.title || `Dia ${selectedDay}`}</h4>
+                        <button onClick={() => setSelectedDay(null)} className="text-gray-400 hover:text-gray-600 min-h-[44px] min-w-[44px] flex items-center justify-center -mr-2 -mt-2"><X size={14} /></button>
                       </div>
                       <div className="flex items-center gap-4 mb-4">
-                        <div className="text-center">
-                          <div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Retenção</div>
-                          <div className={clsx("text-xl font-bold", retention >= 70 ? 'text-emerald-500' : retention >= 50 ? 'text-orange-500' : 'text-red-500')}>{retention}%</div>
-                        </div>
+                        <div className="text-center"><div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Retenção</div><div className={clsx("text-xl", retention >= 70 ? 'text-emerald-500' : retention >= 50 ? 'text-orange-500' : 'text-red-500')} style={{ fontWeight: 700 }}>{retention}%</div></div>
                         <div className="h-8 w-px bg-gray-200" />
-                        <div className="text-center">
-                          <div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Cards</div>
-                          <div className="text-xl font-bold text-gray-800">{cards}</div>
-                        </div>
+                        <div className="text-center"><div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Cards</div><div className="text-xl text-gray-800" style={{ fontWeight: 700 }}>{cards}</div></div>
                         <div className="h-8 w-px bg-gray-200" />
-                        <div className="text-center">
-                          <div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Pendentes</div>
-                          <div className="text-xl font-bold text-red-500">{pending}</div>
-                        </div>
+                        <div className="text-center"><div className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">Pendentes</div><div className="text-xl text-red-500" style={{ fontWeight: 700 }}>{pending}</div></div>
                       </div>
                       <div className="space-y-2">
-                        <div className="flex justify-between text-xs">
-                          <span className="text-gray-400">Força da Memória</span>
-                          <span className={clsx(retention >= 70 ? 'text-emerald-600' : 'text-pink-600')}>
-                            {retention >= 80 ? 'Forte' : retention >= 60 ? 'Moderada' : 'Enfraquecendo'}
-                          </span>
-                        </div>
-                        <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden">
-                          <div className={clsx("h-full rounded-full", retention >= 70 ? 'bg-gradient-to-r from-emerald-400 to-emerald-600' : 'bg-gradient-to-r from-pink-400 to-pink-600')} style={{ width: `${retention}%` }} />
-                        </div>
+                        <div className="flex justify-between text-xs"><span className="text-gray-400">Força da Memória</span><span className={clsx(retention >= 70 ? 'text-emerald-600' : 'text-pink-600')}>{retention >= 80 ? 'Forte' : retention >= 60 ? 'Moderada' : 'Enfraquecendo'}</span></div>
+                        <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden"><div className={clsx("h-full rounded-full", retention >= 70 ? 'bg-gradient-to-r from-emerald-400 to-emerald-600' : 'bg-gradient-to-r from-pink-400 to-pink-600')} style={{ width: `${retention}%` }} /></div>
                       </div>
-                      <button
-                        onClick={() => navigateTo('review-session')}
-                        className="mt-4 w-full py-2 bg-pink-50 hover:bg-pink-100 text-pink-700 font-bold text-sm rounded-lg transition-colors flex items-center justify-center gap-2"
-                      >
-                        <PlayCircle size={16} /> Revisar Agora
-                      </button>
+                      <button onClick={() => navigateTo('review-session')} className="mt-4 w-full py-2.5 bg-pink-50 hover:bg-pink-100 text-pink-700 text-sm rounded-lg transition-colors flex items-center justify-center gap-2 min-h-[44px]" style={{ fontWeight: 700 }}><PlayCircle size={16} /> Revisar Agora</button>
                     </motion.div>
                   );
                 })()}
               </AnimatePresence>
-
-              {/* Previous month days */}
-              {prevMonthDays.map(d => (
-                <div key={`prev-${d}`} className="border-r border-b border-gray-200 p-2 min-h-[120px] bg-gray-50/30">
-                  <span className="text-gray-300 font-mono text-sm">{d}</span>
-                </div>
-              ))}
-
-              {/* Current month days */}
+              {prevMonthDays.map(d => (<div key={`prev-${d}`} className="border-r border-b border-gray-200 p-1 lg:p-2 min-h-[60px] lg:min-h-[120px] bg-gray-50/30"><span className="text-gray-300 font-mono text-[10px] lg:text-sm">{d}</span></div>))}
               {Array.from({ length: daysInMonth }, (_, i) => i + 1).map(day => {
                 const heat = getHeatLevel(day);
                 const events = getEventsForDay(day);
                 const isCurrentDay = day === today;
                 const hasUrgent = events.some(e => e.isUrgent);
-
                 return (
-                  <div
-                    key={day}
-                    onClick={() => events.length > 0 && setSelectedDay(day === selectedDay ? null : day)}
-                    className={clsx(
-                      "border-r border-b border-gray-200 p-2 min-h-[120px] relative group transition-colors cursor-pointer",
-                      isCurrentDay
-                        ? "bg-violet-500/5 ring-inset ring-2 ring-violet-500/20"
-                        : "hover:bg-white/40",
-                      heatBg(heat)
-                    )}
-                  >
-                    <span className={clsx(
-                      "font-mono text-sm",
-                      isCurrentDay ? "text-violet-600 font-bold" : heat === 'high' ? "text-red-500 font-bold" : "text-gray-500"
-                    )}>
-                      {day}
-                    </span>
-
-                    {/* Heat indicators */}
-                    {heat !== 'none' && (
-                      <div className="absolute top-2 right-2 flex gap-1">
-                        <div className={clsx("w-1.5 h-1.5 rounded-full", heat === 'high' ? 'bg-red-500' : 'bg-orange-500')} />
-                        {hasUrgent && <div className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />}
-                      </div>
-                    )}
-
-                    {isCurrentDay && (
-                      <div className="absolute top-2 right-2 w-2 h-2 bg-violet-500 rounded-full animate-pulse" />
-                    )}
-
-                    {/* Events */}
-                    <div className="mt-2 space-y-1">
-                      {events.map((event, i) => (
-                        <div
-                          key={i}
-                          className={clsx(
-                            "p-1.5 rounded-lg text-xs cursor-pointer transition-all shadow-sm",
-                            CATEGORY_STYLES[event.category],
-                            event.isUrgent && "ring-2 ring-pink-400/30"
-                          )}
-                        >
-                          {event.title && <div className="font-bold mb-0.5 pr-4 truncate">{event.title}</div>}
-                          {event.cards && (
-                            <div className="flex items-center gap-1 text-[10px] opacity-80">
-                              <RotateCcw size={10} /> {event.cards} cards
-                            </div>
-                          )}
-                          {event.time && (
-                            <div className="opacity-80 font-mono text-[10px]">{event.time}</div>
-                          )}
-                          {event.isDue && !event.cards && (
-                            <div className="flex items-center gap-1 text-[10px] font-bold">
-                              <AlertTriangle size={10} /> Revisão Pendente
-                            </div>
-                          )}
-                          {event.noteText && (
-                            <div className="text-xs text-gray-500 italic bg-white/50 border border-white rounded p-1.5 mt-1">
-                              {event.noteText}
-                            </div>
-                          )}
-                        </div>
-                      ))}
+                  <div key={day} onClick={() => events.length > 0 && setSelectedDay(day === selectedDay ? null : day)}
+                    className={clsx("border-r border-b border-gray-200 p-1 lg:p-2 min-h-[60px] lg:min-h-[120px] relative group transition-colors cursor-pointer", isCurrentDay ? "bg-violet-500/5 ring-inset ring-2 ring-violet-500/20" : "hover:bg-white/40", heatBg(heat))}>
+                    <span className={clsx("font-mono text-[10px] lg:text-sm", isCurrentDay ? "text-violet-600" : heat === 'high' ? "text-red-500" : "text-gray-500", (isCurrentDay || heat === 'high') && "font-bold")}>{day}</span>
+                    {heat !== 'none' && (<div className="absolute top-1 lg:top-2 right-1 lg:right-2 flex gap-0.5 lg:gap-1"><div className={clsx("w-1 h-1 lg:w-1.5 lg:h-1.5 rounded-full", heat === 'high' ? 'bg-red-500' : 'bg-orange-500')} />{hasUrgent && <div className="w-1 h-1 lg:w-1.5 lg:h-1.5 rounded-full bg-red-500 animate-pulse" />}</div>)}
+                    {isCurrentDay && <div className="absolute top-1 lg:top-2 right-1 lg:right-2 w-1.5 lg:w-2 h-1.5 lg:h-2 bg-violet-500 rounded-full animate-pulse" />}
+                    <div className="mt-1 lg:mt-2 space-y-1 hidden lg:block">
+                      {events.map((event, i) => (<div key={i} className={clsx("p-1.5 rounded-lg text-xs cursor-pointer transition-all shadow-sm", CATEGORY_STYLES[event.category], event.isUrgent && "ring-2 ring-pink-400/30")}>
+                        {event.title && <div className="mb-0.5 pr-4 truncate" style={{ fontWeight: 700 }}>{event.title}</div>}
+                        {event.cards && <div className="flex items-center gap-1 text-[10px] opacity-80"><RotateCcw size={10} /> {event.cards} cards</div>}
+                        {event.time && <div className="opacity-80 font-mono text-[10px]">{event.time}</div>}
+                        {event.isDue && !event.cards && <div className="flex items-center gap-1 text-[10px]" style={{ fontWeight: 700 }}><AlertTriangle size={10} /> Revisão Pendente</div>}
+                        {event.noteText && <div className="text-xs text-gray-500 italic bg-white/50 border border-white rounded p-1.5 mt-1">{event.noteText}</div>}
+                      </div>))}
                     </div>
+                    {events.length > 0 && (<div className="lg:hidden flex gap-0.5 mt-1 justify-center">{events.slice(0, 3).map((event, i) => (<div key={i} className={clsx("w-1.5 h-1.5 rounded-full", event.category === 'science' ? 'bg-blue-500' : event.category === 'arts' ? 'bg-pink-500' : 'bg-emerald-500')} />))}</div>)}
                   </div>
                 );
               })}
             </div>
           </div>
         </div>
-
-        {/* Memory Timeline Sidebar */}
-        <aside className="w-[360px] h-full bg-white/65 backdrop-blur-xl border-l border-white/60 flex flex-col relative shadow-xl overflow-hidden shrink-0">
-          {/* Sidebar header */}
-          <div className="px-6 py-6 border-b border-gray-200/50 flex items-start justify-between shrink-0 bg-white/20">
-            <div>
-              <h2 className="font-bold text-gray-800 text-lg" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Memory Timeline</h2>
-              <p className="text-gray-400 text-xs mt-1">Impacto do estudo de hoje na retenção</p>
-            </div>
-            <div className="w-10 h-10 flex items-center justify-center bg-white/50 rounded-xl shadow-sm border border-white">
-              <Activity size={18} className="text-violet-500" />
-            </div>
-          </div>
-
-          {/* Timeline content */}
-          <div className="flex-1 overflow-y-auto custom-scrollbar-light px-6 py-6 space-y-8">
-            {/* Now */}
-            <div className="relative pl-4 border-l-2 border-violet-500/30">
-              <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-violet-500 border-4 border-[#f5f6fa]" />
-              <div className="mb-6">
-                <h3 className="text-sm font-bold text-gray-700 mb-2">Agora (14 Fev)</h3>
-                <div className="bg-white rounded-xl p-4 shadow-md ring-1 ring-violet-500/20 relative overflow-hidden">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center text-blue-600">
-                      <Brain size={18} />
-                    </div>
-                    <div>
-                      <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400">
-                        {isConnected && stats ? 'Sessão Atual' : 'Sessão Ativa'}
-                      </div>
-                      <div className="text-sm font-bold text-gray-800">
-                        {isConnected && stats
-                          ? `${stats.totalSessions} sessões realizadas`
-                          : TIMELINE_DATA.activeSession.subject}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex justify-between text-xs">
-                      <span className="text-gray-400">
-                        {isConnected ? 'Retenção Média' : 'Aumento de Retenção Projetado'}
-                      </span>
-                      <span className="text-emerald-600 font-bold">
-                        {isConnected && bktStates.length > 0
-                          ? `${Math.round(bktStates.reduce((s, b) => s + b.p_know, 0) / bktStates.length * 100)}%`
-                          : `+${TIMELINE_DATA.activeSession.retentionBoost}%`}
-                      </span>
-                    </div>
-                    <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden">
-                      <div className="h-full bg-gradient-to-r from-blue-400 to-emerald-400 rounded-full" style={{ width: `${isConnected && bktStates.length > 0 ? Math.round(bktStates.reduce((s, b) => s + b.p_know, 0) / bktStates.length * 100) : TIMELINE_DATA.activeSession.progress}%` }} />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Tomorrow */}
-            <div className="relative pl-4 border-l-2 border-dashed border-gray-300">
-              <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-300 border-4 border-[#f5f6fa]" />
-              <div className="mb-6">
-                <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">Amanhã (15 Fev)</h3>
-                <div className="bg-white/60 rounded-xl p-3 border border-white hover:bg-white transition-colors">
-                  <div className="flex justify-between items-center mb-1">
-                    <span className="text-sm font-bold text-gray-700">Primeira Revisão</span>
-                    <span className="px-2 py-0.5 rounded text-[10px] bg-amber-100 text-amber-700">Prioridade Média</span>
-                  </div>
-                  <p className="text-xs text-gray-400 leading-relaxed">
-                    Completar a sessão de hoje agendará uma revisão curta para amanhã para solidificar os traços iniciais.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* In 3 days */}
-            <div className="relative pl-4 border-l-2 border-dashed border-gray-300">
-              <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-300 border-4 border-[#f5f6fa]" />
-              <div className="mb-6">
-                <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">Em 3 Dias (17 Fev)</h3>
-                <div className="bg-white/40 rounded-xl p-3 border border-white/60">
-                  <div className="flex justify-between items-center mb-1">
-                    <span className="text-sm font-bold text-gray-700">Consolidação</span>
-                    <span className="px-2 py-0.5 rounded text-[10px] bg-emerald-100 text-emerald-700">Baixo Esforço</span>
-                  </div>
-                  <p className="text-xs text-gray-400 leading-relaxed">
-                    Estabilidade da memória atinge 80%. Uma revisão rápida de 5 min estenderá a retenção para 2 semanas.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Critical */}
-            <div className="relative pl-4 border-l-2 border-red-200">
-              <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-red-400 border-4 border-[#f5f6fa] animate-pulse" />
-              <div>
-                <h3 className="text-xs font-bold text-red-500 uppercase tracking-wider mb-2 flex items-center gap-1">
-                  <AlertTriangle size={12} /> Queda Crítica
-                </h3>
-                <div className="bg-gradient-to-br from-red-50 to-orange-50 rounded-xl p-4 border border-red-100 shadow-sm">
-                  <h4 className="text-sm font-bold text-red-900 mb-1">
-                    {criticalTopic
-                      ? criticalTopic.topicTitle
-                      : TIMELINE_DATA.criticalAlert.subject}
-                  </h4>
-                  <p className="text-xs text-red-700/80 mb-3">
-                    {criticalTopic
-                      ? `Retenção caiu para ${criticalTopic.masteryPercent}%. ${criticalTopic.flashcardsDue} cards pendentes.`
-                      : TIMELINE_DATA.criticalAlert.message}
-                  </p>
-                  <button
-                    onClick={() => navigateTo('review-session')}
-                    className="w-full py-1.5 bg-white border border-red-200 text-red-600 text-xs font-bold rounded shadow-sm hover:bg-red-50 transition-colors"
-                  >
-                    Agendar Revisão de Emergência
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="p-4 border-t border-gray-200/50 bg-white/30 backdrop-blur-md shrink-0">
-            <div className="bg-white/60 rounded-lg p-3 border border-white/60 flex items-center justify-between">
-              <div>
-                <div className="text-[10px] text-gray-400 font-bold uppercase tracking-wider">Retenção Geral</div>
-                <div className="text-2xl font-bold text-gray-800" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>{overallRetention}%</div>
-              </div>
-              <div className="h-10 w-24">
-                <svg className="w-full h-full text-emerald-500" preserveAspectRatio="none" viewBox="0 0 100 40">
-                  <path d="M0 30 Q 10 35, 20 25 T 40 20 T 60 15 T 80 5 L 100 10 L 100 40 L 0 40 Z" fill="currentColor" opacity="0.2" />
-                  <path d="M0 30 Q 10 35, 20 25 T 40 20 T 60 15 T 80 5 L 100 10" fill="none" stroke="currentColor" strokeWidth="2" />
-                </svg>
-              </div>
-            </div>
-          </div>
+        <aside className="hidden lg:flex w-[360px] h-full bg-white/65 backdrop-blur-xl border-l border-white/60 flex-col relative shadow-xl overflow-hidden shrink-0">
+          <MemoryTimelineSidebar navigateTo={navigateTo} isConnected={isConnected} stats={stats} bktStates={bktStates} overallRetention={overallRetention} criticalTopic={criticalTopic} />
         </aside>
+        <MobileDrawer isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} width={340}>
+          <MemoryTimelineSidebar navigateTo={navigateTo} isConnected={isConnected} stats={stats} bktStates={bktStates} overallRetention={overallRetention} criticalTopic={criticalTopic} />
+        </MobileDrawer>
       </div>
     </div>
   );

--- a/src/app/components/content/MasteryDashboardView.tsx
+++ b/src/app/components/content/MasteryDashboardView.tsx
@@ -14,10 +14,12 @@ import {
   Plus,
   Layers,
   BookOpen,
+  CalendarDays,
 } from 'lucide-react';
 import clsx from 'clsx';
 import { AxonPageHeader } from '@/app/components/shared/AxonPageHeader';
 import { headingStyle, components, colors } from '@/app/design-system';
+import { MobileDrawer } from '@/app/components/layout/MobileDrawer';
 
 // Mock data
 interface CalendarEvent {
@@ -41,47 +43,11 @@ const CALENDAR_EVENTS: CalendarEvent[] = [
 ];
 
 const TODAY_TASKS = [
-  {
-    id: '1',
-    type: 'review' as const,
-    subject: 'Psicologia Cognitiva',
-    title: 'Mapeamento Conceitual',
-    retention: 25,
-    urgency: 'urgent' as const,
-  },
-  {
-    id: '2',
-    type: 'session' as const,
-    subject: 'Fisiologia II',
-    title: 'Prática de Integração',
-    description: 'Complete os problemas 14-22 do Capítulo 4.',
-    time: '14:00',
-    isPrimary: true,
-  },
-  {
-    id: '3',
-    type: 'session' as const,
-    subject: 'Anatomia',
-    title: 'Ler Capítulo 4',
-    description: 'Foco na seção de membro superior.',
-    time: '16:30',
-    duration: '45m',
-  },
-  {
-    id: '4',
-    type: 'session' as const,
-    subject: 'Bioquímica',
-    title: 'Revisar Anotações',
-    description: 'Revisão rápida antes de dormir.',
-    time: '19:00',
-  },
-  {
-    id: '5',
-    type: 'session' as const,
-    subject: 'Geral',
-    title: 'Diário de Estudo',
-    time: '20:30',
-  },
+  { id: '1', type: 'review' as const, subject: 'Psicologia Cognitiva', title: 'Mapeamento Conceitual', retention: 25, urgency: 'urgent' as const },
+  { id: '2', type: 'session' as const, subject: 'Fisiologia II', title: 'Prática de Integração', description: 'Complete os problemas 14-22 do Capítulo 4.', time: '14:00', isPrimary: true },
+  { id: '3', type: 'session' as const, subject: 'Anatomia', title: 'Ler Capítulo 4', description: 'Foco na seção de membro superior.', time: '16:30', duration: '45m' },
+  { id: '4', type: 'session' as const, subject: 'Bioquímica', title: 'Revisar Anotações', description: 'Revisão rápida antes de dormir.', time: '19:00' },
+  { id: '5', type: 'session' as const, subject: 'Geral', title: 'Diário de Estudo', time: '20:30' },
 ];
 
 const CATEGORY_STYLES = {
@@ -106,25 +72,90 @@ const SUBJECT_ACCENT_COLORS: Record<string, string> = {
   'Geral': 'bg-gray-300',
 };
 
+// ── Daily Sidebar Content (extracted for reuse in drawer) ──
+function DailySidebarContent({ navigateTo, displayTasks, remainingTasks, completionPct }: {
+  navigateTo: (route: string) => void;
+  displayTasks: typeof TODAY_TASKS;
+  remainingTasks: number;
+  completionPct: number;
+}) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 lg:px-6 py-4 lg:py-6 border-b border-gray-200/50 flex items-start justify-between shrink-0">
+        <div>
+          <h2 className="text-gray-800 text-base lg:text-xl" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>Sexta-feira, 14</h2>
+          <p className="text-gray-400 text-sm mt-1">{remainingTasks} tarefas restantes</p>
+        </div>
+        <div className="relative w-12 h-12 flex items-center justify-center shrink-0">
+          <svg className="w-full h-full -rotate-90" viewBox="0 0 36 36">
+            <path className="text-gray-200" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" fill="none" stroke="currentColor" strokeWidth="3" />
+            <path className="text-violet-500 drop-shadow-md" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" fill="none" stroke="currentColor" strokeDasharray={`${completionPct}, 100`} strokeLinecap="round" strokeWidth="3" />
+          </svg>
+          <span className="absolute text-xs text-violet-600" style={{ fontWeight: 700 }}>{completionPct}%</span>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto custom-scrollbar-light px-4 lg:px-6 py-4 space-y-6">
+        {displayTasks.filter(t => t.type === 'review').length > 0 && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 mb-2">
+              <span className="relative flex h-3 w-3"><span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75" /><span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" /></span>
+              <h3 className="text-xs uppercase tracking-wider text-gray-400" style={{ fontWeight: 700 }}>Revisões Espaçadas</h3>
+            </div>
+            {displayTasks.filter(t => t.type === 'review').map(task => (
+              <div key={task.id} className="bg-white rounded-xl p-3 lg:p-4 shadow-md ring-1 ring-red-500/30 relative overflow-hidden">
+                <div className="absolute top-0 left-0 w-1 h-full bg-gradient-to-b from-red-500 to-orange-500" />
+                <div className="flex justify-between items-start mb-2">
+                  <span className={clsx("px-2 py-1 rounded-md text-xs uppercase tracking-wider", SUBJECT_BADGE_STYLES[task.subject] || 'bg-gray-100 text-gray-500')} style={{ fontWeight: 700 }}><Brain size={12} className="inline mr-1" />{task.subject}</span>
+                  <span className="font-mono text-xs text-red-500 bg-red-50 px-2 py-1 rounded" style={{ fontWeight: 700 }}>Urgente</span>
+                </div>
+                <h3 className="text-gray-800 mb-1" style={{ fontWeight: 700 }}>{task.title}</h3>
+                <div className="mb-4">
+                  <div className="flex justify-between text-[10px] text-gray-400 mb-1 uppercase"><span>Retenção</span><span className="text-red-500">{task.retention}% (Crítico)</span></div>
+                  <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden"><div className="h-full bg-gradient-to-r from-red-500 to-orange-400 rounded-full" style={{ width: `${task.retention}%` }} /></div>
+                </div>
+                <button onClick={() => navigateTo('review-session')} className="w-full h-11 rounded-lg bg-gradient-to-r from-red-500 to-orange-500 text-white text-sm tracking-wide shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 active:scale-95 min-h-[44px]" style={{ fontWeight: 700 }}><PlayCircle size={16} className="animate-pulse" /> Iniciar Revisão</button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="space-y-4">
+          <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-2" style={{ fontWeight: 700 }}>Agenda de Hoje</h3>
+          {displayTasks.filter(t => t.type === 'session').map((task, i) => {
+            const opacity = i >= 2 ? (i >= 3 ? 'opacity-60 hover:opacity-100' : 'opacity-80 hover:opacity-100') : '';
+            return (
+              <div key={task.id} className={clsx("bg-white rounded-xl p-3 lg:p-4 shadow-sm border border-white hover:bg-white transition-colors relative overflow-hidden", task.isPrimary && "ring-1 ring-violet-500/20 shadow-md", opacity)}>
+                <div className={clsx("absolute top-0 left-0 w-1 h-full", SUBJECT_ACCENT_COLORS[task.subject] || 'bg-gray-300')} />
+                <div className="flex justify-between items-start mb-2">
+                  <span className={clsx("px-2 py-1 rounded-md text-xs uppercase tracking-wider", SUBJECT_BADGE_STYLES[task.subject] || 'bg-gray-100 text-gray-500')} style={{ fontWeight: 700 }}>{task.subject}</span>
+                  <span className="font-mono text-xs text-gray-400 bg-gray-50 px-2 py-1 rounded">{task.time}</span>
+                </div>
+                <h3 className={clsx("text-gray-800 mb-1", !task.isPrimary && 'text-base')} style={{ fontWeight: 700 }}>{task.title}</h3>
+                {task.description && <p className="text-sm text-gray-400 mb-3">{task.description}</p>}
+                {task.isPrimary && (<button onClick={() => navigateTo('study')} className="w-full h-11 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 text-white text-sm tracking-wide shadow-md hover:shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 active:scale-95 min-h-[44px]" style={{ fontWeight: 700 }}><Play size={16} /> Iniciar Sessão</button>)}
+                {task.duration && (<div className="flex gap-2 mt-1"><span className="text-xs text-gray-400 flex items-center gap-1"><Clock size={12} /> {task.duration}</span></div>)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="p-3 lg:p-4 border-t border-gray-200/50 bg-white/30 backdrop-blur-md shrink-0">
+        <button className="w-full py-2.5 rounded-lg border-2 border-dashed border-violet-500/30 text-violet-600 text-sm hover:bg-violet-50 hover:border-violet-500/50 transition-all flex items-center justify-center gap-2 min-h-[44px]" style={{ fontWeight: 700 }}><Plus size={16} /> Adicionar Nova Tarefa</button>
+      </div>
+    </div>
+  );
+}
+
 export function MasteryDashboardView() {
   const { navigateTo } = useStudentNav();
   const { bktStates, dailyActivity, stats, isConnected } = useStudentDataContext();
   const { tree } = useContentTree();
   const [viewMode, setViewMode] = useState<'day' | 'week' | 'month'>('month');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Build topic lookup from content tree
   const topicLookup = useMemo(() => {
     const map = new Map<string, string>();
     if (!tree) return map;
-    for (const course of tree.courses) {
-      for (const semester of course.semesters) {
-        for (const section of semester.sections) {
-          for (const topic of section.topics) {
-            map.set(topic.id, topic.name);
-          }
-        }
-      }
-    }
+    for (const course of tree.courses) for (const semester of course.semesters) for (const section of semester.sections) for (const topic of section.topics) map.set(topic.id, topic.name);
     return map;
   }, [tree]);
 
@@ -132,50 +163,19 @@ export function MasteryDashboardView() {
   const prevMonthDays = [26, 27, 28, 29, 30];
   const daysInMonth = 28;
   const today = 14;
-  const completionPct = isConnected && bktStates.length > 0
-    ? Math.round(bktStates.reduce((s, b) => s + b.p_know, 0) / bktStates.length * 100)
-    : 65;
+  const completionPct = isConnected && bktStates.length > 0 ? Math.round(bktStates.reduce((s, b) => s + b.p_know, 0) / bktStates.length * 100) : 65;
 
-  // Build calendar events from real daily activity
   const activityMap = useMemo(() => {
     const map = new Map<number, { minutes: number; cards: number; sessions: number }>();
-    if (isConnected && dailyActivity.length > 0) {
-      dailyActivity.forEach(d => {
-        const date = new Date(d.date + 'T12:00:00');
-        if (date.getMonth() === 1 && date.getFullYear() === 2026) {
-          map.set(date.getDate(), {
-            minutes: d.studyMinutes,
-            cards: d.cardsReviewed,
-            sessions: d.sessionsCount,
-          });
-        }
-      });
-    }
+    if (isConnected && dailyActivity.length > 0) dailyActivity.forEach(d => { const date = new Date(d.date + 'T12:00:00'); if (date.getMonth() === 1 && date.getFullYear() === 2026) map.set(date.getDate(), { minutes: d.studyMinutes, cards: d.cardsReviewed, sessions: d.sessionsCount }); });
     return map;
   }, [isConnected, dailyActivity]);
 
-  // Build today's tasks from BKT states (low p_know = urgent review)
   const displayTasks = useMemo(() => {
     if (!isConnected || bktStates.length === 0) return TODAY_TASKS;
-
-    const urgentTopics = [...bktStates]
-      .filter(b => b.p_know < 0.5)
-      .sort((a, b) => a.p_know - b.p_know)
-      .slice(0, 3);
-
-    const reviewTasks = urgentTopics.map((b, i) => ({
-      id: `review-${i}`,
-      type: 'review' as const,
-      subject: topicLookup.get(b.subtopic_id) || `Tópico ${b.subtopic_id.slice(0, 6)}`,
-      title: 'Revisão Espaçada',
-      retention: Math.round(b.p_know * 100),
-      urgency: 'urgent' as const,
-    }));
-
-    // Keep mock session tasks as scheduled items (they represent the day's agenda)
-    const sessionTasks = TODAY_TASKS.filter(t => t.type === 'session');
-
-    return [...reviewTasks, ...sessionTasks];
+    const urgentTopics = [...bktStates].filter(b => b.p_know < 0.5).sort((a, b) => a.p_know - b.p_know).slice(0, 3);
+    const reviewTasks = urgentTopics.map((b, i) => ({ id: `review-${i}`, type: 'review' as const, subject: topicLookup.get(b.subtopic_id) || `Tópico ${b.subtopic_id.slice(0, 6)}`, title: 'Revisão Espaçada', retention: Math.round(b.p_know * 100), urgency: 'urgent' as const }));
+    return [...reviewTasks, ...TODAY_TASKS.filter(t => t.type === 'session')];
   }, [isConnected, bktStates, topicLookup]);
 
   const remainingTasks = displayTasks.filter(t => t.type === 'session').length;
@@ -183,249 +183,52 @@ export function MasteryDashboardView() {
   const getEventsForDay = (day: number) => {
     const actData = activityMap.get(day);
     const mockEvents = CALENDAR_EVENTS.filter(e => e.day === day);
-    if (isConnected && actData && actData.minutes > 0 && mockEvents.length === 0) {
-      // Synthesize event from real activity
-      return [{
-        day,
-        title: `${actData.sessions} sessão(ões)`,
-        category: 'core' as const,
-        time: `${actData.minutes} min`,
-        hasReview: actData.cards > 0,
-      }];
-    }
+    if (isConnected && actData && actData.minutes > 0 && mockEvents.length === 0) return [{ day, title: `${actData.sessions} sessão(ões)`, category: 'core' as const, time: `${actData.minutes} min`, hasReview: actData.cards > 0 }];
     return mockEvents;
   };
 
   return (
     <div className="h-full flex flex-col bg-[#f5f6fa]">
-      {/* Header */}
       <div className="shrink-0">
         <AxonPageHeader
           title="Fevereiro 2026"
           subtitle="Painel de domínio do estudo"
           onBack={() => navigateTo('schedule')}
-          statsLeft={
-            <div className="flex items-center gap-1 bg-white/60 rounded-lg p-1 border border-gray-200/60">
-              <button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400">
-                <ChevronLeft size={18} />
-              </button>
-              <button className="px-3 py-1 text-sm text-gray-700">Hoje</button>
-              <button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400">
-                <ChevronRight size={18} />
-              </button>
-            </div>
-          }
-          statsRight={
-            <div className="flex bg-gray-100/50 p-1 rounded-xl border border-gray-200/50">
-              {(['day', 'week', 'month'] as const).map(mode => (
-                <button
-                  key={mode}
-                  onClick={() => setViewMode(mode)}
-                  className={clsx(
-                    "px-4 py-1.5 rounded-lg text-sm transition-all",
-                    viewMode === mode
-                      ? "bg-white shadow-sm text-violet-600"
-                      : "text-gray-400 hover:text-gray-600 hover:bg-white/50"
-                  )}
-                >
-                  {mode === 'day' ? 'Dia' : mode === 'week' ? 'Semana' : 'Mês'}
-                </button>
-              ))}
-            </div>
-          }
+          statsLeft={<div className="flex items-center gap-1 bg-white/60 rounded-lg p-1 border border-gray-200/60"><button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400 min-h-[44px] min-w-[44px] flex items-center justify-center"><ChevronLeft size={18} /></button><button className="px-2 lg:px-3 py-1 text-sm text-gray-700 min-h-[44px]">Hoje</button><button className="p-1 hover:bg-white rounded-md transition-colors text-gray-400 min-h-[44px] min-w-[44px] flex items-center justify-center"><ChevronRight size={18} /></button></div>}
+          statsRight={<div className="flex items-center gap-2"><button onClick={() => setSidebarOpen(true)} className="lg:hidden flex items-center gap-1.5 px-3 py-1.5 bg-white/60 rounded-lg border border-gray-200/60 text-gray-600 text-sm min-h-[44px]"><CalendarDays size={16} className="text-violet-500" /><span className="hidden sm:inline">Agenda</span></button><div className="flex bg-gray-100/50 p-1 rounded-xl border border-gray-200/50">{(['day', 'week', 'month'] as const).map(mode => (<button key={mode} onClick={() => setViewMode(mode)} className={clsx("px-3 lg:px-4 py-1.5 rounded-lg text-sm transition-all whitespace-nowrap min-h-[44px]", viewMode === mode ? "bg-white shadow-sm text-violet-600" : "text-gray-400 hover:text-gray-600 hover:bg-white/50")}>{mode === 'day' ? 'Dia' : mode === 'week' ? 'Sem' : 'Mês'}</button>))}</div></div>}
         />
       </div>
-
-      {/* Content: Calendar + Sidebar */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Main Calendar */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-          {/* Day headers */}
-          <div className="grid grid-cols-7 border-b border-gray-200 px-8 pb-2 pt-3 shrink-0">
-            {daysOfWeek.map(day => (
-              <div key={day} className="text-center text-xs font-mono text-gray-400 uppercase tracking-wider">
-                {day}
-              </div>
-            ))}
+        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+          <div className="grid grid-cols-7 border-b border-gray-200 px-4 lg:px-8 pb-2 pt-3 shrink-0">
+            {daysOfWeek.map(day => (<div key={day} className="text-center text-[10px] lg:text-xs font-mono text-gray-400 uppercase tracking-wider">{day}</div>))}
           </div>
-
-          {/* Calendar grid */}
-          <div className="flex-1 px-8 pb-8 overflow-y-auto custom-scrollbar-light">
-            <div className="grid grid-cols-7 h-full min-h-[600px] border-l border-t border-gray-200 rounded-bl-xl rounded-br-xl bg-white/30 backdrop-blur-sm">
-              {/* Previous month days */}
-              {prevMonthDays.map(d => (
-                <div key={`prev-${d}`} className="border-r border-b border-gray-200 p-2 min-h-[120px] bg-gray-50/30">
-                  <span className="text-gray-300 font-mono text-sm">{d}</span>
-                </div>
-              ))}
-
-              {/* Current month */}
+          <div className="flex-1 px-2 lg:px-8 pb-4 lg:pb-8 overflow-y-auto custom-scrollbar-light">
+            <div className="grid grid-cols-7 h-full min-h-[400px] lg:min-h-[600px] border-l border-t border-gray-200 rounded-bl-xl rounded-br-xl bg-white/30 backdrop-blur-sm">
+              {prevMonthDays.map(d => (<div key={`prev-${d}`} className="border-r border-b border-gray-200 p-1 lg:p-2 min-h-[60px] lg:min-h-[120px] bg-gray-50/30"><span className="text-gray-300 font-mono text-[10px] lg:text-sm">{d}</span></div>))}
               {Array.from({ length: daysInMonth }, (_, i) => i + 1).map(day => {
                 const events = getEventsForDay(day);
                 const isCurrentDay = day === today;
-
                 return (
-                  <div
-                    key={day}
-                    className={clsx(
-                      "border-r border-b border-gray-200 p-2 min-h-[120px] relative group transition-colors",
-                      isCurrentDay
-                        ? "bg-violet-500/5 ring-inset ring-2 ring-violet-500/20"
-                        : "hover:bg-white/40"
-                    )}
-                  >
-                    <span className={clsx(
-                      "font-mono text-sm",
-                      isCurrentDay ? "text-violet-600 font-bold" : "text-gray-500"
-                    )}>
-                      {day}
-                    </span>
-
-                    {isCurrentDay && (
-                      <div className="absolute top-2 right-2 w-2 h-2 bg-violet-500 rounded-full" />
-                    )}
-
-                    <div className="mt-2 space-y-1">
-                      {events.map((event, i) => (
-                        <div
-                          key={i}
-                          className={clsx(
-                            "p-1.5 rounded-lg text-xs cursor-pointer hover:brightness-95 transition-all shadow-sm relative overflow-hidden",
-                            CATEGORY_STYLES[event.category]
-                          )}
-                        >
-                          <div className="font-bold mb-0.5 pr-4 truncate">{event.title}</div>
-                          {event.time && (
-                            <div className="opacity-80 font-mono text-[10px]">{event.time}</div>
-                          )}
-                          {event.hasReview && (
-                            <div className="absolute top-1.5 right-1.5 text-blue-600 bg-white/40 rounded-full p-0.5">
-                              <Brain size={12} />
-                            </div>
-                          )}
-                        </div>
-                      ))}
+                  <div key={day} className={clsx("border-r border-b border-gray-200 p-1 lg:p-2 min-h-[60px] lg:min-h-[120px] relative group transition-colors", isCurrentDay ? "bg-violet-500/5 ring-inset ring-2 ring-violet-500/20" : "hover:bg-white/40")}>
+                    <span className={clsx("font-mono text-[10px] lg:text-sm", isCurrentDay ? "text-violet-600 font-bold" : "text-gray-500")}>{day}</span>
+                    {isCurrentDay && <div className="absolute top-1 lg:top-2 right-1 lg:right-2 w-1.5 lg:w-2 h-1.5 lg:h-2 bg-violet-500 rounded-full" />}
+                    <div className="mt-1 lg:mt-2 space-y-1 hidden lg:block">
+                      {events.map((event, i) => (<div key={i} className={clsx("p-1.5 rounded-lg text-xs cursor-pointer hover:brightness-95 transition-all shadow-sm relative overflow-hidden", CATEGORY_STYLES[event.category])}><div className="mb-0.5 pr-4 truncate" style={{ fontWeight: 700 }}>{event.title}</div>{event.time && <div className="opacity-80 font-mono text-[10px]">{event.time}</div>}{event.hasReview && <div className="absolute top-1.5 right-1.5 text-blue-600 bg-white/40 rounded-full p-0.5"><Brain size={12} /></div>}</div>))}
                     </div>
+                    {events.length > 0 && (<div className="lg:hidden flex gap-0.5 mt-1 justify-center">{events.slice(0, 3).map((event, i) => (<div key={i} className={clsx("w-1.5 h-1.5 rounded-full", event.category === 'science' ? 'bg-blue-500' : event.category === 'arts' ? 'bg-pink-500' : 'bg-emerald-500')} />))}</div>)}
                   </div>
                 );
               })}
             </div>
           </div>
         </div>
-
-        {/* Daily Sidebar */}
-        <aside className="w-[370px] h-full bg-white/65 backdrop-blur-xl border-l border-white/60 flex flex-col relative shadow-xl overflow-hidden shrink-0">
-          {/* Header */}
-          <div className="px-6 py-6 border-b border-gray-200/50 flex items-start justify-between shrink-0">
-            <div>
-              <h2 className="font-bold text-gray-800 text-xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Sexta-feira, 14</h2>
-              <p className="text-gray-400 text-sm mt-1">{remainingTasks} tarefas restantes</p>
-            </div>
-            {/* Progress ring */}
-            <div className="relative w-12 h-12 flex items-center justify-center">
-              <svg className="w-full h-full -rotate-90" viewBox="0 0 36 36">
-                <path className="text-gray-200" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" fill="none" stroke="currentColor" strokeWidth="3" />
-                <path className="text-violet-500 drop-shadow-md" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" fill="none" stroke="currentColor" strokeDasharray={`${completionPct}, 100`} strokeLinecap="round" strokeWidth="3" />
-              </svg>
-              <span className="absolute text-xs font-bold text-violet-600">{completionPct}%</span>
-            </div>
-          </div>
-
-          {/* Tasks list */}
-          <div className="flex-1 overflow-y-auto custom-scrollbar-light px-6 py-4 space-y-6">
-            {/* Spaced Reviews */}
-            {displayTasks.filter(t => t.type === 'review').length > 0 && (
-              <div className="space-y-3">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="relative flex h-3 w-3">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75" />
-                    <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
-                  </span>
-                  <h3 className="text-xs font-bold uppercase tracking-wider text-gray-400">Revisões Espaçadas</h3>
-                </div>
-
-                {displayTasks.filter(t => t.type === 'review').map(task => (
-                  <div key={task.id} className="bg-white rounded-xl p-4 shadow-md ring-1 ring-red-500/30 relative overflow-hidden group">
-                    <div className="absolute top-0 left-0 w-1 h-full bg-gradient-to-b from-red-500 to-orange-500" />
-                    <div className="flex justify-between items-start mb-2">
-                      <span className={clsx("px-2 py-1 rounded-md text-xs font-bold uppercase tracking-wider", SUBJECT_BADGE_STYLES[task.subject] || 'bg-gray-100 text-gray-500')}>
-                        <Brain size={12} className="inline mr-1" />
-                        {task.subject}
-                      </span>
-                      <span className="font-mono text-xs text-red-500 font-bold bg-red-50 px-2 py-1 rounded">Urgente</span>
-                    </div>
-                    <h3 className="font-bold text-gray-800 mb-1">{task.title}</h3>
-                    <div className="mb-4">
-                      <div className="flex justify-between text-[10px] text-gray-400 mb-1 uppercase">
-                        <span>Retenção</span>
-                        <span className="text-red-500">{task.retention}% (Crítico)</span>
-                      </div>
-                      <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden">
-                        <div className="h-full bg-gradient-to-r from-red-500 to-orange-400 rounded-full" style={{ width: `${task.retention}%` }} />
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => navigateTo('review-session')}
-                      className="w-full h-10 rounded-lg bg-gradient-to-r from-red-500 to-orange-500 text-white font-bold text-sm tracking-wide shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 active:scale-95"
-                    >
-                      <PlayCircle size={16} className="animate-pulse" /> Iniciar Revisão
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Today's Schedule */}
-            <div className="space-y-4">
-              <h3 className="text-xs font-bold uppercase tracking-wider text-gray-400 mb-2">Agenda de Hoje</h3>
-              {displayTasks.filter(t => t.type === 'session').map((task, i) => {
-                const opacity = i === 0 ? '' : i === 1 ? '' : i === 2 ? 'opacity-80 hover:opacity-100' : 'opacity-60 hover:opacity-100';
-                return (
-                  <div
-                    key={task.id}
-                    className={clsx(
-                      "bg-white rounded-xl p-4 shadow-sm border border-white hover:bg-white transition-colors relative overflow-hidden",
-                      task.isPrimary && "ring-1 ring-violet-500/20 shadow-md",
-                      opacity
-                    )}
-                  >
-                    <div className={clsx("absolute top-0 left-0 w-1 h-full", SUBJECT_ACCENT_COLORS[task.subject] || 'bg-gray-300')} />
-                    <div className="flex justify-between items-start mb-2">
-                      <span className={clsx("px-2 py-1 rounded-md text-xs font-bold uppercase tracking-wider", SUBJECT_BADGE_STYLES[task.subject] || 'bg-gray-100 text-gray-500')}>
-                        {task.subject}
-                      </span>
-                      <span className="font-mono text-xs text-gray-400 bg-gray-50 px-2 py-1 rounded">{task.time}</span>
-                    </div>
-                    <h3 className={clsx("font-bold text-gray-800 mb-1", task.isPrimary ? '' : 'text-base')}>{task.title}</h3>
-                    {task.description && <p className="text-sm text-gray-400 mb-3">{task.description}</p>}
-                    {task.isPrimary && (
-                      <button
-                        onClick={() => navigateTo('study')}
-                        className="w-full h-10 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 text-white font-bold text-sm tracking-wide shadow-md hover:shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 active:scale-95"
-                      >
-                        <Play size={16} /> Iniciar Sessão
-                      </button>
-                    )}
-                    {task.duration && (
-                      <div className="flex gap-2 mt-1">
-                        <span className="text-xs text-gray-400 flex items-center gap-1">
-                          <Clock size={12} /> {task.duration}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="p-4 border-t border-gray-200/50 bg-white/30 backdrop-blur-md shrink-0">
-            <button className="w-full py-2.5 rounded-lg border-2 border-dashed border-violet-500/30 text-violet-600 font-bold text-sm hover:bg-violet-50 hover:border-violet-500/50 transition-all flex items-center justify-center gap-2">
-              <Plus size={16} /> Adicionar Nova Tarefa
-            </button>
-          </div>
+        <aside className="hidden lg:flex w-[370px] h-full bg-white/65 backdrop-blur-xl border-l border-white/60 flex-col relative shadow-xl overflow-hidden shrink-0">
+          <DailySidebarContent navigateTo={navigateTo} displayTasks={displayTasks} remainingTasks={remainingTasks} completionPct={completionPct} />
         </aside>
+        <MobileDrawer isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} width={340}>
+          <DailySidebarContent navigateTo={navigateTo} displayTasks={displayTasks} remainingTasks={remainingTasks} completionPct={completionPct} />
+        </MobileDrawer>
       </div>
     </div>
   );

--- a/src/app/components/content/ReviewSessionView.tsx
+++ b/src/app/components/content/ReviewSessionView.tsx
@@ -166,12 +166,10 @@ function buildDecksFromFsrs(
 
   const now = new Date();
 
-  // Group FSRS states by summary_id (or subtopic_id as fallback)
   const groups = new Map<string, { states: FsrsStateRecord[]; label: string }>();
   for (const s of fsrsStates) {
     const key = s.summary_id || s.subtopic_id || 'unknown';
     if (!groups.has(key)) {
-      // Try to find a name from the content tree
       let label = key;
       if (tree?.courses) {
         for (const c of tree.courses) {
@@ -198,13 +196,11 @@ function buildDecksFromFsrs(
     const avgDifficulty = states.reduce((sum, s) => sum + s.difficulty, 0) / totalCards;
     const easePercent = Math.round((1 - avgDifficulty / 10) * 100);
 
-    // Determine urgency
     let dueUrgency: Deck['dueUrgency'] = 'none';
     if (cardsDue > 20) dueUrgency = 'critical';
     else if (cardsDue > 5) dueUrgency = 'warning';
     else if (cardsDue > 0) dueUrgency = 'info';
 
-    // Next review: find nearest future review
     const futureReviews = states
       .map(s => new Date(s.next_review))
       .filter(d => d > now)
@@ -253,7 +249,7 @@ function buildDecksFromFsrs(
       icon: iconSet.icon,
       iconBg: iconSet.bg,
     };
-  }).sort((a, b) => b.cardsDue - a.cardsDue);  // Most urgent first
+  }).sort((a, b) => b.cardsDue - a.cardsDue);
 }
 
 export function ReviewSessionView() {
@@ -265,7 +261,6 @@ export function ReviewSessionView() {
   const [fsrsStates, setFsrsStates] = useState<FsrsStateRecord[]>([]);
   const [fsrsLoading, setFsrsLoading] = useState(true);
 
-  // Fetch FSRS states on mount
   useEffect(() => {
     if (!user?.id) { setFsrsLoading(false); return; }
     let cancelled = false;
@@ -282,7 +277,6 @@ export function ReviewSessionView() {
     return () => { cancelled = true; };
   }, [user?.id]);
 
-  // Build decks from real FSRS data or fallback to mock
   const realDecks = useMemo(
     () => buildDecksFromFsrs(fsrsStates, tree),
     [fsrsStates, tree],
@@ -290,12 +284,10 @@ export function ReviewSessionView() {
   const decks = realDecks.length > 0 ? realDecks : MOCK_DECKS;
   const hasRealData = realDecks.length > 0;
 
-  // Pagination
   const pageSize = 5;
   const totalPages = Math.max(1, Math.ceil(decks.length / pageSize));
   const pagedDecks = decks.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
-  // Build real stats from backend data
   const now = new Date();
   const totalDue = hasRealData
     ? fsrsStates.filter(s => new Date(s.next_review) <= now).length
@@ -331,23 +323,19 @@ export function ReviewSessionView() {
           actionButton={
             <button
               onClick={() => navigateTo('review-session')}
-              className="flex items-center gap-2 px-5 py-2.5 bg-teal-600 hover:bg-teal-700 text-white rounded-full text-sm shadow-sm transition-all active:scale-95"
+              className="flex items-center gap-2 px-4 lg:px-5 py-2.5 bg-teal-600 hover:bg-teal-700 text-white rounded-full text-sm shadow-sm transition-all active:scale-95 min-h-[44px]"
             >
-              <PlayCircle size={16} /> Revisão Rápida
+              <PlayCircle size={16} /> <span className="hidden sm:inline">Revisão Rápida</span><span className="sm:hidden">Revisar</span>
             </button>
           }
         />
       </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-y-auto custom-scrollbar-light p-6 space-y-6">
+      {/* Content — RESPONSIVE: p-4 lg:p-6 */}
+      <div className="flex-1 overflow-y-auto custom-scrollbar-light p-4 lg:p-6 space-y-4 lg:space-y-6">
         {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {/* Total Mastered */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 lg:gap-4">
+          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
             <KPICard
               icon={<GraduationCap size={20} />}
               label="Cards Dominados"
@@ -355,31 +343,19 @@ export function ReviewSessionView() {
               trendSlot={<TrendBadge label={MOCK_STATS.masteredTrend} up />}
             />
           </motion.div>
-
-          {/* Today's Load */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.05 }}
-          >
+          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.05 }}>
             <KPICard
               icon={<Layers size={20} />}
               label="Carga de Hoje"
               value={effectiveStats.todayLoad}
-              trendSlot={<span className="text-xs font-semibold text-teal-700">{effectiveStats.todayDone}/{effectiveStats.todayLoad}</span>}
+              trendSlot={<span className="text-xs text-teal-700" style={{ fontWeight: 600 }}>{effectiveStats.todayDone}/{effectiveStats.todayLoad}</span>}
             >
               <div className={`mt-3 ${components.progressBar.track}`} style={{ height: '6px' }}>
                 <div className={`${components.progressBar.colorDefault} h-1.5 rounded-full transition-all`} style={{ width: `${todayPct}%` }} />
               </div>
             </KPICard>
           </motion.div>
-
-          {/* Avg Retention */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.1 }}
-          >
+          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }}>
             <KPICard
               icon={<Brain size={20} />}
               label="Taxa de Retenção"
@@ -389,7 +365,7 @@ export function ReviewSessionView() {
           </motion.div>
         </div>
 
-        {/* Decks Table */}
+        {/* Decks Table / Cards */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -397,20 +373,20 @@ export function ReviewSessionView() {
           className="bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.04)] border border-gray-100 flex flex-col overflow-hidden"
         >
           {/* Table header bar */}
-          <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
-            <h3 className="text-lg font-semibold text-gray-900" style={headingStyle}>Decks & Matérias Ativos</h3>
+          <div className="px-4 lg:px-6 py-3 lg:py-4 border-b border-gray-100 flex items-center justify-between">
+            <h3 className="text-base lg:text-lg text-gray-900" style={{ ...headingStyle, fontWeight: 600 }}>Decks & Matérias Ativos</h3>
             <div className="flex gap-2">
-              <button className="p-2 hover:bg-gray-50 rounded-lg text-gray-400 transition-colors">
+              <button className="p-2 hover:bg-gray-50 rounded-lg text-gray-400 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center">
                 <Filter size={18} />
               </button>
-              <button className="p-2 hover:bg-gray-50 rounded-lg text-gray-400 transition-colors">
+              <button className="p-2 hover:bg-gray-50 rounded-lg text-gray-400 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center">
                 <MoreHorizontal size={18} />
               </button>
             </div>
           </div>
 
-          {/* Table */}
-          <div className="overflow-auto">
+          {/* ── DESKTOP TABLE (hidden on mobile) ── */}
+          <div className="hidden lg:block overflow-auto">
             <table className="w-full text-left border-collapse">
               <thead className="bg-gray-50/80 sticky top-0 z-10">
                 <tr>
@@ -436,19 +412,19 @@ export function ReviewSessionView() {
                           {deck.icon}
                         </div>
                         <div>
-                          <p className="font-semibold text-gray-900 text-sm">{deck.name}</p>
+                          <p className="text-gray-900 text-sm" style={{ fontWeight: 600 }}>{deck.name}</p>
                           <p className="text-xs text-gray-500">{deck.category}</p>
                         </div>
                       </div>
                     </td>
                     <td className="py-4 px-6 text-center">
-                      <span className={clsx("inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium", DUE_BADGE_STYLES[deck.dueUrgency])}>
+                      <span className={clsx("inline-flex items-center px-2.5 py-0.5 rounded-full text-xs", DUE_BADGE_STYLES[deck.dueUrgency])} style={{ fontWeight: 500 }}>
                         {deck.cardsDue} Pendentes
                       </span>
                     </td>
                     <td className="py-4 px-6 text-center">
                       <div className="flex flex-col items-center">
-                        <span className={clsx("text-sm font-semibold font-mono", deck.easeColor)}>{deck.easeFactor}%</span>
+                        <span className={clsx("text-sm font-mono", deck.easeColor)} style={{ fontWeight: 600 }}>{deck.easeFactor}%</span>
                         <div className="w-16 h-1 bg-gray-200 rounded-full mt-1 overflow-hidden">
                           <div
                             className={clsx("h-full rounded-full", deck.easeBarPct >= 80 ? 'bg-emerald-500' : deck.easeBarPct >= 50 ? 'bg-amber-500' : 'bg-orange-500')}
@@ -458,19 +434,19 @@ export function ReviewSessionView() {
                       </div>
                     </td>
                     <td className="py-4 px-6 text-right">
-                      <p className={clsx("text-sm font-medium", deck.nextReviewColor)}>{deck.nextReview}</p>
+                      <p className={clsx("text-sm", deck.nextReviewColor)} style={{ fontWeight: 500 }}>{deck.nextReview}</p>
                       <p className="text-xs text-gray-500">{deck.nextReviewSub}</p>
                     </td>
                     <td className="py-4 px-6 text-right">
                       {deck.cardsDue > 0 ? (
                         <button
                           onClick={() => navigateTo('flashcards')}
-                          className="text-teal-600 hover:text-teal-700 text-sm font-medium hover:underline"
+                          className="text-teal-600 hover:text-teal-700 text-sm hover:underline" style={{ fontWeight: 500 }}
                         >
                           Revisar
                         </button>
                       ) : (
-                        <button className="text-gray-400 hover:text-teal-600 text-sm font-medium transition-colors">
+                        <button className="text-gray-400 hover:text-teal-600 text-sm transition-colors" style={{ fontWeight: 500 }}>
                           Detalhes
                         </button>
                       )}
@@ -481,16 +457,82 @@ export function ReviewSessionView() {
             </table>
           </div>
 
-          {/* Table footer */}
-          <div className="px-6 py-4 border-t border-gray-100 flex items-center justify-between">
+          {/* ── MOBILE CARD LIST (hidden on desktop) ── */}
+          <div className="lg:hidden divide-y divide-gray-100">
+            {pagedDecks.map((deck, i) => (
+              <motion.div
+                key={deck.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 0.2 + i * 0.04 }}
+                className="p-4 active:bg-gray-50/60 transition-colors"
+              >
+                {/* Row 1: Icon + Name + Due badge */}
+                <div className="flex items-start gap-3 mb-3">
+                  <div className={clsx("w-10 h-10 rounded-lg flex items-center justify-center text-white shadow-sm shrink-0", deck.iconBg)}>
+                    {deck.icon}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-gray-900 text-sm truncate" style={{ fontWeight: 600 }}>{deck.name}</p>
+                    <p className="text-xs text-gray-500">{deck.category}</p>
+                  </div>
+                  <span className={clsx("inline-flex items-center px-2 py-0.5 rounded-full text-[10px] shrink-0", DUE_BADGE_STYLES[deck.dueUrgency])} style={{ fontWeight: 500 }}>
+                    {deck.cardsDue}
+                  </span>
+                </div>
+
+                {/* Row 2: Stats row */}
+                <div className="flex items-center justify-between gap-4 mb-3">
+                  {/* Ease factor */}
+                  <div className="flex items-center gap-2 flex-1">
+                    <span className="text-[10px] text-gray-400 uppercase">Facilidade</span>
+                    <span className={clsx("text-xs font-mono", deck.easeColor)} style={{ fontWeight: 600 }}>{deck.easeFactor}%</span>
+                    <div className="flex-1 h-1 bg-gray-200 rounded-full overflow-hidden max-w-[60px]">
+                      <div
+                        className={clsx("h-full rounded-full", deck.easeBarPct >= 80 ? 'bg-emerald-500' : deck.easeBarPct >= 50 ? 'bg-amber-500' : 'bg-orange-500')}
+                        style={{ width: `${deck.easeBarPct}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Next review */}
+                  <div className="text-right">
+                    <p className={clsx("text-xs", deck.nextReviewColor)} style={{ fontWeight: 500 }}>{deck.nextReview}</p>
+                    <p className="text-[10px] text-gray-500">{deck.nextReviewSub}</p>
+                  </div>
+                </div>
+
+                {/* Row 3: Action */}
+                {deck.cardsDue > 0 ? (
+                  <button
+                    onClick={() => navigateTo('flashcards')}
+                    className="w-full py-2.5 bg-teal-50 hover:bg-teal-100 text-teal-700 text-sm rounded-lg transition-colors min-h-[44px] flex items-center justify-center gap-2"
+                    style={{ fontWeight: 600 }}
+                  >
+                    <PlayCircle size={14} /> Revisar Agora
+                  </button>
+                ) : (
+                  <button
+                    className="w-full py-2.5 bg-gray-50 hover:bg-gray-100 text-gray-500 text-sm rounded-lg transition-colors min-h-[44px]"
+                    style={{ fontWeight: 500 }}
+                  >
+                    Ver Detalhes
+                  </button>
+                )}
+              </motion.div>
+            ))}
+          </div>
+
+          {/* Table footer — RESPONSIVE */}
+          <div className="px-4 lg:px-6 py-3 lg:py-4 border-t border-gray-100 flex items-center justify-between">
             <p className="text-xs text-gray-400">
-              Mostrando {(currentPage - 1) * pageSize + 1}-{Math.min(currentPage * pageSize, decks.length)} de {decks.length} decks
+              <span className="hidden sm:inline">Mostrando </span>{(currentPage - 1) * pageSize + 1}-{Math.min(currentPage * pageSize, decks.length)} de {decks.length}
             </p>
             <div className="flex gap-1">
               <button
                 onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
                 disabled={currentPage === 1}
-                className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 bg-white hover:bg-gray-50 text-gray-400 text-xs disabled:opacity-40"
+                className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 bg-white hover:bg-gray-50 text-gray-400 text-xs disabled:opacity-40 min-h-[44px] min-w-[44px]"
               >
                 <ChevronLeft size={14} />
               </button>
@@ -499,7 +541,7 @@ export function ReviewSessionView() {
                   key={i}
                   onClick={() => setCurrentPage(i + 1)}
                   className={clsx(
-                    "w-8 h-8 flex items-center justify-center rounded-lg border text-xs",
+                    "w-8 h-8 flex items-center justify-center rounded-lg border text-xs min-h-[44px] min-w-[44px]",
                     currentPage === i + 1
                       ? "border-teal-500 bg-white text-teal-600"
                       : "border-gray-200 bg-white hover:bg-gray-50 text-gray-400"
@@ -511,7 +553,7 @@ export function ReviewSessionView() {
               <button
                 onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
                 disabled={currentPage === totalPages}
-                className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 bg-white hover:bg-gray-50 text-gray-400 text-xs disabled:opacity-40"
+                className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 bg-white hover:bg-gray-50 text-gray-400 text-xs disabled:opacity-40 min-h-[44px] min-w-[44px]"
               >
                 <ChevronRight size={14} />
               </button>

--- a/src/app/components/content/StudyDashboardsView.tsx
+++ b/src/app/components/content/StudyDashboardsView.tsx
@@ -217,7 +217,6 @@ export function StudyDashboardsView() {
   const realSubjects: SubjectCard[] = useMemo(() => {
     if (!isConnected || bktStates.length === 0) return [];
 
-    // Group bkt states by section
     const sectionGroups = new Map<string, { name: string; department: string; states: typeof bktStates }>();
     bktStates.forEach(b => {
       const lookup = topicLookup.get(b.subtopic_id);
@@ -243,7 +242,6 @@ export function StudyDashboardsView() {
       const ringOffset = Math.round((1 - avgPKnow) * 125);
       const urgency = getUrgencyLevel(retention);
 
-      // Build mini-heatmap from individual topic mastery values
       const heatmap = group.states
         .map(b => {
           const pct = Math.round(b.p_know * 100);
@@ -255,11 +253,8 @@ export function StudyDashboardsView() {
         .concat(Array(Math.max(0, 20 - group.states.length)).fill(`bg-${c}-100`))
         .slice(0, 20);
 
-      // Consistency label
       const variance = group.states.reduce((s, b) => s + Math.abs(b.p_know - avgPKnow), 0) / group.states.length;
       const consistency = variance < 0.1 ? 'Estável' : variance < 0.2 ? 'Moderada' : 'Volátil';
-
-      // Next review estimation
       const hasDue = group.states.some(b => b.p_know < 0.5);
 
       return {
@@ -297,13 +292,14 @@ export function StudyDashboardsView() {
           subtitle="Visualize sua retenção e otimize intervalos de estudo"
           onBack={() => navigateTo('schedule')}
           statsRight={
-            <div className="flex bg-white/60 p-1 rounded-xl border border-gray-200/60 backdrop-blur-sm">
+            /* RESPONSIVE: overflow-x-auto para tabs, min-h touch target */
+            <div className="flex bg-white/60 p-1 rounded-xl border border-gray-200/60 backdrop-blur-sm overflow-x-auto">
               {TABS.map(tab => (
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
                   className={clsx(
-                    "px-5 py-2 rounded-lg text-sm transition-all",
+                    "px-3 lg:px-5 py-2 rounded-lg text-sm transition-all whitespace-nowrap min-h-[44px]",
                     activeTab === tab.id
                       ? "bg-white shadow-sm text-violet-600"
                       : "text-gray-400 hover:text-gray-600 hover:bg-white/50"
@@ -317,109 +313,108 @@ export function StudyDashboardsView() {
         />
       </div>
 
-      {/* Content */}
+      {/* Content — RESPONSIVE: px-4 lg:px-8 */}
       <div className="flex-1 overflow-y-auto custom-scrollbar-light relative">
         {/* Ambient blur */}
         <div className="absolute top-0 left-1/2 w-[800px] h-[500px] bg-violet-500/5 rounded-full blur-[120px] pointer-events-none -translate-x-1/2 -translate-y-1/2" />
 
-        <div className="px-8 pb-12 space-y-8 relative z-10 pt-6">
+        <div className="px-4 lg:px-8 pb-8 lg:pb-12 space-y-6 lg:space-y-8 relative z-10 pt-4 lg:pt-6">
           {/* Global Forgetting Curve */}
           {activeTab === 'overview' && (
             <>
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="bg-white/65 backdrop-blur-xl rounded-2xl p-6 shadow-md border border-white/60 relative overflow-hidden"
+                className="bg-white/65 backdrop-blur-xl rounded-2xl p-4 lg:p-6 shadow-md border border-white/60 relative overflow-hidden"
               >
-                <div className="flex justify-between items-center mb-6">
-                  <h3 className="font-bold text-gray-800 text-xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Curva de Esquecimento Global</h3>
-                  <div className="flex gap-4">
-                    <div className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full bg-violet-500" />
-                      <span className="text-xs text-gray-400">Retenção Real</span>
+                {/* RESPONSIVE: flex-col sm:flex-row, legend flex-wrap */}
+                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 lg:mb-6">
+                  <h3 className="text-gray-800 text-base lg:text-xl" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>Curva de Esquecimento Global</h3>
+                  <div className="flex flex-wrap gap-2 lg:gap-4">
+                    <div className="flex items-center gap-1.5 lg:gap-2">
+                      <span className="w-2.5 h-2.5 lg:w-3 lg:h-3 rounded-full bg-violet-500" />
+                      <span className="text-[10px] lg:text-xs text-gray-400">Retenção Real</span>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full bg-blue-500" />
-                      <span className="text-xs text-gray-400">Decaimento Previsto</span>
+                    <div className="flex items-center gap-1.5 lg:gap-2">
+                      <span className="w-2.5 h-2.5 lg:w-3 lg:h-3 rounded-full bg-blue-500" />
+                      <span className="text-[10px] lg:text-xs text-gray-400">Decaimento Previsto</span>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full bg-gray-300 border border-gray-400" />
-                      <span className="text-xs text-gray-400">Limite Ideal</span>
+                    <div className="flex items-center gap-1.5 lg:gap-2">
+                      <span className="w-2.5 h-2.5 lg:w-3 lg:h-3 rounded-full bg-gray-300 border border-gray-400" />
+                      <span className="text-[10px] lg:text-xs text-gray-400">Limite Ideal</span>
                     </div>
                   </div>
                 </div>
 
-                {/* Chart */}
-                <div className="relative w-full h-80 bg-white/30 rounded-xl border border-white/50 p-4">
-                  {/* Y axis labels */}
-                  <div className="absolute left-4 top-4 bottom-8 flex flex-col justify-between text-xs text-gray-400 font-mono">
-                    <span>100%</span>
-                    <span>75%</span>
-                    <span>50%</span>
-                    <span>25%</span>
-                    <span>0%</span>
-                  </div>
-
-                  {/* Grid + Lines */}
-                  <div className="absolute left-12 right-4 top-4 bottom-8 border-l border-b border-gray-300">
-                    {/* Grid lines */}
-                    <div className="w-full border-b border-gray-100 border-dashed absolute top-0" style={{ height: '25%' }} />
-                    <div className="w-full border-b border-gray-100 border-dashed absolute top-1/4" style={{ height: '25%' }} />
-                    <div className="w-full border-b border-gray-100 border-dashed absolute top-2/4" style={{ height: '25%' }} />
-                    
-                    {/* Threshold line */}
-                    <div className="w-full border-b-2 border-dashed border-red-200 absolute group" style={{ top: '20%' }}>
-                      <span className="absolute right-0 -top-6 bg-red-50 text-red-500 text-[10px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity">
-                        Limite de Revisão
-                      </span>
+                {/* Chart — RESPONSIVE: overflow-x-auto, min-w for scrollable area */}
+                <div className="overflow-x-auto -mx-2 px-2">
+                  <div className="relative w-full min-w-[480px] h-60 lg:h-80 bg-white/30 rounded-xl border border-white/50 p-4">
+                    {/* Y axis labels */}
+                    <div className="absolute left-4 top-4 bottom-8 flex flex-col justify-between text-xs text-gray-400 font-mono">
+                      <span>100%</span>
+                      <span>75%</span>
+                      <span>50%</span>
+                      <span>25%</span>
+                      <span>0%</span>
                     </div>
 
-                    {/* Retention curve (SVG) */}
-                    <svg className="absolute inset-0 w-full h-full overflow-visible" preserveAspectRatio="none">
-                      {/* Actual retention */}
-                      <path
-                        d="M0,20 Q150,40 300,100 T600,160 T900,180"
-                        fill="none"
-                        stroke="#8b5cf6"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        className="drop-shadow-lg filter"
-                      />
-                      <circle cx="0" cy="20" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" />
-                      <circle cx="300" cy="100" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" className="cursor-pointer" />
-                      <circle cx="600" cy="160" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" className="cursor-pointer" />
+                    {/* Grid + Lines */}
+                    <div className="absolute left-12 right-4 top-4 bottom-8 border-l border-b border-gray-300">
+                      <div className="w-full border-b border-gray-100 border-dashed absolute top-0" style={{ height: '25%' }} />
+                      <div className="w-full border-b border-gray-100 border-dashed absolute top-1/4" style={{ height: '25%' }} />
+                      <div className="w-full border-b border-gray-100 border-dashed absolute top-2/4" style={{ height: '25%' }} />
+                      
+                      {/* Threshold line */}
+                      <div className="w-full border-b-2 border-dashed border-red-200 absolute group" style={{ top: '20%' }}>
+                        <span className="absolute right-0 -top-6 bg-red-50 text-red-500 text-[10px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity">
+                          Limite de Revisão
+                        </span>
+                      </div>
 
-                      {/* Predicted decay */}
-                      <path
-                        d="M0,20 Q120,80 250,150 T500,220"
-                        fill="none"
-                        stroke="#3B82F6"
-                        strokeWidth="3"
-                        strokeDasharray="8,4"
-                        strokeOpacity="0.6"
-                      />
-                    </svg>
-                  </div>
+                      {/* Retention curve (SVG) */}
+                      <svg className="absolute inset-0 w-full h-full overflow-visible" preserveAspectRatio="none">
+                        <path
+                          d="M0,20 Q150,40 300,100 T600,160 T900,180"
+                          fill="none"
+                          stroke="#8b5cf6"
+                          strokeWidth="3"
+                          strokeLinecap="round"
+                          className="drop-shadow-lg filter"
+                        />
+                        <circle cx="0" cy="20" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" />
+                        <circle cx="300" cy="100" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" className="cursor-pointer" />
+                        <circle cx="600" cy="160" r="4" fill="white" stroke="#8b5cf6" strokeWidth="2" className="cursor-pointer" />
+                        <path
+                          d="M0,20 Q120,80 250,150 T500,220"
+                          fill="none"
+                          stroke="#3B82F6"
+                          strokeWidth="3"
+                          strokeDasharray="8,4"
+                          strokeOpacity="0.6"
+                        />
+                      </svg>
+                    </div>
 
-                  {/* X axis labels */}
-                  <div className="absolute left-12 right-4 bottom-2 flex justify-between text-xs text-gray-400 font-mono">
-                    <span>Dia 0</span>
-                    <span>Dia 3</span>
-                    <span>Dia 7</span>
-                    <span>Dia 14</span>
-                    <span>Dia 30</span>
+                    {/* X axis labels */}
+                    <div className="absolute left-12 right-4 bottom-2 flex justify-between text-xs text-gray-400 font-mono">
+                      <span>Dia 0</span>
+                      <span>Dia 3</span>
+                      <span>Dia 7</span>
+                      <span>Dia 14</span>
+                      <span>Dia 30</span>
+                    </div>
                   </div>
                 </div>
               </motion.div>
 
               {/* Subject Performance Header */}
               <div className="flex items-center justify-between">
-                <h3 className="font-bold text-gray-800 text-xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Desempenho por Matéria</h3>
-                <div className="flex gap-2">
-                  <button className="p-2 hover:bg-white/50 rounded-lg text-gray-400 transition-colors">
+                <h3 className="text-gray-800 text-base lg:text-xl" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>Desempenho por Matéria</h3>
+                <div className="flex gap-1 lg:gap-2">
+                  <button className="p-2 hover:bg-white/50 rounded-lg text-gray-400 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center">
                     <Filter size={18} />
                   </button>
-                  <button className="p-2 hover:bg-white/50 rounded-lg text-gray-400 transition-colors">
+                  <button className="p-2 hover:bg-white/50 rounded-lg text-gray-400 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center">
                     <ArrowUpDown size={18} />
                   </button>
                 </div>
@@ -427,9 +422,9 @@ export function StudyDashboardsView() {
             </>
           )}
 
-          {/* Subject Cards Grid */}
+          {/* Subject Cards Grid — RESPONSIVE: gap-4 lg:gap-6 */}
           {(activeTab === 'overview' || activeTab === 'subjects') && (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 lg:gap-6">
               {displaySubjects.map((subject, i) => (
                 <motion.div
                   key={subject.id}
@@ -437,7 +432,7 @@ export function StudyDashboardsView() {
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: i * 0.05 }}
                   className={clsx(
-                    "bg-white/65 backdrop-blur-xl rounded-2xl p-5 hover:shadow-lg hover:-translate-y-1 transition-all duration-300 relative group overflow-hidden border border-white/60",
+                    "bg-white/65 backdrop-blur-xl rounded-2xl p-4 lg:p-5 hover:shadow-lg hover:-translate-y-1 transition-all duration-300 relative group overflow-hidden border border-white/60",
                     subject.isUrgent && "ring-2 ring-red-100"
                   )}
                 >
@@ -446,17 +441,17 @@ export function StudyDashboardsView() {
 
                   {/* Header */}
                   <div className="flex justify-between items-start mb-4">
-                    <div className="flex items-center gap-3">
-                      <div className={clsx("w-10 h-10 rounded-lg flex items-center justify-center", subject.iconBg, subject.iconColor)}>
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className={clsx("w-10 h-10 rounded-lg flex items-center justify-center shrink-0", subject.iconBg, subject.iconColor)}>
                         {subject.icon}
                       </div>
-                      <div>
-                        <h4 className="font-bold text-gray-800">{subject.name}</h4>
+                      <div className="min-w-0">
+                        <h4 className="text-gray-800 truncate" style={{ fontWeight: 700 }}>{subject.name}</h4>
                         <span className="text-xs text-gray-400">{subject.department}</span>
                       </div>
                     </div>
                     {/* Retention ring */}
-                    <div className="relative w-12 h-12 flex items-center justify-center">
+                    <div className="relative w-12 h-12 flex items-center justify-center shrink-0">
                       <svg className="w-full h-full -rotate-90" viewBox="0 0 48 48">
                         <circle cx="24" cy="24" r="20" fill="none" stroke="#E2E8F0" strokeWidth="4" />
                         <circle
@@ -469,7 +464,7 @@ export function StudyDashboardsView() {
                           strokeDashoffset={subject.ringOffset}
                         />
                       </svg>
-                      <span className={clsx("absolute text-xs font-bold", subject.retentionColor)}>{subject.retention}%</span>
+                      <span className={clsx("absolute text-xs", subject.retentionColor)} style={{ fontWeight: 700 }}>{subject.retention}%</span>
                     </div>
                   </div>
 
@@ -516,27 +511,27 @@ export function StudyDashboardsView() {
                 <div className="w-14 h-14 rounded-full bg-white/50 flex items-center justify-center text-gray-400 group-hover:bg-violet-50 group-hover:text-violet-500 transition-colors">
                   <Plus size={28} />
                 </div>
-                <span className="font-bold text-gray-400 group-hover:text-violet-500 transition-colors">Adicionar Matéria</span>
+                <span className="text-gray-400 group-hover:text-violet-500 transition-colors" style={{ fontWeight: 700 }}>Adicionar Matéria</span>
               </motion.button>
             </div>
           )}
 
-          {/* Settings tab */}
+          {/* Settings tab — RESPONSIVE: p-4 lg:p-8, full-width on mobile */}
           {activeTab === 'settings' && (
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
-              className="bg-white/65 backdrop-blur-xl rounded-2xl p-8 shadow-md border border-white/60 max-w-2xl"
+              className="bg-white/65 backdrop-blur-xl rounded-2xl p-4 lg:p-8 shadow-md border border-white/60 max-w-2xl"
             >
               <div className="flex items-center gap-3 mb-6">
                 <Settings size={20} className="text-violet-500" />
-                <h3 className="font-bold text-gray-800 text-lg" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Configurações do Algoritmo</h3>
+                <h3 className="text-gray-800 text-base lg:text-lg" style={{ fontWeight: 700, fontFamily: "'Space Grotesk', sans-serif" }}>Configurações do Algoritmo</h3>
               </div>
               <div className="space-y-6">
                 <div>
-                  <label className="text-sm font-bold text-gray-600 mb-2 block">Intervalo Mínimo de Revisão</label>
+                  <label className="text-sm text-gray-600 mb-2 block" style={{ fontWeight: 700 }}>Intervalo Mínimo de Revisão</label>
                   <p className="text-xs text-gray-400 mb-2">Tempo mínimo entre revisões de um mesmo card.</p>
-                  <select className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-700 focus:ring-violet-500 focus:border-violet-500">
+                  <select className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-700 focus:ring-violet-500 focus:border-violet-500 min-h-[44px]">
                     <option>15 minutos</option>
                     <option>1 hora</option>
                     <option>4 horas</option>
@@ -544,31 +539,31 @@ export function StudyDashboardsView() {
                   </select>
                 </div>
                 <div>
-                  <label className="text-sm font-bold text-gray-600 mb-2 block">Limite de Retenção</label>
+                  <label className="text-sm text-gray-600 mb-2 block" style={{ fontWeight: 700 }}>Limite de Retenção</label>
                   <p className="text-xs text-gray-400 mb-2">Nível de retenção abaixo do qual o sistema agenda revisão automática.</p>
                   <input
                     type="range"
                     min="50"
                     max="95"
                     defaultValue="80"
-                    className="w-full accent-violet-500"
+                    className="w-full accent-violet-500 min-h-[44px]"
                   />
                   <div className="flex justify-between text-xs text-gray-400 mt-1">
                     <span>50%</span>
-                    <span className="text-violet-600 font-bold">80%</span>
+                    <span className="text-violet-600" style={{ fontWeight: 700 }}>80%</span>
                     <span>95%</span>
                   </div>
                 </div>
                 <div>
-                  <label className="text-sm font-bold text-gray-600 mb-2 block">Cards por Sessão</label>
+                  <label className="text-sm text-gray-600 mb-2 block" style={{ fontWeight: 700 }}>Cards por Sessão</label>
                   <p className="text-xs text-gray-400 mb-2">Número máximo de cards por sessão de revisão.</p>
                   <input
                     type="number"
                     defaultValue={20}
-                    className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-700 focus:ring-violet-500 focus:border-violet-500"
+                    className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-700 focus:ring-violet-500 focus:border-violet-500 min-h-[44px]"
                   />
                 </div>
-                <button className="px-6 py-2.5 bg-gradient-to-r from-violet-600 to-purple-600 text-white font-bold text-sm rounded-lg shadow-md hover:brightness-110 transition-all">
+                <button className="w-full sm:w-auto px-6 py-2.5 bg-gradient-to-r from-violet-600 to-purple-600 text-white text-sm rounded-lg shadow-md hover:brightness-110 transition-all min-h-[44px]" style={{ fontWeight: 700 }}>
                   Salvar Configurações
                 </button>
               </div>
@@ -586,7 +581,7 @@ export function StudyDashboardsView() {
           {isConnected && bktStates.length > 0 && (
             <div className="p-4 bg-emerald-50 rounded-xl border border-emerald-100 text-center">
               <p className="text-xs text-emerald-600">
-                ✓ Dados conectados ao backend — {bktStates.length} estados de conhecimento, {dailyActivity.length} dias de atividade.
+                Dados conectados ao backend — {bktStates.length} estados de conhecimento, {dailyActivity.length} dias de atividade.
               </p>
             </div>
           )}

--- a/src/plan/MOBILE_RESPONSIVE_PLAN.md
+++ b/src/plan/MOBILE_RESPONSIVE_PLAN.md
@@ -35,45 +35,92 @@
 | 1.10 | StudyStreakCard.tsx | YA RESPONSIVE (centered card, text-based) | ✅ sin cambios |
 | 1.11 | DashboardStudyPlans.tsx | header stack, btn full-width mobile, touch targets | ✅ |
 
-## FASE 1C — ScheduleView
+## FASE 1C — ScheduleView (COMPLETADA)
 | # | Archivo | Cambio | Estado |
 |---|---------|--------|--------|
-| 1.12 | StudyPlanDashboard.tsx | 3-col → tabs mobile | ⬜ |
-| 1.13 | PlanCalendarSidebar.tsx | hidden lg:flex + tab | ⬜ |
-| 1.14 | PlanProgressSidebar.tsx | hidden lg:flex + tab | ⬜ |
-| 1.15 | DefaultScheduleView.tsx | 2-col → stack | ⬜ |
-| 1.16 | QuickNavLinks.tsx | grid-cols-2 mobile | ⬜ |
+| 1.12 | StudyPlanDashboard.tsx | 3-col -> tabs mobile | ✅ |
+| 1.13 | PlanCalendarSidebar.tsx | hidden lg:flex + tab | ✅ |
+| 1.14 | PlanProgressSidebar.tsx | hidden lg:flex + tab | ✅ |
+| 1.15 | DefaultScheduleView.tsx | 2-col -> stack | ✅ |
+| 1.16 | QuickNavLinks.tsx | grid-cols-2 mobile | ✅ |
 
-## FASE 2 — Secundarias
+## FASE 2 — Secundarias (COMPLETADA)
 | # | Archivo | Cambio | Estado |
 |---|---------|--------|--------|
-| 2.1 | StudentSummaryReader.tsx | Breadcrumb simplificado, tabs scrollable | ⬜ |
-| 2.2 | KeywordPopup.tsx | w-[calc(100vw-2rem)] mobile, bottom sheet | ⬜ |
-| 2.3 | PanelSidebar.tsx | Hidden mobile | ⬜ |
-| 2.4 | DailyPerformanceSidebar.tsx | Full-width mobile | ⬜ |
+| 2.1 | StudentSummaryReader.tsx | Breadcrumb simplificado, tabs scrollable | ✅ |
+| 2.2 | KeywordPopup.tsx | w-[calc(100vw-2rem)] mobile, bottom sheet | ✅ |
+| 2.3 | PanelSidebar.tsx | Hidden mobile | ✅ |
+| 2.4 | DailyPerformanceSidebar.tsx | Full-width mobile | ✅ |
+
+## FASE 3 — Dashboard & Revisiones (COMPLETADA)
+| # | Archivo | Cambio | Estado |
+|---|---------|--------|--------|
+| 3.1 | ReviewSessionView.tsx | Tabla 5-col -> card stack mobile, p-4 lg:p-6, touch targets 44px, pagination responsive | ✅ |
+| 3.2 | StudyDashboardsView.tsx | px-4 lg:px-8, chart legend flex-wrap, chart overflow-x-auto min-w-[480px], tabs scroll horizontal, settings p-4 lg:p-8, touch targets | ✅ |
+| 3.3 | KnowledgeHeatmapView.tsx | Sidebar hidden lg:flex + MobileDrawer, calendar cells min-h-[60px] lg:min-h-[120px], events hidden lg:block + dot indicators mobile, popover mobile positioning, px-4 lg:px-8 | ✅ |
+| 3.4 | MasteryDashboardView.tsx | Sidebar hidden lg:flex + MobileDrawer, calendar cells responsive, events hidden lg:block + dot indicators mobile, view mode tabs responsive, px-4 lg:px-8 | ✅ |
 
 ---
 
-## Auditoría Cruzada (post Fase 0+1A+1B)
+## Auditoria Cruzada (post Fase 0+1A+1B)
 
 | # | Severidad | Issue | Fix |
 |---|-----------|-------|-----|
-| 1 | 🟡 | MobileDrawer scroll lock race condition (2 drawers) | Counter global `openDrawerCount` |
-| 2 | 🟡 | AxonPageHeader perdía token `components.pageHeader.wrapper` | Usa token base + `!px` override |
-| 3 | 🟠 | `useIsMobile` duplicado inline en StudentLayout | Extraído a `/hooks/useIsMobile.ts` |
+| 1 | amarillo | MobileDrawer scroll lock race condition (2 drawers) | Counter global `openDrawerCount` |
+| 2 | amarillo | AxonPageHeader perdia token `components.pageHeader.wrapper` | Usa token base + `!px` override |
+| 3 | naranja | `useIsMobile` duplicado inline en StudentLayout | Extraido a `/hooks/useIsMobile.ts` |
+
+## Auditoria Cruzada — Fase 3
+
+| # | Severidad | Issue | Fix |
+|---|-----------|-------|-----|
+| 1 | rojo | Import path MobileDrawer incorrecto (`shared/` en vez de `layout/`) en KnowledgeHeatmapView y MasteryDashboardView | Corregido a `@/app/components/layout/MobileDrawer` |
+| 2 | rojo | Prop `open` no existe en MobileDrawer (real: `isOpen`), prop `title` tampoco existe | Corregido a `isOpen={sidebarOpen}`, removido `title` |
+| 3 | amarillo | Popover en KnowledgeHeatmapView usaba `window.innerWidth` (viola CSS-first) | Cambiado a `matchMedia` query para desktop positioning |
+| 4 | amarillo | Import `PanelRightOpen` sin usar en KnowledgeHeatmapView | Removido |
+| 5 | amarillo | Tab label cambiado innecesariamente en StudyDashboardsView | Restaurado texto original `Config. Algoritmo` |
+| 6 | verde | MobileDrawer width=280 default chico para sidebar content | Agregado `width={340}` explicito |
 
 ---
 
 ## Patrones Clave
 ```
-hidden lg:flex          → ocultar sidebar mobile
-flex flex-col lg:flex-row → stack → row
-w-full lg:w-72          → full mobile → fixed desktop
-p-4 lg:p-8              → padding reducido
-grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 → grid responsive
-min-w-0                 → prevent flex overflow
-overflow-x-auto         → horizontal scroll tablas
-min-h-[44px]            → touch targets (Apple HIG)
+hidden lg:flex          -> ocultar sidebar mobile
+flex flex-col lg:flex-row -> stack -> row
+w-full lg:w-72          -> full mobile -> fixed desktop
+p-4 lg:p-6              -> padding reducido
+px-4 lg:px-8            -> padding horizontal reducido
+grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 -> grid responsive
+min-w-0                 -> prevent flex overflow
+overflow-x-auto         -> horizontal scroll tablas/charts
+min-h-[44px]            -> touch targets (Apple HIG)
+min-h-[60px] lg:min-h-[120px] -> calendar cells responsive
+hidden lg:block         -> ocultar detalle en mobile
+hidden lg:table-cell    -> ocultar columnas tabla en mobile
+MobileDrawer            -> sidebar content en drawer mobile
+```
+
+## Patrones Fase 3 (nuevos)
+```
+Tabla -> Card stack:
+  hidden lg:block       -> tabla desktop
+  lg:hidden             -> card list mobile
+  
+Calendar sidebar:
+  hidden lg:flex        -> sidebar desktop
+  MobileDrawer          -> sidebar content en drawer
+  Boton toggle mobile   -> abre drawer
+  
+Calendar cells:
+  min-h-[60px] lg:min-h-[120px]  -> celdas mas chicas mobile
+  text-[10px] lg:text-sm          -> numeros mas chicos
+  hidden lg:block (events)        -> solo dots en mobile
+  dot indicators (lg:hidden)      -> resumen visual mobile
+
+Chart responsive:
+  overflow-x-auto       -> scroll horizontal si no cabe
+  min-w-[480px]         -> minimo para que el chart sea legible
+  flex-wrap (legend)    -> legend items wrappean en mobile
 ```
 
 ## Brand Colors (ya migrados)


### PR DESCRIPTION
## Fase 3 — Mobile Responsive: Dashboard & Revisiones

### Archivos modificados (4 views + plan)

| Archivo | Cambios clave |
|---|---|
| `ReviewSessionView.tsx` | Tabla 5-col -> card stack mobile (dual render `hidden lg:block` / `lg:hidden`), padding `p-4 lg:p-6`, touch targets 44px, paginacion responsive |
| `StudyDashboardsView.tsx` | `px-4 lg:px-8`, chart legend `flex-wrap`, chart `overflow-x-auto min-w-[480px]`, tabs scroll horizontal, settings `p-4 lg:p-8` |
| `KnowledgeHeatmapView.tsx` | Sidebar extraido a `MemoryTimelineSidebar` -> `hidden lg:flex` desktop + `MobileDrawer` mobile, celdas `min-h-[60px] lg:min-h-[120px]`, eventos `hidden lg:block` + dot indicators, popover responsive |
| `MasteryDashboardView.tsx` | Sidebar extraido a `DailySidebarContent` -> `hidden lg:flex` desktop + `MobileDrawer` mobile, celdas responsive, dot indicators, view mode tabs responsive |
| `MOBILE_RESPONSIVE_PLAN.md` | Actualizado: Fase 3 marcada COMPLETADA + auditoria cruzada documentada |

### Auditoria cruzada (6 issues encontrados y corregidos)

| # | Sev | Issue | Fix |
|---|---|---|---|
| 1 | HIGH | Import path MobileDrawer incorrecto (`shared/` -> `layout/`) | Corregido |
| 2 | HIGH | Prop `open` inexistente (real: `isOpen`), prop `title` inexistente | Corregido |
| 3 | MED | Popover usaba `window.innerWidth` (viola CSS-first) | `matchMedia` |
| 4 | MED | Import `PanelRightOpen` sin usar | Removido |
| 5 | MED | Tab label cambiado innecesariamente | Restaurado |
| 6 | LOW | MobileDrawer width=280 default chico | `width={340}` explicito |

### Patrones aplicados
- `hidden lg:flex` / `lg:hidden` para sidebar toggle
- `MobileDrawer` con `isOpen`/`onClose`/`width={340}` (contrato verificado)
- Touch targets `min-h-[44px]` en todos los interactivos
- Calendar cells `min-h-[60px] lg:min-h-[120px]`
- Dot indicators `lg:hidden` para eventos en mobile
- `overflow-x-auto` + `min-w-[480px]` para charts

### Nota post-merge
- Correr `prettier` sobre los 4 archivos (formato comprimido por push batch)
- Follow-up: boton X del MobileDrawer invisible sobre fondo claro (issue menor, backdrop close funciona)

Closes #52 (Phase 3)