### PR TITLE
fix: audit AI generation bugs (AXO-125)

### DIFF
--- a/src/app/components/content/useFlashcardsManager.ts
+++ b/src/app/components/content/useFlashcardsManager.ts
@@ -5,7 +5,7 @@
 // computed values from FlashcardsManager into a reusable hook.
 // ============================================================
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { apiCall, ensureGeneralKeyword } from '@/app/lib/api';
+import { apiCall } from '@/app/lib/api';
 import * as flashcardApi from '@/app/services/flashcardApi';
 import type { FlashcardItem } from '@/app/services/flashcardApi';
 import type { Keyword } from '@/app/types/platform';


### PR DESCRIPTION
## Summary
- Audited 4 reported AI generation bugs from AXO-119
- **P0 handleRateLimitError**: Already fixed — function returns `never`, re-throws all non-429 errors correctly (`as-types.ts:220-229`)
- **P0 ensureGeneralKeyword .id**: Already fixed — all callers (`FlashcardFormModal`, `useQuestionForm`, `CaptureViewDialog`) use the returned string directly, none call `.id`
- **P1 SmartFlashcardGenerator error classification**: N/A — component removed in v4.4.6
- **P2 aiFlashcardGenerator dead imports**: Already clean — no remaining imports found
- Removed unused `ensureGeneralKeyword` import from `useFlashcardsManager.ts`

## Test plan
- [x] `npm run build` passes clean
- [ ] Verify flashcard creation still works (FlashcardFormModal)
- [ ] Verify quiz question creation still works (useQuestionForm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)