### PR TITLE
fix: remove last backdrop-blur from BlockQuizModal

### DIFF
--- a/src/app/components/student/BlockQuizModal.tsx
+++ b/src/app/components/student/BlockQuizModal.tsx
@@ -20,7 +20,7 @@ import type { QuizQuestion as DbQuizQuestion } from '@/app/services/quizQuestion
 // ── Design tokens (inlined from design system) ──────────────
 
 const MODAL_OVERLAY =
-  'fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm';
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
 
 const MODAL_CARD =
   'bg-white rounded-2xl shadow-2xl border border-gray-200';


### PR DESCRIPTION
Rebased version of PR #377. After rebase, 42 of 43 glassmorphism removals were already in main. Only 1 remaining change: remove backdrop-blur-sm from BlockQuizModal overlay.\n\nBuild: passing