### PR TITLE
feat: Calendar v2 route integration (AXO-118)

### DIFF
--- a/src/app/components/calendar/CalendarPage.tsx
+++ b/src/app/components/calendar/CalendarPage.tsx
@@ -1,0 +1,42 @@
+// ============================================================
+// Axon — CalendarPage
+//
+// Page wrapper for Calendar v2. Renders CountdownWidget (when
+// upcoming exams exist) above CalendarView. Lazy-loaded via
+// calendar-student-routes.ts.
+// ============================================================
+
+import React, { Suspense, useMemo } from 'react';
+import { startOfMonth, endOfMonth, addMonths } from 'date-fns';
+import { ErrorBoundary } from '@/app/components/shared/ErrorBoundary';
+import { CalendarView } from './CalendarView';
+import { CountdownWidget } from './CountdownWidget';
+import { CalendarSkeleton } from './CalendarSkeleton';
+import { useCalendarEvents } from '@/app/hooks/useCalendarEvents';
+
+export function CalendarPage() {
+  // Fetch a 3-month window for the countdown widget
+  const now = useMemo(() => new Date(), []);
+  const from = useMemo(() => startOfMonth(now), [now]);
+  const to = useMemo(() => endOfMonth(addMonths(now, 2)), [now]);
+
+  const { events } = useCalendarEvents({ from, to });
+
+  // Show countdown only if there are upcoming exam events
+  const hasUpcomingExams = events.some(
+    e => e.is_final && new Date(e.date) >= now,
+  );
+
+  return (
+    <ErrorBoundary>
+      <div className="p-4 lg:p-6 space-y-4 max-w-5xl mx-auto">
+        {hasUpcomingExams && (
+          <CountdownWidget events={events} />
+        )}
+        <Suspense fallback={<CalendarSkeleton />}>
+          <CalendarView />
+        </Suspense>
+      </div>
+    </ErrorBoundary>
+  );
+}

--- a/src/app/components/layout/Sidebar.tsx
+++ b/src/app/components/layout/Sidebar.tsx
@@ -17,15 +17,16 @@ import { useNavigation } from '@/app/context/NavigationContext';
 import { viewToPath, type ViewType } from '@/app/hooks/useStudentNav';
 import { components } from '@/app/design-system';
 import { motion } from 'motion/react';
-import { 
-  LayoutDashboard, 
-  BookOpen, 
-  Layers, 
-  Box, 
-  GraduationCap, 
-  Settings, 
+import {
+  LayoutDashboard,
+  BookOpen,
+  Layers,
+  Box,
+  GraduationCap,
+  Settings,
   Users,
   Calendar,
+  CalendarDays,
   Home,
   Database,
   Flame,
@@ -53,6 +54,7 @@ export function Sidebar() {
     { id: 'flashcards', label: 'Flashcards', icon: Layers },
     { id: '3d', label: 'Atlas 3D', icon: Box },
     { id: 'quiz', label: 'Quiz', icon: GraduationCap },
+    { id: 'calendario', label: 'Calendario', icon: CalendarDays },
     { id: 'student-data', label: 'Mis Datos', icon: Database },
   ];
 

--- a/src/app/hooks/useStudentNav.ts
+++ b/src/app/hooks/useStudentNav.ts
@@ -33,6 +33,7 @@ export type ViewType =
   | 'mastery-dashboard'
   | 'student-data'
   | 'gamification'
+  | 'calendario'
   | 'settings';
 
 // ── Mapping helpers ──────────────────────────────────────────

--- a/src/app/routes/calendar-student-routes.ts
+++ b/src/app/routes/calendar-student-routes.ts
@@ -1,0 +1,14 @@
+// ============================================================
+// Axon — Calendar Student Routes
+//
+// Route: /student/calendario → CalendarPage (lazy-loaded)
+// ============================================================
+import type { RouteObject } from 'react-router';
+import { lazyRetry } from '@/app/utils/lazyRetry';
+
+export const calendarStudentRoutes: RouteObject[] = [
+  {
+    path: 'calendario',
+    lazy: () => lazyRetry(() => import('@/app/components/calendar/CalendarPage')).then(m => ({ Component: m.CalendarPage })),
+  },
+];

--- a/src/app/routes/student-routes.ts
+++ b/src/app/routes/student-routes.ts
@@ -19,6 +19,7 @@ import { summaryStudentRoutes } from './summary-student-routes';
 import { flashcardStudentRoutes } from './flashcard-student-routes';
 import { studyStudentRoutes } from './study-student-routes';
 import { threeDStudentRoutes } from './threed-student-routes';
+import { calendarStudentRoutes } from './calendar-student-routes';
 
 export const studentChildren: RouteObject[] = [
   ...studyStudentRoutes,       // Agent 5 (includes index route)
@@ -26,6 +27,7 @@ export const studentChildren: RouteObject[] = [
   ...summaryStudentRoutes,     // Agent 2
   ...flashcardStudentRoutes,   // Agent 3
   ...threeDStudentRoutes,      // Agent 6
+  ...calendarStudentRoutes,    // Calendar v2
   // Catch-all — keep last
   {
     path: '*',


### PR DESCRIPTION
## Summary
- Created `CalendarPage.tsx` — page wrapper rendering `CountdownWidget` (for upcoming finals) + `CalendarView`
- Added `calendar-student-routes.ts` with route path `/student/calendario`
- Wired `calendarStudentRoutes` into `student-routes.ts`
- Added `calendario` ViewType to `useStudentNav.ts`
- Added "Calendario" nav item with `CalendarDays` icon to `Sidebar.tsx`

## Test plan
- [ ] Navigate to `/student/calendario` — CalendarView renders
- [ ] "Calendario" link visible in student sidebar with CalendarDays icon
- [ ] CountdownWidget appears when upcoming final exams exist
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)