### PR TITLE
fix: responsive curriculum + light theme tree

### DIFF
--- a/src/app/components/roles/pages/professor/ProfessorCurriculumPage.tsx
+++ b/src/app/components/roles/pages/professor/ProfessorCurriculumPage.tsx
@@ -1,12 +1,15 @@
 // ============================================================
-// Axon — Professor: Curriculum Page
+// Axon — Professor: Curriculum Page (Responsive)
 //
 // Two modes:
-//   1. TREE MODE (default): ContentTree (340px) + TopicDetailPanel
-//   2. EDITOR MODE (when editing a summary): EditorSidebar (collapsible) + SummaryDetailView (full-page)
+//   1. TREE MODE (default): ContentTree (collapsible) + TopicDetailPanel
+//   2. EDITOR MODE (when editing a summary): EditorSidebar + SummaryDetailView
+//
+// Responsive:
+//   - Desktop (lg+): inline collapsible tree panel
+//   - Mobile (<lg): tree in MobileDrawer overlay
 //
 // Uses ContentTreeContext for data + ContentTree for UI.
-// PARALLEL-SAFE: This file is independent. Edit freely.
 // ============================================================
 import React, { useState, useCallback } from 'react';
 import { useContentTree } from '@/app/context/ContentTreeContext';
@@ -14,7 +17,9 @@ import { ContentTree } from '@/app/components/shared/ContentTree';
 import { PageHeader } from '@/app/components/shared/PageHeader';
 import { EditorSidebar } from '@/app/components/professor/EditorSidebar';
 import { SummaryDetailView } from './SummaryDetailView';
-import { ListTree, RefreshCw } from 'lucide-react';
+import { MobileDrawer } from '@/app/components/layout/MobileDrawer';
+import { useIsMobile } from '@/app/hooks/useIsMobile';
+import { ListTree, RefreshCw, PanelLeftClose, PanelLeft } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Toaster, toast } from 'sonner';
 import { TopicDetailPanel } from './TopicDetailPanel';
@@ -33,6 +38,7 @@ export function ProfessorCurriculumPage() {
   } = useContentTree();
 
   const [refreshing, setRefreshing] = useState(false);
+  const isMobile = useIsMobile(1024);
 
   // ── Editor mode state ───────────────────────────────────
   const [editingSummary, setEditingSummary] = useState<Summary | null>(null);
@@ -40,7 +46,16 @@ export function ProfessorCurriculumPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeTab, setActiveTab] = useState<'content' | '3d'>('content');
 
+  // ── Tree panel state ────────────────────────────────────
+  const [treeVisible, setTreeVisible] = useState(true);
+  const [mobileTreeOpen, setMobileTreeOpen] = useState(false);
+
   const isEditorMode = editingSummary !== null;
+
+  // Close mobile drawer when topic is selected
+  React.useEffect(() => {
+    if (selectedTopicId && isMobile) setMobileTreeOpen(false);
+  }, [selectedTopicId, isMobile]);
 
   const handleEditSummary = useCallback((summary: Summary, topicName: string) => {
     setEditingSummary(summary);
@@ -53,7 +68,6 @@ export function ProfessorCurriculumPage() {
   }, []);
 
   const handleSummaryUpdated = useCallback(() => {
-    // Refresh context tree in background (summary status may have changed)
     refresh().catch(() => {});
   }, [refresh]);
 
@@ -81,7 +95,7 @@ export function ProfessorCurriculumPage() {
       }
     };
 
-  // Find selected topic name from tree for the detail panel
+  // Find selected topic name from tree
   let selectedTopicName = '';
   if (tree && selectedTopicId) {
     const courses = tree?.courses || [];
@@ -118,6 +132,34 @@ export function ProfessorCurriculumPage() {
     }
     return { courses: courses.length, semesters, sections, topics };
   }, [tree]);
+
+  // ── Shared tree content (used by desktop panel + mobile drawer) ──
+  const treeContent = (
+    <ContentTree
+      tree={tree}
+      loading={loading}
+      error={error}
+      editable={canEdit}
+      selectedTopicId={selectedTopicId}
+      onSelectTopic={(id) => {
+        selectTopic(id);
+        if (isMobile) setMobileTreeOpen(false);
+      }}
+      onRefresh={refresh}
+      onAddCourse={wrap(addCourse, 'Curso creado')}
+      onEditCourse={wrap(editCourse, 'Curso actualizado')}
+      onDeleteCourse={wrap(removeCourse, 'Curso eliminado')}
+      onAddSemester={wrap(addSemester, 'Semestre creado')}
+      onEditSemester={wrap(editSemester, 'Semestre actualizado')}
+      onDeleteSemester={wrap(removeSemester, 'Semestre eliminado')}
+      onAddSection={wrap(addSection, 'Seccion creada')}
+      onEditSection={wrap(editSection, 'Seccion actualizada')}
+      onDeleteSection={wrap(removeSection, 'Seccion eliminada')}
+      onAddTopic={wrap(addTopic, 'Topico creado')}
+      onEditTopic={wrap(editTopic, 'Topico actualizado')}
+      onDeleteTopic={wrap(removeTopic, 'Topico eliminado')}
+    />
+  );
 
   // ══════════════════════════════════════════════════════════
   // EDITOR MODE: EditorSidebar + SummaryDetailView
@@ -156,42 +198,52 @@ export function ProfessorCurriculumPage() {
   }
 
   // ══════════════════════════════════════════════════════════
-  // TREE MODE: ContentTree + TopicDetailPanel (original view)
+  // TREE MODE: ContentTree + TopicDetailPanel
   // ══════════════════════════════════════════════════════════
   return (
     <div className="h-full flex flex-col bg-[#F0F2F5]">
       <Toaster position="top-right" richColors />
 
       {/* Page Header */}
-      <div className="px-6 pt-6 pb-0">
+      <div className="px-4 lg:px-6 pt-4 lg:pt-6 pb-0">
         <PageHeader
           icon={<ListTree size={20} />}
           title="Curriculum"
           subtitle="Administra la estructura de cursos, semestres, secciones y topicos"
           accent="purple"
           actions={
-            <button
-              onClick={handleRefresh}
-              disabled={refreshing}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-600 hover:text-gray-900 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors disabled:opacity-50"
-            >
-              <RefreshCw size={13} className={refreshing ? 'animate-spin' : ''} />
-              Actualizar
-            </button>
+            <div className="flex items-center gap-2">
+              {/* Mobile: open tree button */}
+              <button
+                onClick={() => setMobileTreeOpen(true)}
+                className="lg:hidden inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-purple-600 hover:text-purple-700 bg-purple-50 border border-purple-100 rounded-lg hover:bg-purple-100 transition-colors"
+              >
+                <ListTree size={13} />
+                Contenido
+              </button>
+              <button
+                onClick={handleRefresh}
+                disabled={refreshing}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-600 hover:text-gray-900 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw size={13} className={refreshing ? 'animate-spin' : ''} />
+                <span className="hidden sm:inline">Actualizar</span>
+              </button>
+            </div>
           }
         />
       </div>
 
       {/* Stats bar */}
       {!loading && tree && (tree?.courses || []).length > 0 && (
-        <div className="px-6 py-3 border-b border-gray-100 bg-white flex items-center gap-6">
+        <div className="px-4 lg:px-6 py-2.5 border-b border-gray-100 bg-white flex items-center gap-4 lg:gap-6 overflow-x-auto">
           {[
-            { label: 'Cursos', value: stats.courses, color: 'text-violet-600' },
+            { label: 'Cursos', value: stats.courses, color: 'text-purple-600' },
             { label: 'Semestres', value: stats.semesters, color: 'text-blue-600' },
             { label: 'Secciones', value: stats.sections, color: 'text-emerald-600' },
             { label: 'Topicos', value: stats.topics, color: 'text-gray-600' },
           ].map(s => (
-            <div key={s.label} className="flex items-center gap-1.5">
+            <div key={s.label} className="flex items-center gap-1.5 shrink-0">
               <span className={`text-sm font-semibold ${s.color}`}>{s.value}</span>
               <span className="text-xs text-gray-400">{s.label}</span>
             </div>
@@ -199,36 +251,47 @@ export function ProfessorCurriculumPage() {
         </div>
       )}
 
+      {/* ── Mobile Tree Drawer ── */}
+      <MobileDrawer
+        isOpen={mobileTreeOpen}
+        onClose={() => setMobileTreeOpen(false)}
+        width={300}
+        zIndex={40}
+      >
+        <div className="h-full bg-white">
+          {treeContent}
+        </div>
+      </MobileDrawer>
+
       {/* Main content: tree + detail panel */}
       <div className="flex-1 flex min-h-0 overflow-hidden">
-        {/* Left: Content Tree (dark panel) */}
-        <motion.div
-          initial={{ opacity: 0, x: -10 }}
-          animate={{ opacity: 1, x: 0 }}
-          className="w-[340px] shrink-0 bg-zinc-950 border-r border-white/[0.06] flex flex-col overflow-hidden"
-        >
-          <ContentTree
-            tree={tree}
-            loading={loading}
-            error={error}
-            editable={canEdit}
-            selectedTopicId={selectedTopicId}
-            onSelectTopic={(id) => selectTopic(id)}
-            onRefresh={refresh}
-            onAddCourse={wrap(addCourse, 'Curso creado')}
-            onEditCourse={wrap(editCourse, 'Curso actualizado')}
-            onDeleteCourse={wrap(removeCourse, 'Curso eliminado')}
-            onAddSemester={wrap(addSemester, 'Semestre creado')}
-            onEditSemester={wrap(editSemester, 'Semestre actualizado')}
-            onDeleteSemester={wrap(removeSemester, 'Semestre eliminado')}
-            onAddSection={wrap(addSection, 'Seccion creada')}
-            onEditSection={wrap(editSection, 'Seccion actualizada')}
-            onDeleteSection={wrap(removeSection, 'Seccion eliminada')}
-            onAddTopic={wrap(addTopic, 'Topico creado')}
-            onEditTopic={wrap(editTopic, 'Topico actualizado')}
-            onDeleteTopic={wrap(removeTopic, 'Topico eliminado')}
-          />
-        </motion.div>
+
+        {/* ── Desktop: collapsible tree panel ── */}
+        <AnimatePresence initial={false}>
+          {treeVisible && (
+            <motion.div
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 320, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+              className="hidden lg:flex flex-col shrink-0 bg-white border-r border-gray-200 overflow-hidden"
+            >
+              {/* Collapse toggle bar */}
+              <div className="flex items-center justify-end px-2 py-1.5 border-b border-gray-100 shrink-0">
+                <button
+                  onClick={() => setTreeVisible(false)}
+                  className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                  title="Ocultar arbol"
+                >
+                  <PanelLeftClose size={15} />
+                </button>
+              </div>
+              <div className="flex-1 overflow-hidden">
+                {treeContent}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Right: Detail panel */}
         <div className="flex-1 overflow-y-auto">
@@ -237,14 +300,22 @@ export function ProfessorCurriculumPage() {
               key={selectedTopicId}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="p-8"
+              className="p-4 lg:p-8"
             >
               <div className="max-w-4xl">
-                <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-                  <span>Curriculum</span>
-                  <ChevronRight size={14} />
-                  <span className="text-gray-600">{selectedTopicName}</span>
-                </div>
+                {/* Action bar: expand tree button */}
+                {!treeVisible && (
+                  <div className="hidden lg:flex mb-4">
+                    <button
+                      onClick={() => setTreeVisible(true)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
+                      title="Mostrar arbol"
+                    >
+                      <PanelLeft size={14} />
+                      Mostrar arbol
+                    </button>
+                  </div>
+                )}
 
                 {/* Tabs */}
                 <div className="flex gap-1 mb-6 border-b border-gray-100 pb-0">
@@ -252,7 +323,7 @@ export function ProfessorCurriculumPage() {
                     onClick={() => setActiveTab('content')}
                     className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${
                       activeTab === 'content'
-                        ? 'border-violet-600 text-violet-700 bg-violet-50'
+                        ? 'border-purple-600 text-purple-700 bg-purple-50'
                         : 'border-transparent text-gray-500 hover:text-gray-700'
                     }`}
                   >
@@ -263,7 +334,7 @@ export function ProfessorCurriculumPage() {
                     onClick={() => setActiveTab('3d')}
                     className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${
                       activeTab === '3d'
-                        ? 'border-violet-600 text-violet-700 bg-violet-50'
+                        ? 'border-purple-600 text-purple-700 bg-purple-50'
                         : 'border-transparent text-gray-500 hover:text-gray-700'
                     }`}
                   >
@@ -286,13 +357,24 @@ export function ProfessorCurriculumPage() {
               </div>
             </motion.div>
           ) : (
-            <div className="h-full flex items-center justify-center">
+            <div className="h-full flex items-center justify-center p-4">
               <div className="text-center">
                 <div className="w-16 h-16 rounded-2xl bg-gray-100 flex items-center justify-center mx-auto mb-4">
                   <ListTree size={28} className="text-gray-300" />
                 </div>
                 <p className="text-gray-400 text-sm">Selecciona un topico del arbol</p>
                 <p className="text-gray-300 text-xs mt-1">para ver y editar su contenido y modelos 3D</p>
+
+                {/* Mobile/collapsed: quick access to tree */}
+                {(isMobile || !treeVisible) && (
+                  <button
+                    onClick={() => isMobile ? setMobileTreeOpen(true) : setTreeVisible(true)}
+                    className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 text-sm text-purple-600 bg-purple-50 border border-purple-100 rounded-lg hover:bg-purple-100 transition-colors"
+                  >
+                    <ListTree size={16} />
+                    Abrir arbol de contenido
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/src/app/components/roles/pages/professor/ProfessorCurriculumPage.tsx
+++ b/src/app/components/roles/pages/professor/ProfessorCurriculumPage.tsx
@@ -216,7 +216,7 @@ export function ProfessorCurriculumPage() {
               {/* Mobile: open tree button */}
               <button
                 onClick={() => setMobileTreeOpen(true)}
-                className="lg:hidden inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-purple-600 hover:text-purple-700 bg-purple-50 border border-purple-100 rounded-lg hover:bg-purple-100 transition-colors"
+                className="lg:hidden inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-violet-600 hover:text-violet-700 bg-violet-50 border border-violet-100 rounded-lg hover:bg-violet-100 transition-colors"
               >
                 <ListTree size={13} />
                 Contenido
@@ -238,7 +238,7 @@ export function ProfessorCurriculumPage() {
       {!loading && tree && (tree?.courses || []).length > 0 && (
         <div className="px-4 lg:px-6 py-2.5 border-b border-gray-100 bg-white flex items-center gap-4 lg:gap-6 overflow-x-auto">
           {[
-            { label: 'Cursos', value: stats.courses, color: 'text-purple-600' },
+            { label: 'Cursos', value: stats.courses, color: 'text-violet-600' },
             { label: 'Semestres', value: stats.semesters, color: 'text-blue-600' },
             { label: 'Secciones', value: stats.sections, color: 'text-emerald-600' },
             { label: 'Topicos', value: stats.topics, color: 'text-gray-600' },
@@ -282,6 +282,7 @@ export function ProfessorCurriculumPage() {
                   onClick={() => setTreeVisible(false)}
                   className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
                   title="Ocultar arbol"
+                  aria-label="Ocultar arbol de contenido"
                 >
                   <PanelLeftClose size={15} />
                 </button>
@@ -310,6 +311,7 @@ export function ProfessorCurriculumPage() {
                       onClick={() => setTreeVisible(true)}
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
                       title="Mostrar arbol"
+                      aria-label="Mostrar arbol de contenido"
                     >
                       <PanelLeft size={14} />
                       Mostrar arbol
@@ -323,7 +325,7 @@ export function ProfessorCurriculumPage() {
                     onClick={() => setActiveTab('content')}
                     className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${
                       activeTab === 'content'
-                        ? 'border-purple-600 text-purple-700 bg-purple-50'
+                        ? 'border-violet-600 text-violet-700 bg-violet-50'
                         : 'border-transparent text-gray-500 hover:text-gray-700'
                     }`}
                   >
@@ -334,7 +336,7 @@ export function ProfessorCurriculumPage() {
                     onClick={() => setActiveTab('3d')}
                     className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${
                       activeTab === '3d'
-                        ? 'border-purple-600 text-purple-700 bg-purple-50'
+                        ? 'border-violet-600 text-violet-700 bg-violet-50'
                         : 'border-transparent text-gray-500 hover:text-gray-700'
                     }`}
                   >
@@ -369,7 +371,7 @@ export function ProfessorCurriculumPage() {
                 {(isMobile || !treeVisible) && (
                   <button
                     onClick={() => isMobile ? setMobileTreeOpen(true) : setTreeVisible(true)}
-                    className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 text-sm text-purple-600 bg-purple-50 border border-purple-100 rounded-lg hover:bg-purple-100 transition-colors"
+                    className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 text-sm text-violet-600 bg-violet-50 border border-violet-100 rounded-lg hover:bg-violet-100 transition-colors"
                   >
                     <ListTree size={16} />
                     Abrir arbol de contenido

--- a/src/app/components/shared/ContentTree.tsx
+++ b/src/app/components/shared/ContentTree.tsx
@@ -89,7 +89,7 @@ function InlineEditor({
         onKeyDown={handleKeyDown}
         onBlur={() => { if (value.trim()) onSave(value.trim()); else onCancel(); }}
         placeholder={placeholder}
-        className="flex-1 min-w-0 px-2 py-1 bg-gray-50 border border-purple-200 rounded text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-purple-500/30"
+        className="flex-1 min-w-0 px-2 py-1 bg-gray-50 border border-violet-200 rounded text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-violet-500/30"
       />
       <button onClick={() => value.trim() && onSave(value.trim())} className="p-1 text-emerald-600 hover:text-emerald-700">
         <Check size={14} />
@@ -122,7 +122,7 @@ function NodeActions({
         <button
           onClick={e => { e.stopPropagation(); onAddChild(); }}
           title={addLabel}
-          className="p-1 rounded text-purple-500 hover:text-purple-600 hover:bg-purple-50"
+          className="p-1 rounded text-violet-500 hover:text-violet-600 hover:bg-violet-50"
         >
           <Plus size={13} />
         </button>
@@ -243,7 +243,7 @@ export function ContentTree({
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-3">
-        <Loader2 className="w-6 h-6 text-purple-500 animate-spin" />
+        <Loader2 className="w-6 h-6 text-violet-500 animate-spin" />
         <p className="text-sm text-gray-400">Cargando contenido...</p>
       </div>
     );
@@ -256,7 +256,7 @@ export function ContentTree({
         <AlertCircle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-500 text-center">{error}</p>
         {onRefresh && (
-          <button onClick={onRefresh} className="text-xs text-purple-600 hover:text-purple-700 underline">
+          <button onClick={onRefresh} className="text-xs text-violet-600 hover:text-violet-700 underline">
             Reintentar
           </button>
         )}
@@ -268,8 +268,8 @@ export function ContentTree({
   if (!tree || tree.courses.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-4 px-4">
-        <div className="w-14 h-14 rounded-2xl bg-purple-50 border border-purple-100 flex items-center justify-center">
-          <BookMarked className="w-7 h-7 text-purple-400" />
+        <div className="w-14 h-14 rounded-2xl bg-violet-50 border border-violet-100 flex items-center justify-center">
+          <BookMarked className="w-7 h-7 text-violet-400" />
         </div>
         <div className="text-center">
           <p className="text-sm text-gray-500">No hay cursos aun</p>
@@ -280,7 +280,7 @@ export function ContentTree({
         {editable && onAddCourse && (
           <button
             onClick={() => setEditing({ type: 'add', level: 'course', id: 'new' })}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white text-sm rounded-lg transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-500 text-white text-sm rounded-lg transition-colors"
           >
             <Plus size={16} />
             Crear primer curso
@@ -345,7 +345,7 @@ export function ContentTree({
   };
 
   const LEVEL_COLORS: Record<NodeLevel, string> = {
-    course: 'text-purple-500',
+    course: 'text-violet-500',
     semester: 'text-blue-500',
     section: 'text-emerald-500',
     topic: 'text-gray-400',
@@ -386,7 +386,7 @@ export function ContentTree({
             "group/node flex items-center gap-1.5 cursor-pointer transition-colors",
             compact ? "py-1.5 pr-2" : "py-1.5 pr-3",
             isSelected
-              ? "bg-purple-50 text-purple-700"
+              ? "bg-violet-50 text-violet-700"
               : "text-gray-600 hover:bg-gray-50 hover:text-gray-900",
           )}
           style={{ paddingLeft: depthPadding(depth) }}
@@ -489,7 +489,7 @@ export function ContentTree({
           <span className="text-xs text-gray-400 uppercase tracking-wider">Contenido</span>
           <button
             onClick={() => setEditing({ type: 'add', level: 'course', id: 'new' })}
-            className="inline-flex items-center gap-1 px-2 py-1 text-[11px] text-purple-600 hover:text-purple-700 bg-purple-50 hover:bg-purple-100 rounded-md transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-1 text-[11px] text-violet-600 hover:text-violet-700 bg-violet-50 hover:bg-violet-100 rounded-md transition-colors"
           >
             <Plus size={12} />
             Curso

--- a/src/app/components/shared/ContentTree.tsx
+++ b/src/app/components/shared/ContentTree.tsx
@@ -1,12 +1,13 @@
 // ============================================================
-// Axon — Content Tree Component
+// Axon — Content Tree Component (Light Theme)
 //
 // Expandable tree: Courses > Semesters > Sections > Topics
 // Supports read-only (student) and editable (professor) modes.
 //
 // Used by:
 //   - ProfessorCurriculumPage (editable, full page)
-//   - TopicSidebar (read-only, narrow sidebar)
+//
+// Theme: Light — harmonizes with the page bg (#F0F2F5).
 // ============================================================
 
 import React, { useState, useCallback } from 'react';
@@ -88,12 +89,12 @@ function InlineEditor({
         onKeyDown={handleKeyDown}
         onBlur={() => { if (value.trim()) onSave(value.trim()); else onCancel(); }}
         placeholder={placeholder}
-        className="flex-1 min-w-0 px-2 py-1 bg-zinc-800 border border-violet-500/40 rounded text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-violet-500/50"
+        className="flex-1 min-w-0 px-2 py-1 bg-gray-50 border border-purple-200 rounded text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-purple-500/30"
       />
-      <button onClick={() => value.trim() && onSave(value.trim())} className="p-1 text-emerald-400 hover:text-emerald-300">
+      <button onClick={() => value.trim() && onSave(value.trim())} className="p-1 text-emerald-600 hover:text-emerald-700">
         <Check size={14} />
       </button>
-      <button onClick={onCancel} className="p-1 text-zinc-500 hover:text-zinc-300">
+      <button onClick={onCancel} className="p-1 text-gray-400 hover:text-gray-600">
         <X size={14} />
       </button>
     </div>
@@ -116,12 +117,12 @@ function NodeActions({
   compact?: boolean;
 }) {
   return (
-    <div className={clsx("flex items-center gap-0.5 shrink-0", compact ? "opacity-0 group-hover/node:opacity-100" : "opacity-0 group-hover/node:opacity-100")} style={{ transition: 'opacity 0.15s' }}>
+    <div className={clsx("flex items-center gap-0.5 shrink-0", "opacity-0 group-hover/node:opacity-100")} style={{ transition: 'opacity 0.15s' }}>
       {onAddChild && (
         <button
           onClick={e => { e.stopPropagation(); onAddChild(); }}
           title={addLabel}
-          className="p-1 rounded text-violet-400 hover:text-violet-300 hover:bg-violet-500/10"
+          className="p-1 rounded text-purple-500 hover:text-purple-600 hover:bg-purple-50"
         >
           <Plus size={13} />
         </button>
@@ -129,14 +130,14 @@ function NodeActions({
       <button
         onClick={e => { e.stopPropagation(); onEdit(); }}
         title="Editar"
-        className="p-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
+        className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100"
       >
         <Pencil size={12} />
       </button>
       <button
         onClick={e => { e.stopPropagation(); onDelete(); }}
         title="Eliminar"
-        className="p-1 rounded text-red-500/60 hover:text-red-400 hover:bg-red-500/10"
+        className="p-1 rounded text-red-400 hover:text-red-500 hover:bg-red-50"
       >
         <Trash2 size={12} />
       </button>
@@ -191,7 +192,7 @@ export function ContentTree({
     }
   }, [tree, expandAll, expanded.size]);
 
-  // ── CRUD handlers ──────────────────���──────────────────
+  // ── CRUD handlers ──────────────────────────────────────
 
   const handleSave = async (value: string) => {
     if (!editing) return;
@@ -242,8 +243,8 @@ export function ContentTree({
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-3">
-        <Loader2 className="w-6 h-6 text-violet-400 animate-spin" />
-        <p className="text-sm text-zinc-500">Cargando contenido...</p>
+        <Loader2 className="w-6 h-6 text-purple-500 animate-spin" />
+        <p className="text-sm text-gray-400">Cargando contenido...</p>
       </div>
     );
   }
@@ -253,9 +254,9 @@ export function ContentTree({
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-3 px-4">
         <AlertCircle className="w-6 h-6 text-red-400" />
-        <p className="text-sm text-red-300 text-center">{error}</p>
+        <p className="text-sm text-red-500 text-center">{error}</p>
         {onRefresh && (
-          <button onClick={onRefresh} className="text-xs text-violet-400 hover:text-violet-300 underline">
+          <button onClick={onRefresh} className="text-xs text-purple-600 hover:text-purple-700 underline">
             Reintentar
           </button>
         )}
@@ -267,19 +268,19 @@ export function ContentTree({
   if (!tree || tree.courses.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-4 px-4">
-        <div className="w-14 h-14 rounded-2xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center">
-          <BookMarked className="w-7 h-7 text-violet-400" />
+        <div className="w-14 h-14 rounded-2xl bg-purple-50 border border-purple-100 flex items-center justify-center">
+          <BookMarked className="w-7 h-7 text-purple-400" />
         </div>
         <div className="text-center">
-          <p className="text-sm text-zinc-300">No hay cursos aun</p>
-          <p className="text-xs text-zinc-500 mt-1">
+          <p className="text-sm text-gray-500">No hay cursos aun</p>
+          <p className="text-xs text-gray-400 mt-1">
             {editable ? 'Crea el primer curso para empezar' : 'El profesor aun no ha creado contenido'}
           </p>
         </div>
         {editable && onAddCourse && (
           <button
             onClick={() => setEditing({ type: 'add', level: 'course', id: 'new' })}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-500 text-white text-sm rounded-lg transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white text-sm rounded-lg transition-colors"
           >
             <Plus size={16} />
             Crear primer curso
@@ -301,22 +302,22 @@ export function ContentTree({
 
   // ── Delete confirmation ───────────────────────────────
   const deleteModal = confirmDelete && (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setConfirmDelete(null)}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setConfirmDelete(null)}>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="bg-zinc-900 border border-white/10 rounded-xl p-6 max-w-sm mx-4 shadow-2xl"
+        className="bg-white border border-gray-200 rounded-xl p-6 max-w-sm mx-4 shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
-        <h3 className="text-white text-sm">Eliminar {confirmDelete.level}</h3>
-        <p className="text-zinc-400 text-xs mt-2">
-          Estas seguro de eliminar <span className="text-white">&ldquo;{confirmDelete.name}&rdquo;</span>?
+        <h3 className="text-gray-900 text-sm font-medium">Eliminar {confirmDelete.level}</h3>
+        <p className="text-gray-500 text-xs mt-2">
+          Estas seguro de eliminar <span className="text-gray-900 font-medium">&ldquo;{confirmDelete.name}&rdquo;</span>?
           {confirmDelete.level !== 'topic' && ' Esto eliminara todo su contenido.'}
         </p>
         <div className="flex justify-end gap-2 mt-5">
           <button
             onClick={() => setConfirmDelete(null)}
-            className="px-3 py-1.5 text-xs text-zinc-400 hover:text-white bg-zinc-800 rounded-lg transition-colors"
+            className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 bg-gray-100 rounded-lg transition-colors"
           >
             Cancelar
           </button>
@@ -344,10 +345,10 @@ export function ContentTree({
   };
 
   const LEVEL_COLORS: Record<NodeLevel, string> = {
-    course: 'text-violet-400',
-    semester: 'text-blue-400',
-    section: 'text-emerald-400',
-    topic: 'text-zinc-400',
+    course: 'text-purple-500',
+    semester: 'text-blue-500',
+    section: 'text-emerald-500',
+    topic: 'text-gray-400',
   };
 
   const CHILD_LEVELS: Record<string, NodeLevel> = {
@@ -385,8 +386,8 @@ export function ContentTree({
             "group/node flex items-center gap-1.5 cursor-pointer transition-colors",
             compact ? "py-1.5 pr-2" : "py-1.5 pr-3",
             isSelected
-              ? "bg-violet-500/15 text-violet-300"
-              : "text-zinc-300 hover:bg-white/[0.04] hover:text-white",
+              ? "bg-purple-50 text-purple-700"
+              : "text-gray-600 hover:bg-gray-50 hover:text-gray-900",
           )}
           style={{ paddingLeft: depthPadding(depth) }}
           onClick={() => {
@@ -421,7 +422,7 @@ export function ContentTree({
             <span className={clsx(
               "flex-1 min-w-0 truncate",
               compact ? "text-xs" : "text-[13px]",
-              isLeaf && !isSelected && "text-zinc-400",
+              isLeaf && !isSelected && "text-gray-500",
             )}>
               {item.name}
             </span>
@@ -484,11 +485,11 @@ export function ContentTree({
     <div className="flex flex-col h-full">
       {/* Header with "Add course" button */}
       {editable && (
-        <div className={clsx("flex items-center justify-between border-b border-white/[0.06] shrink-0", compact ? "px-3 py-2" : "px-4 py-3")}>
-          <span className="text-xs text-zinc-500 uppercase tracking-wider">Contenido</span>
+        <div className={clsx("flex items-center justify-between border-b border-gray-100 shrink-0", compact ? "px-3 py-2" : "px-4 py-3")}>
+          <span className="text-xs text-gray-400 uppercase tracking-wider">Contenido</span>
           <button
             onClick={() => setEditing({ type: 'add', level: 'course', id: 'new' })}
-            className="inline-flex items-center gap-1 px-2 py-1 text-[11px] text-violet-400 hover:text-violet-300 bg-violet-500/10 hover:bg-violet-500/15 rounded-md transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-1 text-[11px] text-purple-600 hover:text-purple-700 bg-purple-50 hover:bg-purple-100 rounded-md transition-colors"
           >
             <Plus size={12} />
             Curso


### PR DESCRIPTION
## Summary
- Convert ContentTree from dark theme (bg-zinc-950) to light theme (bg-white) harmonizing with page background
- Make ProfessorCurriculumPage responsive: MobileDrawer for mobile (<lg), collapsible panel for desktop
- Remove duplicate breadcrumb (was in both parent and TopicDetailPanel)
- Unify color tokens to violet-* for consistency with professor theme
- Add aria-labels on collapse/expand buttons for accessibility

## Test plan
- [x] Build passes (0 errors)
- [x] Desktop: tree panel visible, collapsible with animation
- [x] Desktop: "Mostrar arbol" button appears when collapsed
- [x] Mobile: tree hidden, "Contenido" button opens MobileDrawer
- [x] Mobile: drawer auto-closes on topic selection
- [x] No duplicate breadcrumb
- [x] Delete modal renders with white bg
- [x] Stats bar scrollable on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)