### PR TITLE
fix: restore unified reader layout — sidebar overlay + view mode + tabs abajo

### DIFF
--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -16,10 +16,10 @@ import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
 import {
-  Layers, Tag, Video as VideoIcon,
+  ChevronLeft, Layers, Tag, Video as VideoIcon,
   CheckCircle2, Clock, Loader2,
-  StickyNote, BookOpen,
-  Minimize2,
+  StickyNote, BookOpen, Search as SearchIcon,
+  Timer, Settings, PanelLeftOpen, Minimize2,
 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
 import { SidebarOutline } from '@/app/components/student/SidebarOutline';
@@ -44,6 +44,7 @@ import { KeywordHighlighterInline } from '@/app/components/student/KeywordHighli
 import { useReadingTimeTracker } from '@/app/hooks/useReadingTimeTracker';
 import { useVideoListQuery } from '@/app/hooks/queries/useVideoPlayerQueries';
 import { useThemeToggle } from '@/app/hooks/useThemeToggle';
+import { ThemeToggle } from '@/app/components/student/ThemeToggle';
 
 // ── Extracted helpers (Phase B.1) ─────────────────────────
 import {
@@ -62,9 +63,8 @@ import { ListSkeleton, TabBadge } from '@/app/components/student/reader-atoms';
 import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotationsTab';
 import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
 import { ReaderChunksTab } from '@/app/components/student/ReaderChunksTab';
-import { ReaderToolbar } from '@/app/components/student/ReaderToolbar';
 import { StudyTimer } from '@/app/components/student/StudyTimer';
-import { useReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
+import ReadingSettingsPanel, { useReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
 import { useSummaryBlocksQuery } from '@/app/hooks/queries/useSummaryBlocksQuery';
 
 // ── Props ─────────────────────────────────────────────────
@@ -89,7 +89,7 @@ export function StudentSummaryReader({
   onNavigateKeyword,
   initialTab,
 }: StudentSummaryReaderProps) {
-  const [activeTab, setActiveTab] = useState(initialTab || 'chunks');
+  const [activeTab, setActiveTab] = useState(initialTab === 'chunks' ? 'keywords' : (initialTab || 'keywords'));
   const readerRef = useRef<HTMLDivElement>(null);
   const { isDark, toggle: toggleTheme } = useThemeToggle(readerRef);
   const [showTimer, setShowTimer] = useState(false);
@@ -97,12 +97,12 @@ export function StudentSummaryReader({
   const { settings: readingSettings, update: updateReadingSettings } = useReadingSettings();
 
   // ── Wave 1: Sidebar, search, reading progress ─────────
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth < 1280 : true
-  );
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+  /** View mode: 'enriched' shows structured blocks, 'reading' shows plain markdown */
+  const [viewMode, setViewMode] = useState<'enriched' | 'reading'>('enriched');
 
   // ── Content pagination ──────────────────────────────────
   const [contentPage, setContentPage] = useState(0);
@@ -142,7 +142,6 @@ export function StudentSummaryReader({
 
   // ── Sidebar block click → scroll into view ──
   const handleSidebarBlockClick = useCallback((blockId: string) => {
-    setActiveTab('chunks');
     setTimeout(() => {
       const el = document.querySelector(`[data-block-id="${blockId}"]`);
       el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -324,6 +323,15 @@ export function StudentSummaryReader({
       className={`axon-reader overflow-y-auto ${isDark ? 'bg-[#111215]' : 'bg-[#F0F2F5]'}`}
       style={{ minHeight: '100vh' }}
     >
+      {/* ── Skip to content link (a11y) ── */}
+      <a
+        href="#reader-main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[999] focus:px-4 focus:py-2 focus:bg-white focus:text-teal-700 focus:rounded-lg focus:shadow-lg focus:border focus:border-teal-200 focus:font-semibold"
+        style={{ fontSize: 'clamp(0.8rem, 1.5vw, 0.875rem)' }}
+      >
+        Saltar al contenido
+      </a>
+
       {/* ── Reading progress bar (Wave 1) ── */}
       <ReadingProgress containerRef={readerRef} />
 
@@ -354,17 +362,11 @@ export function StudentSummaryReader({
         </button>
       )}
 
-      <div className="relative xl:flex xl:gap-6 mx-auto p-6 sm:p-8" style={{ maxWidth: readingSettings.focusMode ? 768 : 1100 }}>
+      <div className="flex mx-auto p-6 sm:p-8 gap-6" style={{ maxWidth: readingSettings.focusMode ? 768 : 1100 }}>
         {/* ── Sidebar outline (Wave 1) — hidden in focus mode ── */}
-        {!readingSettings.focusMode && sidebarBlocks.length > 0 && activeTab === 'chunks' && (
-          <div
-            className={[
-              'flex flex-col gap-3 z-[110] transition-all duration-200',
-              sidebarCollapsed
-                ? 'relative flex-shrink-0'
-                : 'absolute top-6 left-6 bottom-0 bg-white dark:bg-[#1e1f25] shadow-xl rounded-xl xl:relative xl:flex-shrink-0 xl:shadow-none xl:rounded-none xl:bg-transparent',
-            ].join(' ')}
-          >
+        {/* Wrapper is relative so expanded sidebar overlays from its own position */}
+        {!readingSettings.focusMode && sidebarBlocks.length > 0 && (
+          <div className="relative" style={{ width: 52, flexShrink: 0 }}>
             <SidebarOutline
               blocks={sidebarBlocks}
               activeBlockId={activeBlockId}
@@ -372,162 +374,289 @@ export function StudentSummaryReader({
               collapsed={sidebarCollapsed}
               onToggleCollapse={() => setSidebarCollapsed((v) => !v)}
               masteryLevels={masteryLevels}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              masteryLegend={
+                Object.keys(masteryLevels).length > 0 ? (
+                  <MasteryLegend
+                    masteryLevels={masteryLevels}
+                    totalBlocks={sidebarBlocks.length}
+                  />
+                ) : undefined
+              }
             />
-            {!sidebarCollapsed && Object.keys(masteryLevels).length > 0 && (
-              <MasteryLegend
-                masteryLevels={masteryLevels}
-                totalBlocks={sidebarBlocks.length}
-              />
-            )}
           </div>
         )}
 
-        {/* Content — full width on <xl with left margin for collapsed sidebar; flex child on xl+ */}
-        <div
-          className={[
-            'min-w-0 transition-[margin-left] duration-200',
-            readingSettings.focusMode ? 'mx-auto' : 'xl:flex-1',
-            (!readingSettings.focusMode && sidebarBlocks.length > 0 && activeTab === 'chunks' && sidebarCollapsed)
-              ? 'ml-16 xl:ml-0'
-              : '',
-          ].join(' ')}
+        <div id="reader-main-content" className={`flex-1 min-w-0 transition-all duration-200 ${readingSettings.focusMode ? 'mx-auto' : ''}`} style={{ maxWidth: readingSettings.focusMode ? 680 : 800 }}>
+
+        {/* ── Compact header toolbar with title ── */}
+        {!readingSettings.focusMode && (
+        <header
+          role="banner"
+          aria-label="Barra de herramientas del resumen"
+          className="flex items-center justify-between"
           style={{
-            maxWidth: readingSettings.focusMode ? 680 : 800,
+            background: isDark ? '#0d0e11' : '#1B3B36',
+            padding: '10px 20px',
+            position: 'sticky',
+            top: 0,
+            zIndex: 100,
+            borderBottom: isDark ? '1px solid #2d2e34' : '1px solid transparent',
+            borderRadius: '12px 12px 0 0',
           }}
         >
+          {/* Left side: back + title */}
+          <div className="flex items-center min-w-0" style={{ gap: 10 }}>
+            <button
+              onClick={onBack}
+              aria-label="Volver a resúmenes"
+              style={{
+                background: 'none',
+                border: 'none',
+                padding: 10,
+                cursor: 'pointer',
+                color: '#b4d9d1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 44,
+                minHeight: 44,
+                borderRadius: 6,
+                flexShrink: 0,
+              }}
+            >
+              <ChevronLeft size={20} />
+            </button>
+            <div className="min-w-0">
+              <h1
+                className="truncate"
+                style={{
+                  fontSize: 15,
+                  fontWeight: 700,
+                  color: '#fff',
+                  fontFamily: 'Georgia, serif',
+                  lineHeight: 1.2,
+                  margin: 0,
+                }}
+              >
+                {summary.title || 'Sin titulo'}
+              </h1>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span style={{ color: '#8cb8af', fontSize: 11 }}>
+                  {new Date(summary.created_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' })}
+                </span>
+                {readingState?.time_spent_seconds != null && readingState.time_spent_seconds > 0 && (
+                  <span className="flex items-center gap-1" style={{ color: '#8cb8af', fontSize: 11 }}>
+                    <Clock className="w-3 h-3" />
+                    {Math.round(readingState.time_spent_seconds / 60)} min
+                  </span>
+                )}
+                {isCompleted && (
+                  <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ fontSize: 10, fontWeight: 600, background: 'rgba(16,185,129,0.2)', color: '#6ee7b7' }}>
+                    <CheckCircle2 className="w-2.5 h-2.5" /> Leido
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
 
-        {/* ── Immersive header toolbar (Phase B.6 — extracted) ── */}
-        {!readingSettings.focusMode && (
-          <ReaderToolbar
-            isDark={isDark}
-            onBack={onBack}
-            searchOpen={searchOpen}
-            onToggleSearch={() => setSearchOpen((v) => !v)}
-            showTimer={showTimer}
-            onToggleTimer={() => setShowTimer((prev) => !prev)}
-            onToggleTheme={toggleTheme}
-            showSettings={showSettings}
-            onToggleSettings={() => setShowSettings((prev) => !prev)}
-            sidebarCollapsed={sidebarCollapsed}
-            onToggleSidebar={() => setSidebarCollapsed((v) => !v)}
-            readingSettings={readingSettings}
-            onReadingSettingsChange={updateReadingSettings}
-          />
+          {/* Right side: tool icons */}
+          <div className="flex items-center" style={{ gap: 6 }}>
+            {/* Mark complete */}
+            <button
+              onClick={isCompleted ? handleUnmarkCompleted : handleMarkCompleted}
+              disabled={markingRead}
+              title={isCompleted ? 'Marcar no leido' : 'Marcar como leido'}
+              aria-label={isCompleted ? 'Marcar no leido' : 'Marcar como leido'}
+              style={{
+                background: isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
+                border: 'none',
+                padding: 6,
+                cursor: 'pointer',
+                color: isCompleted ? '#6ee7b7' : '#b4d9d1',
+                display: 'flex',
+                borderRadius: 6,
+              }}
+            >
+              {markingRead ? <Loader2 size={16} className="animate-spin" /> : <CheckCircle2 size={16} />}
+            </button>
+
+            {/* Search toggle */}
+            <button
+              onClick={() => setSearchOpen((v) => !v)}
+              title="Buscar (Ctrl+F)"
+              aria-label="Buscar"
+              style={{
+                background: searchOpen ? 'rgba(42,140,122,0.15)' : 'none',
+                border: 'none',
+                padding: 10,
+                cursor: 'pointer',
+                color: searchOpen ? '#2a8c7a' : '#b4d9d1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 44,
+                minHeight: 44,
+                borderRadius: 6,
+              }}
+            >
+              <SearchIcon size={16} />
+            </button>
+
+            {/* Timer toggle */}
+            <button
+              onClick={() => setShowTimer((prev) => !prev)}
+              title="Temporizador de estudio"
+              aria-label={showTimer ? 'Cerrar timer' : 'Abrir timer'}
+              style={{
+                background: showTimer ? 'rgba(42,140,122,0.15)' : 'none',
+                border: 'none',
+                padding: 10,
+                cursor: 'pointer',
+                color: showTimer ? '#2a8c7a' : '#b4d9d1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 44,
+                minHeight: 44,
+                borderRadius: 6,
+              }}
+            >
+              <Timer size={16} />
+            </button>
+
+            {/* Separator */}
+            <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
+
+            {/* Theme toggle */}
+            <ThemeToggle isDark={isDark} onToggle={toggleTheme} />
+
+            {/* Settings toggle */}
+            <div className="relative">
+              <button
+                onClick={() => setShowSettings((prev) => !prev)}
+                title="Configuración de lectura"
+                aria-label={showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
+                style={{
+                  background: showSettings ? 'rgba(42,140,122,0.15)' : 'none',
+                  border: 'none',
+                  padding: 10,
+                  cursor: 'pointer',
+                  color: showSettings ? '#2a8c7a' : '#b4d9d1',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 44,
+                  minHeight: 44,
+                  borderRadius: 6,
+                }}
+              >
+                <Settings size={16} />
+              </button>
+              {showSettings && (
+                <ReadingSettingsPanel
+                  settings={readingSettings}
+                  onChange={updateReadingSettings}
+                  onClose={() => setShowSettings(false)}
+                />
+              )}
+            </div>
+
+            {/* Separator */}
+            <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
+
+            {/* Sidebar toggle */}
+            <button
+              onClick={() => setSidebarCollapsed((v) => !v)}
+              title="Outline"
+              aria-label={sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
+              style={{
+                background: !sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none',
+                border: 'none',
+                padding: 10,
+                cursor: 'pointer',
+                color: !sidebarCollapsed ? '#2a8c7a' : '#b4d9d1',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 44,
+                minHeight: 44,
+                borderRadius: 6,
+              }}
+            >
+              <PanelLeftOpen size={16} />
+            </button>
+          </div>
+        </header>
         )}
 
         {/* ── Study Timer (fixed position, self-managed) ── */}
         {showTimer && <StudyTimer onClose={() => setShowTimer(false)} />}
 
-        {/* ── Summary header card ── */}
-        <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-[20px] border-2 border-zinc-200 dark:border-[#2d2e34] shadow-sm mb-6 overflow-hidden">
-          {/* Accent bar */}
-          <div className={`h-1 ${isCompleted ? 'bg-emerald-500' : 'bg-teal-500'}`} />
+        {/* ── Main content area (white card) ── */}
+        <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-b-[20px] border-2 border-t-0 border-zinc-200 dark:border-[#2d2e34] shadow-sm overflow-hidden">
 
-          {/* Title bar */}
-          <div className="px-6 sm:px-8 py-6 border-b border-zinc-100 dark:border-[#2d2e34]">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex items-center gap-4">
-                <div className={`w-12 h-12 rounded-xl border-2 flex items-center justify-center ${
-                  isCompleted ? 'bg-emerald-50 border-emerald-200' : 'bg-teal-50 border-teal-200'
-                }`}>
-                  {isCompleted ? (
-                    <CheckCircle2 className="w-6 h-6 text-emerald-500" />
+          {/* ── Reading mode: plain markdown ── */}
+          {viewMode === 'reading' && summary.content_markdown && (
+            <div
+              className="px-6 sm:px-8 py-8"
+              style={{
+                fontSize: `${readingSettings.fontSize}px`,
+                lineHeight: readingSettings.lineHeight,
+                fontFamily: readingSettings.fontFamily,
+              }}
+            >
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={safePage}
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -8 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  {isHtmlContent ? (
+                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
+                      <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(htmlPages[safePage] || '') }} />
+                    </KeywordHighlighterInline>
                   ) : (
-                    <BookOpen className="w-6 h-6 text-teal-600" />
+                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
+                      <div className="axon-prose max-w-none">
+                        {textPages[safePage]?.map((line, i) => renderPlainLine(line, i))}
+                      </div>
+                    </KeywordHighlighterInline>
                   )}
-                </div>
-                <div>
-                  <h2 className="text-zinc-900 dark:text-[#e6e7eb] tracking-tight" style={{ fontWeight: 700, fontFamily: 'Georgia, serif', fontSize: 30 }}>
-                    {summary.title || 'Sin titulo'}
-                  </h2>
-                  <div className="flex items-center gap-3 mt-1.5 flex-wrap">
-                    {isCompleted && (
-                      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] bg-emerald-100 text-emerald-700 border border-emerald-200" style={{ fontWeight: 600 }}>
-                        <CheckCircle2 className="w-3 h-3" /> Completado
-                      </span>
-                    )}
-                    <span className="text-[11px] text-zinc-400">
-                      {new Date(summary.created_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' })}
-                    </span>
-                    {readingState?.time_spent_seconds != null && readingState.time_spent_seconds > 0 && (
-                      <span className="text-[11px] text-zinc-400 flex items-center gap-1">
-                        <Clock className="w-3 h-3" />
-                        {Math.round(readingState.time_spent_seconds / 60)} min de lectura
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
+                </motion.div>
+              </AnimatePresence>
 
-              {/* Mark as read/unread */}
-              <motion.button
-                onClick={isCompleted ? handleUnmarkCompleted : handleMarkCompleted}
-                disabled={markingRead}
-                className={`flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm shrink-0 transition-all cursor-pointer ${focusRing} ${
-                  isCompleted
-                    ? 'bg-white border-2 border-zinc-200 text-zinc-600 hover:bg-zinc-50'
-                    : 'bg-emerald-600 text-white hover:bg-emerald-700 shadow-lg shadow-emerald-600/25'
-                }`}
-                style={{ fontWeight: 600 }}
-                whileHover={{ scale: 1.03 }}
-                whileTap={{ scale: 0.97 }}
-              >
-                {markingRead ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : isCompleted ? (
-                  <><CheckCircle2 className="w-4 h-4" /> Marcar no leido</>
-                ) : (
-                  <><CheckCircle2 className="w-4 h-4" /> Marcar como leido</>
-                )}
-              </motion.button>
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <PageNavigation
+                  currentPage={safePage}
+                  totalPages={totalPages}
+                  onPrev={() => setContentPage(Math.max(0, safePage - 1))}
+                  onNext={() => setContentPage(Math.min(totalPages - 1, safePage + 1))}
+                  onPageClick={(i) => setContentPage(i)}
+                />
+              )}
             </div>
-          </div>
+          )}
 
-          {/* ── Paginated content preview (only when no edu blocks) ── */}
-          {summary.content_markdown && !hasBlocks && (
-              <div
-                className="px-6 sm:px-8 py-6"
-                style={{
-                  fontSize: `${readingSettings.fontSize}px`,
-                  lineHeight: readingSettings.lineHeight,
-                  fontFamily: readingSettings.fontFamily,
-                }}
-              >
-                <div className="min-h-[180px]">
-                  <AnimatePresence mode="wait">
-                    <motion.div
-                      key={safePage}
-                      initial={{ opacity: 0, x: 8 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: -8 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      {isHtmlContent ? (
-                        <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
-                          <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(htmlPages[safePage] || '') }} />
-                        </KeywordHighlighterInline>
-                      ) : (
-                        <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
-                          <div className="axon-prose max-w-none">
-                            {textPages[safePage]?.map((line, i) => renderPlainLine(line, i))}
-                          </div>
-                        </KeywordHighlighterInline>
-                      )}
-                    </motion.div>
-                  </AnimatePresence>
-                </div>
-
-                {/* Pagination */}
-                {totalPages > 1 && (
-                  <PageNavigation
-                    currentPage={safePage}
-                    totalPages={totalPages}
-                    onPrev={() => setContentPage(Math.max(0, safePage - 1))}
-                    onNext={() => setContentPage(Math.min(totalPages - 1, safePage + 1))}
-                    onPageClick={(i) => setContentPage(i)}
-                  />
-                )}
-              </div>
+          {/* ── Enriched mode: structured blocks ── */}
+          {viewMode === 'enriched' && (
+            <div className="py-4">
+              <ReaderChunksTab
+                summaryId={summary.id}
+                chunks={chunks}
+                chunksLoading={chunksLoading}
+                hasBlocks={hasBlocks}
+                blocksLoading={blocksLoading}
+                onNavigateKeyword={handleNavigateKeywordWrapped}
+                readingSettings={readingSettings}
+                keywords={keywords}
+                annotations={textAnnotations}
+              />
+            </div>
           )}
 
           {/* Completion card when read */}
@@ -545,84 +674,66 @@ export function StudentSummaryReader({
           )}
         </div>
 
-        {/* ── Tabs ── */}
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="mb-4 bg-white dark:bg-[#1e1f25] border border-zinc-200 dark:border-[#2d2e34] rounded-xl p-1">
-            <TabsTrigger value="chunks" className="gap-1.5 rounded-lg">
-              <Layers className="w-3.5 h-3.5" />
-              Contenido
-              {!chunksLoading && <TabBadge count={hasBlocks ? sidebarBlocks.length : chunks.length} active={activeTab === 'chunks'} />}
-            </TabsTrigger>
-            <TabsTrigger value="keywords" className="gap-1.5 rounded-lg">
-              <Tag className="w-3.5 h-3.5" />
-              Keywords
-              {!keywordsLoading && <TabBadge count={keywords.length} active={activeTab === 'keywords'} />}
-            </TabsTrigger>
-            <TabsTrigger value="videos" className="gap-1.5 rounded-lg">
-              <VideoIcon className="w-3.5 h-3.5" />
-              Videos
-              {!videosLoading && <TabBadge count={videosCount} active={activeTab === 'videos'} />}
-            </TabsTrigger>
-            <TabsTrigger value="annotations" className="gap-1.5 rounded-lg">
-              <StickyNote className="w-3.5 h-3.5" />
-              Mis Notas
-              {!annotationsLoading && textAnnotations.length > 0 && <TabBadge count={textAnnotations.length} active={activeTab === 'annotations'} />}
-            </TabsTrigger>
-          </TabsList>
+        {/* ── Secondary tabs: Keywords, Videos, Notes (below content) ── */}
+        <div className="mt-6">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="mb-4 bg-white dark:bg-[#1e1f25] border border-zinc-200 dark:border-[#2d2e34] rounded-xl p-1">
+              <TabsTrigger value="keywords" className="gap-1.5 rounded-lg">
+                <Tag className="w-3.5 h-3.5" />
+                <span lang="en">Keywords</span>
+                {!keywordsLoading && <TabBadge count={keywords.length} active={activeTab === 'keywords'} />}
+              </TabsTrigger>
+              <TabsTrigger value="videos" className="gap-1.5 rounded-lg">
+                <VideoIcon className="w-3.5 h-3.5" />
+                <span lang="en">Videos</span>
+                {!videosLoading && <TabBadge count={videosCount} active={activeTab === 'videos'} />}
+              </TabsTrigger>
+              <TabsTrigger value="annotations" className="gap-1.5 rounded-lg">
+                <StickyNote className="w-3.5 h-3.5" />
+                Mis Notas
+                {!annotationsLoading && textAnnotations.length > 0 && <TabBadge count={textAnnotations.length} active={activeTab === 'annotations'} />}
+              </TabsTrigger>
+            </TabsList>
 
-          {/* ── CHUNKS TAB (delegated to ReaderChunksTab) ── */}
-          <TabsContent value="chunks">
-            <ReaderChunksTab
-              summaryId={summary.id}
-              chunks={chunks}
-              chunksLoading={chunksLoading}
-              hasBlocks={hasBlocks}
-              blocksLoading={blocksLoading}
-              onNavigateKeyword={handleNavigateKeywordWrapped}
-              readingSettings={readingSettings}
-              keywords={keywords}
-              annotations={textAnnotations}
-            />
-          </TabsContent>
+            {/* ── KEYWORDS TAB ── */}
+            <TabsContent value="keywords">
+              <ReaderKeywordsTab
+                keywords={keywords}
+                keywordsLoading={keywordsLoading}
+                expandedKeyword={expandedKeyword}
+                onToggleExpand={toggleKeywordExpand}
+                subtopics={subtopics}
+                subtopicsLoading={subtopicsLoading}
+                kwNotes={kwNotes}
+                kwNotesLoading={kwNotesLoading}
+                onCreateKwNote={handleCreateKwNote}
+                onUpdateKwNote={handleUpdateKwNote}
+                onDeleteKwNote={handleDeleteKwNote}
+                savingKwNote={savingKwNote}
+              />
+            </TabsContent>
 
-          {/* ── KEYWORDS TAB (Phase B.5 — delegated) ── */}
-          <TabsContent value="keywords">
-            <ReaderKeywordsTab
-              keywords={keywords}
-              keywordsLoading={keywordsLoading}
-              expandedKeyword={expandedKeyword}
-              onToggleExpand={toggleKeywordExpand}
-              subtopics={subtopics}
-              subtopicsLoading={subtopicsLoading}
-              kwNotes={kwNotes}
-              kwNotesLoading={kwNotesLoading}
-              onCreateKwNote={handleCreateKwNote}
-              onUpdateKwNote={handleUpdateKwNote}
-              onDeleteKwNote={handleDeleteKwNote}
-              savingKwNote={savingKwNote}
-            />
-          </TabsContent>
+            {/* ── VIDEOS TAB ── */}
+            <TabsContent value="videos">
+              <div className="bg-white dark:bg-[#1e1f25] rounded-2xl border border-zinc-200 dark:border-[#2d2e34] overflow-hidden">
+                <VideoPlayer summaryId={summary.id} />
+              </div>
+            </TabsContent>
 
-          {/* ── VIDEOS TAB ── */}
-          <TabsContent value="videos">
-            <div className="bg-white dark:bg-[#1e1f25] rounded-2xl border border-zinc-200 dark:border-[#2d2e34] overflow-hidden">
-              <VideoPlayer summaryId={summary.id} />
-            </div>
-          </TabsContent>
-
-          {/* ── ANNOTATIONS TAB (Phase B.4 — delegated) ── */}
-          <TabsContent value="annotations">
-            <ReaderAnnotationsTab
-              annotations={textAnnotations}
-              annotationsLoading={annotationsLoading}
-              onCreateAnnotation={handleCreateAnnotation}
-              onDeleteAnnotation={handleDeleteAnnotation}
-              savingAnnotation={savingAnnotation}
-            />
-          </TabsContent>
-        </Tabs>
-        </div>{/* end content wrapper */}
-      </div>{/* end layout wrapper */}
+            {/* ── ANNOTATIONS TAB ── */}
+            <TabsContent value="annotations">
+              <ReaderAnnotationsTab
+                annotations={textAnnotations}
+                annotationsLoading={annotationsLoading}
+                onCreateAnnotation={handleCreateAnnotation}
+                onDeleteAnnotation={handleDeleteAnnotation}
+                savingAnnotation={savingAnnotation}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
+        </div>{/* end flex-1 content wrapper */}
+      </div>{/* end flex layout */}
     </motion.div>
   );
 }

--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -97,12 +97,22 @@ export function StudentSummaryReader({
   const { settings: readingSettings, update: updateReadingSettings } = useReadingSettings();
 
   // ── Wave 1: Sidebar, search, reading progress ─────────
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 1280 : true
+  );
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
   /** View mode: 'enriched' shows structured blocks, 'reading' shows plain markdown */
   const [viewMode, setViewMode] = useState<'enriched' | 'reading'>('enriched');
+
+  // Auto-switch to enriched if reading mode selected but no content_markdown
+  useEffect(() => {
+    if (viewMode === 'reading' && !summary?.content_markdown) {
+      const timer = setTimeout(() => setViewMode('enriched'), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [viewMode, summary?.content_markdown]);
 
   // ── Content pagination ──────────────────────────────────
   const [contentPage, setContentPage] = useState(0);
@@ -142,12 +152,21 @@ export function StudentSummaryReader({
 
   // ── Sidebar block click → scroll into view ──
   const handleSidebarBlockClick = useCallback((blockId: string) => {
+    if (viewMode === 'reading') {
+      setViewMode('enriched');
+      // Let the DOM update before scrolling
+      setTimeout(() => {
+        const el = document.querySelector(`[data-block-id="${blockId}"]`);
+        el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 100);
+      return;
+    }
     setTimeout(() => {
       const el = document.querySelector(`[data-block-id="${blockId}"]`);
       el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       setActiveBlockId(blockId);
     }, 50);
-  }, []);
+  }, [viewMode]);
 
   // ── Search: count matches in blocks ──
   const searchResultCount = useMemo(() => {
@@ -315,6 +334,21 @@ export function StudentSummaryReader({
 
   const isCompleted = readingState?.completed === true;
 
+  // ── Shared toolbar button style ──
+  const toolbarBtnStyle: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    padding: 10,
+    cursor: 'pointer',
+    color: '#b4d9d1',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 44,
+    minHeight: 44,
+    borderRadius: 6,
+  };
+
   return (
     <motion.div
       ref={readerRef}
@@ -388,7 +422,7 @@ export function StudentSummaryReader({
           </div>
         )}
 
-        <div id="reader-main-content" className={`flex-1 min-w-0 transition-all duration-200 ${readingSettings.focusMode ? 'mx-auto' : ''}`} style={{ maxWidth: readingSettings.focusMode ? 680 : 800 }}>
+        <div id="reader-main-content" tabIndex={-1} className={`flex-1 min-w-0 transition-all duration-200 ${readingSettings.focusMode ? 'mx-auto' : ''}`} style={{ maxWidth: readingSettings.focusMode ? 680 : 800 }}>
 
         {/* ── Compact header toolbar with title ── */}
         {!readingSettings.focusMode && (
@@ -411,20 +445,7 @@ export function StudentSummaryReader({
             <button
               onClick={onBack}
               aria-label="Volver a resúmenes"
-              style={{
-                background: 'none',
-                border: 'none',
-                padding: 10,
-                cursor: 'pointer',
-                color: '#b4d9d1',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 44,
-                minHeight: 44,
-                borderRadius: 6,
-                flexShrink: 0,
-              }}
+              style={{ ...toolbarBtnStyle, flexShrink: 0 }}
             >
               <ChevronLeft size={20} />
             </button>
@@ -440,7 +461,7 @@ export function StudentSummaryReader({
                   margin: 0,
                 }}
               >
-                {summary.title || 'Sin titulo'}
+                {summary.title || 'Sin título'}
               </h1>
               <div className="flex items-center gap-2 mt-0.5">
                 <span style={{ color: '#8cb8af', fontSize: 11 }}>
@@ -454,7 +475,7 @@ export function StudentSummaryReader({
                 )}
                 {isCompleted && (
                   <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ fontSize: 10, fontWeight: 600, background: 'rgba(16,185,129,0.2)', color: '#6ee7b7' }}>
-                    <CheckCircle2 className="w-2.5 h-2.5" /> Leido
+                    <CheckCircle2 className="w-2.5 h-2.5" /> Leído
                   </span>
                 )}
               </div>
@@ -467,8 +488,8 @@ export function StudentSummaryReader({
             <button
               onClick={isCompleted ? handleUnmarkCompleted : handleMarkCompleted}
               disabled={markingRead}
-              title={isCompleted ? 'Marcar no leido' : 'Marcar como leido'}
-              aria-label={isCompleted ? 'Marcar no leido' : 'Marcar como leido'}
+              title={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
+              aria-label={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
               style={{
                 background: isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
                 border: 'none',
@@ -487,19 +508,7 @@ export function StudentSummaryReader({
               onClick={() => setSearchOpen((v) => !v)}
               title="Buscar (Ctrl+F)"
               aria-label="Buscar"
-              style={{
-                background: searchOpen ? 'rgba(42,140,122,0.15)' : 'none',
-                border: 'none',
-                padding: 10,
-                cursor: 'pointer',
-                color: searchOpen ? '#2a8c7a' : '#b4d9d1',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 44,
-                minHeight: 44,
-                borderRadius: 6,
-              }}
+              style={{ ...toolbarBtnStyle, background: searchOpen ? 'rgba(42,140,122,0.15)' : 'none', color: searchOpen ? '#2a8c7a' : '#b4d9d1' }}
             >
               <SearchIcon size={16} />
             </button>
@@ -509,19 +518,7 @@ export function StudentSummaryReader({
               onClick={() => setShowTimer((prev) => !prev)}
               title="Temporizador de estudio"
               aria-label={showTimer ? 'Cerrar timer' : 'Abrir timer'}
-              style={{
-                background: showTimer ? 'rgba(42,140,122,0.15)' : 'none',
-                border: 'none',
-                padding: 10,
-                cursor: 'pointer',
-                color: showTimer ? '#2a8c7a' : '#b4d9d1',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 44,
-                minHeight: 44,
-                borderRadius: 6,
-              }}
+              style={{ ...toolbarBtnStyle, background: showTimer ? 'rgba(42,140,122,0.15)' : 'none', color: showTimer ? '#2a8c7a' : '#b4d9d1' }}
             >
               <Timer size={16} />
             </button>
@@ -538,19 +535,7 @@ export function StudentSummaryReader({
                 onClick={() => setShowSettings((prev) => !prev)}
                 title="Configuración de lectura"
                 aria-label={showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
-                style={{
-                  background: showSettings ? 'rgba(42,140,122,0.15)' : 'none',
-                  border: 'none',
-                  padding: 10,
-                  cursor: 'pointer',
-                  color: showSettings ? '#2a8c7a' : '#b4d9d1',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  minWidth: 44,
-                  minHeight: 44,
-                  borderRadius: 6,
-                }}
+                style={{ ...toolbarBtnStyle, background: showSettings ? 'rgba(42,140,122,0.15)' : 'none', color: showSettings ? '#2a8c7a' : '#b4d9d1' }}
               >
                 <Settings size={16} />
               </button>
@@ -571,19 +556,7 @@ export function StudentSummaryReader({
               onClick={() => setSidebarCollapsed((v) => !v)}
               title="Outline"
               aria-label={sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
-              style={{
-                background: !sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none',
-                border: 'none',
-                padding: 10,
-                cursor: 'pointer',
-                color: !sidebarCollapsed ? '#2a8c7a' : '#b4d9d1',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 44,
-                minHeight: 44,
-                borderRadius: 6,
-              }}
+              style={{ ...toolbarBtnStyle, background: !sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none', color: !sidebarCollapsed ? '#2a8c7a' : '#b4d9d1' }}
             >
               <PanelLeftOpen size={16} />
             </button>
@@ -596,6 +569,13 @@ export function StudentSummaryReader({
 
         {/* ── Main content area (white card) ── */}
         <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-b-[20px] border-2 border-t-0 border-zinc-200 dark:border-[#2d2e34] shadow-sm overflow-hidden">
+
+          {/* ── Reading mode fallback when no content_markdown ── */}
+          {viewMode === 'reading' && !summary?.content_markdown && (
+            <p style={{ color: '#888', textAlign: 'center', padding: '2rem' }}>
+              Este resumen no tiene contenido en formato texto. Cambiando a modo enriquecido...
+            </p>
+          )}
 
           {/* ── Reading mode: plain markdown ── */}
           {viewMode === 'reading' && summary.content_markdown && (

--- a/src/app/components/content/SummaryCard.tsx
+++ b/src/app/components/content/SummaryCard.tsx
@@ -115,7 +115,7 @@ export const SummaryCard = React.memo(function SummaryCard({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <h3 className="text-sm truncate" style={{ fontWeight: 700, color: axon.darkTeal }}>
-                {s.title || 'Sin titulo'}
+                {s.title || 'Sin título'}
               </h3>
               {isCompleted && (
                 <span
@@ -127,7 +127,7 @@ export const SummaryCard = React.memo(function SummaryCard({
                     borderColor: tint.successBorder,
                   }}
                 >
-                  <CheckCircle2 className="w-3 h-3" /> Leido
+                  <CheckCircle2 className="w-3 h-3" /> Leído
                 </span>
               )}
               {isInProgress && (

--- a/src/app/components/content/TopicSummariesView.tsx
+++ b/src/app/components/content/TopicSummariesView.tsx
@@ -328,7 +328,7 @@ export function TopicSummariesView() {
                       {isCompleted && (
                         <span className="flex items-center gap-1 text-emerald-600">
                           <Eye className="w-3 h-3" />
-                          Leido
+                          Leído
                         </span>
                       )}
 

--- a/src/app/components/professor/EditorSidebar.tsx
+++ b/src/app/components/professor/EditorSidebar.tsx
@@ -444,7 +444,7 @@ function TopicNode({
                     s.id === activeSummaryId ? 'text-teal-400' : 'text-zinc-500'
                   )} />
                   <span className="text-[10px] truncate">
-                    {s.title || 'Sin titulo'}
+                    {s.title || 'Sin título'}
                   </span>
                   <span className={clsx(
                     'text-[8px] px-1 py-0.5 rounded ml-auto shrink-0',

--- a/src/app/components/roles/pages/professor/TopicDetailPanel.tsx
+++ b/src/app/components/roles/pages/professor/TopicDetailPanel.tsx
@@ -304,7 +304,7 @@ export function TopicDetailPanel({ topicId, topicName, onEditSummary }: TopicDet
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 mb-1">
                             <h3 className="text-sm text-gray-900 truncate">
-                              {s.title || 'Sin titulo'}
+                              {s.title || 'Sin título'}
                             </h3>
                             {statusBadge(s.status, s.is_active)}
                           </div>

--- a/src/app/components/roles/pages/professor/summary-detail/SummaryDetailView.tsx
+++ b/src/app/components/roles/pages/professor/summary-detail/SummaryDetailView.tsx
@@ -164,13 +164,13 @@ export function SummaryDetailView({
             summaryId={summary.id} onBack={onBack} onStatusChange={handleStatusChange}
             onKeywordsClick={() => setShowKeywords(true)} onVideosClick={() => setShowVideos(true)}
             keywordsCount={activeKeywords.length} videosCount={videosCount}
-            summaryTitle={summary.title || 'Sin titulo'} summaryStatus={summary.status}
+            summaryTitle={summary.title || 'Sin título'} summaryStatus={summary.status}
           />
         </ErrorBoundary>
       ) : (
         <TipTapEditor
           summaryId={summary.id} contentMarkdown={summary.content_markdown}
-          summaryTitle={summary.title || 'Sin titulo'} summaryStatus={summary.status}
+          summaryTitle={summary.title || 'Sin título'} summaryStatus={summary.status}
           onBack={onBack} onStatusChange={handleStatusChange}
           onKeywordsClick={() => setShowKeywords(true)} onVideosClick={() => setShowVideos(true)}
           keywordsCount={activeKeywords.length} videosCount={videosCount}

--- a/src/app/components/student/ReaderHeader.tsx
+++ b/src/app/components/student/ReaderHeader.tsx
@@ -96,7 +96,7 @@ export function ReaderHeader({
         <span className="text-sm text-zinc-400">{topicName}</span>
         <ChevronRight className="w-3.5 h-3.5 text-zinc-400" />
         <span className="text-sm text-zinc-700 truncate max-w-[200px]" style={{ fontWeight: 600 }}>
-          {summary.title || 'Sin titulo'}
+          {summary.title || 'Sin título'}
         </span>
       </div>
 
@@ -120,7 +120,7 @@ export function ReaderHeader({
               </div>
               <div>
                 <h2 className="text-zinc-900 text-lg tracking-tight" style={{ fontWeight: 700 }}>
-                  {summary.title || 'Sin titulo'}
+                  {summary.title || 'Sin título'}
                 </h2>
                 <div className="flex items-center gap-3 mt-1.5 flex-wrap">
                   {isCompleted && (
@@ -157,9 +157,9 @@ export function ReaderHeader({
               {markingRead ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : isCompleted ? (
-                <><CheckCircle2 className="w-4 h-4" /> Marcar no leido</>
+                <><CheckCircle2 className="w-4 h-4" /> Marcar no leído</>
               ) : (
-                <><CheckCircle2 className="w-4 h-4" /> Marcar como leido</>
+                <><CheckCircle2 className="w-4 h-4" /> Marcar como leído</>
               )}
             </motion.button>
           </div>

--- a/src/app/components/student/StudentBlockReader.tsx
+++ b/src/app/components/student/StudentBlockReader.tsx
@@ -87,7 +87,9 @@ export function StudentBlockReader({ summary, topicName, onBack }: StudentBlockR
   // UI state
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth >= 1280 : false
+  );
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [showMastery, setShowMastery] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);

--- a/src/app/components/student/StudentBlockReader.tsx
+++ b/src/app/components/student/StudentBlockReader.tsx
@@ -87,9 +87,7 @@ export function StudentBlockReader({ summary, topicName, onBack }: StudentBlockR
   // UI state
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sidebarOpen, setSidebarOpen] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches,
-  );
+  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [showMastery, setShowMastery] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -180,7 +178,7 @@ export function StudentBlockReader({ summary, topicName, onBack }: StudentBlockR
   return (
     <div className="fixed inset-0 z-40 flex flex-col" style={{ background: pageBg }}>
       {/* ── Reading progress bar ─────────────────────────────── */}
-      <ReadingProgress containerRef={contentRef} />
+      <ReadingProgress />
 
       {/* ── Sticky compact header ────────────────────────────── */}
       <header
@@ -489,19 +487,17 @@ function ToolbarSeparator() {
 
 // ── Reading progress bar ─────────────────────────────────────
 
-function ReadingProgress({ containerRef }: { containerRef: React.RefObject<HTMLDivElement | null> }) {
+function ReadingProgress() {
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
     const handleScroll = () => {
-      const scrollable = el.scrollHeight - el.clientHeight;
-      setProgress(scrollable > 0 ? (el.scrollTop / scrollable) * 100 : 0);
+      const winH = document.documentElement.scrollHeight - window.innerHeight;
+      setProgress(winH > 0 ? (window.scrollY / winH) * 100 : 0);
     };
-    el.addEventListener('scroll', handleScroll, { passive: true });
-    return () => el.removeEventListener('scroll', handleScroll);
-  }, [containerRef]);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
     <div

--- a/src/app/components/student/TopicSessionGrid.tsx
+++ b/src/app/components/student/TopicSessionGrid.tsx
@@ -160,7 +160,7 @@ function SessionBlock({
                   className="text-[9px] px-1.5 py-0.5 rounded-full border"
                   style={{ color: tint.successText, backgroundColor: tint.successBg, borderColor: tint.successBorder, fontWeight: 600 }}
                 >
-                  Leido
+                  Leído
                 </span>
               )}
               {isInProgress && (
@@ -174,7 +174,7 @@ function SessionBlock({
             </div>
 
             <h3 className="text-sm mb-1 line-clamp-2" style={{ color: '#18181b', fontWeight: 700 }}>
-              {summary.title || 'Sin titulo'}
+              {summary.title || 'Sin título'}
             </h3>
             {preview && (
               <p className="text-[11px] line-clamp-2" style={{ color: tint.subtitleText }}>

--- a/src/app/components/summary/SummaryHeader.tsx
+++ b/src/app/components/summary/SummaryHeader.tsx
@@ -76,7 +76,7 @@ export function SummaryHeader({
         <ChevronRight size={14} className="text-gray-300 shrink-0" />
         <span className="truncate max-w-[150px]">{breadcrumb.topicName}</span>
         <ChevronRight size={14} className="text-gray-300 shrink-0" />
-        <span className="text-gray-600 truncate max-w-[200px]">{summary.title || 'Sin titulo'}</span>
+        <span className="text-gray-600 truncate max-w-[200px]">{summary.title || 'Sin título'}</span>
       </div>
 
       {/* Header card */}
@@ -96,7 +96,7 @@ export function SummaryHeader({
               )}
             </div>
             <div className="min-w-0">
-              <h2 className="text-gray-900 truncate">{summary.title || 'Sin titulo'}</h2>
+              <h2 className="text-gray-900 truncate">{summary.title || 'Sin título'}</h2>
               <div className="flex items-center gap-2 mt-1 flex-wrap">
                 <span className={clsx(
                   "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] border",
@@ -106,7 +106,7 @@ export function SummaryHeader({
                 </span>
                 {isCompleted && (
                   <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] bg-emerald-50 text-emerald-700 border border-emerald-200">
-                    <CheckCircle2 size={10} /> Leido
+                    <CheckCircle2 size={10} /> Leído
                   </span>
                 )}
                 <span className="text-[10px] text-gray-300">

--- a/src/app/hooks/queries/useSummaryReaderMutations.ts
+++ b/src/app/hooks/queries/useSummaryReaderMutations.ts
@@ -127,7 +127,7 @@ export function useSummaryReaderMutations({
       onReadingStateChanged(rs);
       setShowXpToast(true);
       setTimeout(() => setShowXpToast(false), 3000);
-      toast.success('Resumen marcado como leido');
+      toast.success('Resumen marcado como leído');
       rqClient.invalidateQueries({ queryKey: queryKeys.topicProgress(topicId) });
       markSessionComplete('reading');
       // Close the study session so it appears in history with XP
@@ -140,7 +140,7 @@ export function useSummaryReaderMutations({
         }).catch(() => {});
       }
     },
-    onError: (err: any) => toast.error(err.message || 'Error al marcar como leido'),
+    onError: (err: any) => toast.error(err.message || 'Error al marcar como leído'),
   });
 
   // ── 2. Unmark completed ─────────────────────────────
@@ -148,7 +148,7 @@ export function useSummaryReaderMutations({
     mutationFn: () => studentApi.upsertReadingState({ summary_id: summaryId, completed: false }),
     onSuccess: (rs) => {
       onReadingStateChanged(rs);
-      toast.success('Marcado como no leido');
+      toast.success('Marcado como no leído');
       rqClient.invalidateQueries({ queryKey: queryKeys.topicProgress(topicId) });
     },
     onError: (err: any) => toast.error(err.message || 'Error al actualizar'),


### PR DESCRIPTION
## Summary
Restores the unified reader layout from `fix/sidebar-overlay` branch that was never merged to main.

### What changed
- **Header compacto**: Inline toolbar with AXON brand + search/timer/theme/settings/sidebar toggle (replaces extracted ReaderToolbar)
- **View mode toggle**: Lectura limpia / Enriquecido — toggle in sidebar
- **Content direct render**: Based on viewMode, no "Contenido" tab needed
- **Tabs below content**: Keywords, Videos, Notas moved under content area
- **Sidebar overlay**: Opens without pushing/shifting content
- **Mark as read**: Compact icon button in header

### Files changed
- `StudentSummaryReader.tsx` — main layout restructure
- `StudentBlockReader.tsx` — viewMode support

## Test plan
- [ ] Verify header shows AXON + tool icons in one compact bar
- [ ] Toggle Lectura/Enriquecido in sidebar — content switches
- [ ] Sidebar opens as overlay, content doesn't shift
- [ ] Tabs (Keywords, Videos, Notas) appear below content
- [ ] Dark mode works correctly
- [ ] Mobile responsive