### PR TITLE
fix(realtime): auto-reconnection, token tracking, VAD-only mode

### DIFF
--- a/src/app/services/ai-service/as-realtime.ts
+++ b/src/app/services/ai-service/as-realtime.ts
@@ -11,6 +11,14 @@
 //   1. createRealtimeSession() — gets ephemeral token from backend
 //   2. RealtimeVoiceClient — manages WebSocket + tool execution
 //
+// Features:
+//   - Server-side VAD (no PTT methods)
+//   - Auto-reconnection with exponential backoff (max 3 retries)
+//   - Token expiry tracking with proactive refresh
+//   - Dynamic model from session response
+//   - Institution-scoped tool execution
+//   - Handles both GA and beta event names
+//
 // To add a new tool:
 //   1. Backend: add to REALTIME_TOOLS in realtime-session.ts
 //   2. Here: add to TOOL_EXECUTORS map below
@@ -30,17 +38,24 @@ export interface RealtimeSession {
 /** Discriminated union for known OpenAI Realtime API server events */
 export type RealtimeServerEvent =
   | { type: 'response.audio.delta'; delta: string }
+  | { type: 'response.output_audio.delta'; delta: string }
   | { type: 'response.audio_transcript.delta'; delta: string }
+  | { type: 'response.output_audio_transcript.delta'; delta: string }
   | { type: 'response.audio_transcript.done'; transcript: string }
+  | { type: 'response.output_audio_transcript.done'; transcript: string }
+  | { type: 'response.audio.done' }
+  | { type: 'response.output_audio.done' }
   | { type: 'response.created' }
   | { type: 'response.done'; response: Record<string, unknown> }
   | { type: 'response.function_call_arguments.done'; name: string; arguments: string; call_id: string }
   | { type: 'session.created' }
   | { type: 'session.updated' }
+  | { type: 'session.error'; error: { message: string; type?: string; code?: string } }
   | { type: 'error'; error: { message: string; type?: string; code?: string } }
   | { type: 'input_audio_buffer.speech_started' }
   | { type: 'input_audio_buffer.speech_stopped' }
-  | { type: 'conversation.item.input_audio_transcription.completed'; transcript: string };
+  | { type: 'conversation.item.input_audio_transcription.completed'; transcript: string }
+  | { type: 'rate_limits.updated'; rate_limits: Array<{ name: string; limit: number; remaining: number; reset_seconds: number }> };
 
 export type VoiceCallState = 'idle' | 'connecting' | 'active' | 'error';
 export type AISpeakingState = 'listening' | 'thinking' | 'speaking';
@@ -57,13 +72,22 @@ export interface RealtimeCallbacks {
 // ── Tool Executors (extensible map) ───────────────────────────
 // To add a new tool: add a function here matching the tool name
 // defined in the backend's REALTIME_TOOLS array.
+// The institutionId is injected at call time by the client.
 
-const TOOL_EXECUTORS: Record<string, (args: Record<string, unknown>) => Promise<string>> = {
-  search_course_content: async ({ query }) => {
+type ToolExecutor = (
+  args: Record<string, unknown>,
+  institutionId?: string,
+) => Promise<string>;
+
+const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
+  search_course_content: async ({ query }, institutionId) => {
     try {
+      const body: Record<string, unknown> = { message: query as string };
+      if (institutionId) body.institution_id = institutionId;
+
       const result = await apiCall<{ response: string }>('/ai/rag-chat', {
         method: 'POST',
-        body: JSON.stringify({ message: query as string }),
+        body: JSON.stringify(body),
       });
       return result.response;
     } catch (e) {
@@ -106,21 +130,54 @@ export class RealtimeVoiceClient {
   private userTranscriptBuffer = '';
   private aiTranscriptBuffer = '';
 
+  // Reconnection
+  private reconnectAttempts = 0;
+  private maxReconnects = 3;
+  private sessionCreator?: () => Promise<RealtimeSession>;
+  private intentionalClose = false;
+
+  // Token expiry
+  private tokenExpiresAt: number | null = null;
+  private expiryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Institution context for tools
+  private institutionId?: string;
+
+  // Error tracking
+  private _lastError: string | null = null;
+
   constructor(callbacks: RealtimeCallbacks = {}) {
     this.callbacks = callbacks;
+  }
+
+  // ── Public API ──────────────────────────────────────────────
+
+  /** Store the session creator for auto-reconnection */
+  setSessionCreator(creator: () => Promise<RealtimeSession>): void {
+    this.sessionCreator = creator;
+  }
+
+  /** Set institution ID for tool execution context */
+  setInstitutionId(id: string): void {
+    this.institutionId = id;
   }
 
   /** Emit state change and track it internally */
   private emitState(state: VoiceCallState): void {
     this.currentState = state;
+    if (state !== 'error') {
+      this._lastError = null;
+    }
     this.callbacks.onStateChange?.(state);
   }
 
   /** Connect to OpenAI Realtime API using ephemeral client_secret */
-  connect(clientSecret: string): void {
+  connect(clientSecret: string, model?: string): void {
     this.emitState('connecting');
+    this.intentionalClose = false;
 
-    const url = 'wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5';
+    const wsModel = model || 'gpt-realtime-1.5';
+    const url = `wss://api.openai.com/v1/realtime?model=${wsModel}`;
 
     this.ws = new WebSocket(url, [
       'realtime',
@@ -128,6 +185,7 @@ export class RealtimeVoiceClient {
     ]);
 
     this.ws.onopen = () => {
+      this.reconnectAttempts = 0;
       this.emitState('active');
       this.callbacks.onAISpeakingChange?.('listening');
     };
@@ -142,27 +200,39 @@ export class RealtimeVoiceClient {
     };
 
     this.ws.onerror = () => {
-      this.callbacks.onError?.('Error de conexión WebSocket');
+      this._lastError = 'Error de conexion WebSocket';
+      this.callbacks.onError?.(this._lastError);
       this.emitState('error');
     };
 
     this.ws.onclose = () => {
       this.ws = null;
-      // Don't overwrite error state — let the UI show the error
-      if (this.currentState !== 'error') {
-        this.emitState('idle');
+      this.clearExpiryTimer();
+
+      if (this.intentionalClose) {
+        // User-initiated disconnect — go idle
+        if (this.currentState !== 'error') {
+          this.emitState('idle');
+        }
+      } else {
+        // Unexpected close — attempt reconnection
+        this.reconnect();
       }
     };
   }
 
   /** Disconnect and cleanup */
   disconnect(): void {
+    this.intentionalClose = true;
+    this.clearExpiryTimer();
+
     if (this.ws) {
       this.ws.close();
       this.ws = null;
     }
     this.userTranscriptBuffer = '';
     this.aiTranscriptBuffer = '';
+    this.reconnectAttempts = 0;
   }
 
   /** Send a base64-encoded PCM16 audio chunk */
@@ -173,24 +243,79 @@ export class RealtimeVoiceClient {
     });
   }
 
-  /** Commit the current audio buffer (signals end of user speech) */
-  commitAudio(): void {
-    this.send({ type: 'input_audio_buffer.commit' });
-  }
-
-  /** Trigger the AI to generate a response */
-  createResponse(): void {
-    this.send({ type: 'response.create' });
-  }
-
-  /** Clear the audio buffer (discard accumulated noise) */
-  clearAudioBuffer(): void {
-    this.send({ type: 'input_audio_buffer.clear' });
-  }
-
   /** Check if connected */
   get isConnected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /** Check if in error state */
+  get hasError(): boolean {
+    return this.currentState === 'error';
+  }
+
+  /** Get last error message, or null */
+  get lastError(): string | null {
+    return this._lastError;
+  }
+
+  // ── Private: Reconnection ──────────────────────────────────
+
+  private async reconnect(): Promise<void> {
+    if (this.reconnectAttempts >= this.maxReconnects || !this.sessionCreator) {
+      this._lastError = 'Conexion perdida. Intenta iniciar la llamada de nuevo.';
+      this.callbacks.onError?.(this._lastError);
+      this.emitState('error');
+      return;
+    }
+
+    this.reconnectAttempts++;
+    this.emitState('connecting');
+
+    try {
+      const session = await this.sessionCreator();
+      this.trackTokenExpiry(session.expires_at);
+      this.connect(session.client_secret, session.model);
+    } catch {
+      const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 8000);
+      setTimeout(() => this.reconnect(), delay);
+    }
+  }
+
+  // ── Private: Token Expiry ──────────────────────────────────
+
+  /** Track token expiry and schedule proactive refresh */
+  trackTokenExpiry(expiresAt: string | null): void {
+    this.clearExpiryTimer();
+
+    if (!expiresAt) return;
+
+    const expiresMs = new Date(expiresAt).getTime();
+    if (isNaN(expiresMs)) return;
+
+    this.tokenExpiresAt = expiresMs;
+
+    // Refresh 30 seconds before expiry
+    const refreshIn = expiresMs - Date.now() - 30_000;
+    if (refreshIn <= 0) return;
+
+    this.expiryTimer = setTimeout(() => {
+      // Token about to expire — trigger reconnect with fresh session
+      if (this.isConnected && this.sessionCreator) {
+        this.intentionalClose = true;
+        this.ws?.close();
+        this.ws = null;
+        this.intentionalClose = false;
+        this.reconnect();
+      }
+    }, refreshIn);
+  }
+
+  private clearExpiryTimer(): void {
+    if (this.expiryTimer) {
+      clearTimeout(this.expiryTimer);
+      this.expiryTimer = null;
+    }
+    this.tokenExpiresAt = null;
   }
 
   // ── Private: Event Handling ───────────────────────────────
@@ -215,21 +340,30 @@ export class RealtimeVoiceClient {
         this.callbacks.onAISpeakingChange?.('thinking');
         break;
 
-      // AI audio chunk (for playback)
+      // AI audio chunk (for playback) — GA + beta event names
       case 'response.audio.delta':
-        this.callbacks.onAudioData?.(event.delta);
+      case 'response.output_audio.delta':
+        this.callbacks.onAudioData?.((event as { delta: string }).delta);
         this.callbacks.onAISpeakingChange?.('speaking');
         break;
 
-      // AI transcript chunk (for subtitles)
+      // AI audio done — GA + beta event names
+      case 'response.audio.done':
+      case 'response.output_audio.done':
+        // Audio stream finished — no action needed, response.done handles state
+        break;
+
+      // AI transcript chunk (for subtitles) — GA + beta event names
       case 'response.audio_transcript.delta':
-        this.aiTranscriptBuffer += event.delta || '';
+      case 'response.output_audio_transcript.delta':
+        this.aiTranscriptBuffer += (event as { delta: string }).delta || '';
         this.callbacks.onAITranscript?.(this.aiTranscriptBuffer, false);
         break;
 
-      // AI transcript complete
+      // AI transcript complete — GA + beta event names
       case 'response.audio_transcript.done':
-        this.aiTranscriptBuffer = event.transcript || this.aiTranscriptBuffer;
+      case 'response.output_audio_transcript.done':
+        this.aiTranscriptBuffer = (event as { transcript: string }).transcript || this.aiTranscriptBuffer;
         this.callbacks.onAITranscript?.(this.aiTranscriptBuffer, true);
         break;
 
@@ -243,9 +377,20 @@ export class RealtimeVoiceClient {
         this.handleFunctionCall(event);
         break;
 
-      // Errors
-      case 'error':
-        this.callbacks.onError?.(event.error?.message || 'Error desconocido');
+      // Errors — both session.error and generic error
+      case 'session.error':
+      case 'error': {
+        const errMsg = (event as { error: { message: string } }).error?.message || 'Error desconocido';
+        this._lastError = errMsg;
+        this.callbacks.onError?.(errMsg);
+        break;
+      }
+
+      // Rate limits — log for debugging
+      case 'rate_limits.updated':
+        if (import.meta.env.DEV) {
+          console.debug('[Realtime] Rate limits:', (event as { rate_limits: unknown }).rate_limits);
+        }
         break;
     }
   }
@@ -267,7 +412,7 @@ export class RealtimeVoiceClient {
 
     if (executor) {
       try {
-        output = await executor(args);
+        output = await executor(args, this.institutionId);
       } catch (e) {
         output = `Error ejecutando ${name}: ${(e as Error).message}`;
       }


### PR DESCRIPTION
## Summary
- **Remove PTT methods** (commitAudio, createResponse, clearAudioBuffer) that conflict with server-side VAD
- **Add auto-reconnection** with exponential backoff (max 3 retries) on unexpected WebSocket close
- **Track token expiry** and proactively refresh 30s before expiration to prevent mid-call drops
- **Dynamic model** from session response instead of hardcoded in WebSocket URL
- **Institution-scoped tools** -- pass institution_id to RAG chat for correct content scope
- **Dual event name support** -- handle both GA and beta OpenAI event names (response.audio.delta / response.output_audio.delta)
- **Error tracking** -- add hasError/lastError properties for better UI state detection

## Test plan
- [ ] Start a voice call, verify connection works with server-side VAD
- [ ] Kill network briefly, verify auto-reconnect kicks in and resumes
- [ ] Verify tool calls (search_course_content) include institution_id
- [ ] Verify no TypeScript build errors (`npm run build`)
- [ ] Confirm commitAudio/createResponse/clearAudioBuffer are no longer accessible

Generated with [Claude Code](https://claude.com/claude-code)