### PR TITLE
fix(routes): professor/quizzes → ProfessorQuizzesPage (was PlaceholderPage)

### DIFF
--- a/src/app/routes/professor-routes.ts
+++ b/src/app/routes/professor-routes.ts
@@ -1,8 +1,13 @@
 // ============================================================
 // Axon — Professor Routes (children of ProfessorLayout)
 // PERF-70: All pages lazy-loaded to reduce initial bundle size.
+//
+// FIX: Quizzes, Curriculum, Flashcards routes restored from
+// placeholder to real page components. The original PERF-70
+// refactor accidentally replaced ALL routes with lazyPlaceholder.
 // ============================================================
 import type { RouteObject } from 'react-router';
+import { lazyRetry } from '@/app/utils/lazyRetry';
 
 const lazyPlaceholder = (title: string, desc: string, iconName: string) => ({
   lazy: async () => {
@@ -24,9 +29,18 @@ const lazyPlaceholder = (title: string, desc: string, iconName: string) => ({
 export const professorChildren: RouteObject[] = [
   { index: true,        ...lazyPlaceholder('Dashboard',   'Panel del profesor', 'LayoutDashboard') },
   { path: 'courses',    ...lazyPlaceholder('Cursos',      'Gestion de cursos', 'BookOpen') },
-  { path: 'curriculum', ...lazyPlaceholder('Curriculo',   'Arbol de contenidos', 'ListTree') },
-  { path: 'flashcards', ...lazyPlaceholder('Flashcards',  'Gestion de flashcards', 'Layers') },
-  { path: 'quizzes',    ...lazyPlaceholder('Quizzes',     'Gestion de evaluaciones', 'ClipboardList') },
+  {
+    path: 'curriculum',
+    lazy: () => lazyRetry(() => import('@/app/components/roles/pages/professor/ProfessorCurriculumPage')).then(m => ({ Component: m.ProfessorCurriculumPage })),
+  },
+  {
+    path: 'flashcards',
+    lazy: () => lazyRetry(() => import('@/app/components/roles/pages/professor/ProfessorFlashcardsPage')).then(m => ({ Component: m.ProfessorFlashcardsPage })),
+  },
+  {
+    path: 'quizzes',
+    lazy: () => lazyRetry(() => import('@/app/components/roles/pages/professor/ProfessorQuizzesPage')).then(m => ({ Component: m.ProfessorQuizzesPage })),
+  },
   { path: 'students',   ...lazyPlaceholder('Estudiantes', 'Seguimiento de alumnos', 'Users') },
   { path: 'ai',         ...lazyPlaceholder('IA',          'Herramientas de IA', 'Sparkles') },
   { path: 'settings',   ...lazyPlaceholder('Ajustes',     'Configuracion del profesor', 'Settings') },


### PR DESCRIPTION
## 🚨 Bug Fix — Professor Quiz Route Broken

### Root Cause
The **PERF-70** routing refactor (`bb43c4c`) replaced ALL professor routes with `lazyPlaceholder()`. This means clicking **"Quizzes"** in `/professor/quizzes` loaded a static placeholder page saying *"Quizzes — Gestión de evaluaciones"* instead of the real `ProfessorQuizzesPage` component.

### Impact
- Professor **cannot** see or manage quiz questions
- The full-featured `ProfessorQuizzesPage.tsx` (12KB, cascade selectors, CRUD, filters, stats) exists on main but **was never imported by any route**
- Same issue affects Curriculum and Flashcards professor routes

### Fix (1 file, minimal change)
**`src/app/routes/professor-routes.ts`:**

| Route | Before | After |
|-------|--------|-------|
| `/professor/quizzes` | `lazyPlaceholder('Quizzes',...)` ❌ | `lazy(() => import('ProfessorQuizzesPage'))` ✅ |
| `/professor/curriculum` | `lazyPlaceholder('Curriculo',...)` ❌ | `lazy(() => import('ProfessorCurriculumPage'))` ✅ |
| `/professor/flashcards` | `lazyPlaceholder('Flashcards',...)` ❌ | `lazy(() => import('ProfessorFlashcardsPage'))` ✅ |

All other professor routes remain as placeholders (not our domain).

### What's preserved
- ✅ `lazyRetry()` wrapper from PR #85 (stale chunk protection)
- ✅ All page components untouched (zero logic changes)
- ✅ Student quiz routes unaffected (were already correct)
- ✅ `lazyPlaceholder` helper kept for remaining stub routes

### Testing
- Login as professor → click "Quizzes" → should show cascade selectors + question CRUD
- Login as professor → click "Curriculum" → should show curriculum tree
- Login as professor → click "Flashcards" → should show flashcard manager