### PR TITLE
fix(nav): student Quiz sidebar → /student/quizzes (was /student/quiz 404)

### DIFF
--- a/src/app/hooks/useStudentNav.ts
+++ b/src/app/hooks/useStudentNav.ts
@@ -39,11 +39,13 @@ export type ViewType =
 /** viewType -> URL slug (only entries that differ from the viewType itself) */
 const VIEW_TO_SLUG: Partial<Record<string, string>> = {
   home: '', // index route
+  quiz: 'quizzes', // Sidebar uses ViewType 'quiz', route path is 'quizzes'
 };
 
 /** URL slug -> viewType (only entries that differ from the slug itself) */
 const SLUG_TO_VIEW: Record<string, ViewType> = {
   '': 'home', // index route
+  quizzes: 'quiz', // route path is 'quizzes', ViewType is 'quiz'
 };
 
 export function viewToPath(view: string): string {


### PR DESCRIPTION
## Bug Fix — Student Quiz Navigation Broken

### Root Cause
The student `Sidebar.tsx` uses `ViewType 'quiz'` for the Quiz nav item. `useStudentNav.viewToPath('quiz')` had **no slug override**, so it resolved to `/student/quiz` (singular).

But `quiz-student-routes.ts` registers the path as `'quizzes'` (plural): `/student/quizzes`.

**Result:** Clicking "Quiz" in the student sidebar navigates to `/student/quiz`, which doesn't match any route. The catch-all `*` renders `WelcomeView` instead of `QuizView`.

### Fix (1 file, 2 lines added)
**`src/app/hooks/useStudentNav.ts`:**

```ts
// Before:
const VIEW_TO_SLUG = { home: '' };
const SLUG_TO_VIEW = { '': 'home' };

// After:
const VIEW_TO_SLUG = { home: '', quiz: 'quizzes' };
const SLUG_TO_VIEW = { '': 'home', quizzes: 'quiz' };
```

### What this fixes
- `viewToPath('quiz')` → `/student/quizzes` (matches route) ✅
- `pathToView('/student/quizzes')` → `'quiz'` (sidebar highlight works) ✅
- No route changes needed — quiz-student-routes.ts stays as-is
- No Sidebar.tsx changes needed — ViewType 'quiz' stays as-is

### Testing
- Login as student → click "Quiz" in sidebar → should show QuizSelection (content tree + quiz picker)
- The "Quiz" item in the sidebar should be highlighted when on the quiz page

### Related
- PR #87: Fixed the same issue for professor side (PlaceholderPage → ProfessorQuizzesPage)