### PR TITLE
fix: AI assistant gets summaryId from FlashcardView (AXO-131)

### DIFF
--- a/src/app/components/content/FlashcardView.tsx
+++ b/src/app/components/content/FlashcardView.tsx
@@ -14,6 +14,7 @@ import { useFlashcardEngine } from '@/app/hooks/useFlashcardEngine';
 import { useAuth } from '@/app/context/AuthContext';
 import { useContentTree } from '@/app/context/ContentTreeContext';
 import { useFlashcardCoverage } from '@/app/hooks/useFlashcardCoverage';
+import { useUI } from '@/app/context/UIContext';
 import { ErrorBoundary } from '@/app/components/shared/ErrorBoundary';
 
 import { HubScreen, SectionScreen, DeckScreen, SessionScreen, SummaryScreen } from './flashcard';
@@ -86,6 +87,13 @@ export function FlashcardView() {
   const [fetchedSummaryId, setFetchedSummaryId] = useState<string>('');
   const cardSummaryId = nav.selectedTopic?.flashcards?.[0]?.summary_id || '';
   const currentSummaryId = cardSummaryId || fetchedSummaryId;
+
+  // Lift summaryId to layout so AI assistant can use it (AXO-131)
+  const { setActiveSummaryId } = useUI();
+  useEffect(() => {
+    setActiveSummaryId(currentSummaryId || undefined);
+    return () => setActiveSummaryId(undefined);
+  }, [currentSummaryId, setActiveSummaryId]);
 
   useEffect(() => {
     const topicId = nav.selectedTopic?.id;

--- a/src/app/components/layout/StudentLayout.tsx
+++ b/src/app/components/layout/StudentLayout.tsx
@@ -46,11 +46,13 @@ const AxonAIAssistant = React.lazy(() =>
 // -- Inner shell (needs AppContext available) ------------------
 
 function StudentShell() {
-  const { isSidebarOpen, setSidebarOpen } = useUI();
+  const { isSidebarOpen, setSidebarOpen, activeSummaryId } = useUI();
   const { isStudySessionActive } = useStudySession();
   const { navigateTo, isView } = useStudentNav();
   const location = useLocation();
-  const { summaryId } = useParams<{ summaryId?: string }>();
+  const { summaryId: urlSummaryId } = useParams<{ summaryId?: string }>();
+  // Prefer URL param; fall back to summary ID lifted from child views (AXO-131)
+  const summaryId = urlSummaryId || activeSummaryId;
   const isMobile = useIsMobile();
 
   const showTopicSidebar = isView('study-hub', 'study', 'summaries', 'flashcards') && !isStudySessionActive;
@@ -206,7 +208,7 @@ function StudentShell() {
 
       {/* ── AI Assistant Floating Action Button ── */}
       <AnimatePresence>
-        {!isStudySessionActive && !summaryId && (
+        {!isStudySessionActive && !urlSummaryId && (
           <motion.button
             key="ai-fab"
             initial={{ scale: 0, opacity: 0 }}

--- a/src/app/context/UIContext.tsx
+++ b/src/app/context/UIContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useMemo, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo, type ReactNode } from 'react';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -9,6 +9,9 @@ interface UIContextType {
   setSidebarOpen: (isOpen: boolean) => void;
   theme: ThemeType;
   setTheme: (theme: ThemeType) => void;
+  /** Summary ID lifted from child views (e.g. FlashcardView) for AI assistant */
+  activeSummaryId: string | undefined;
+  setActiveSummaryId: (id: string | undefined) => void;
 }
 
 const noop = () => {};
@@ -18,6 +21,8 @@ const defaultValue: UIContextType = {
   setSidebarOpen: noop,
   theme: 'light',
   setTheme: noop,
+  activeSummaryId: undefined,
+  setActiveSummaryId: noop,
 };
 
 const UIContext = createContext<UIContextType>(defaultValue);
@@ -27,13 +32,20 @@ const UIContext = createContext<UIContextType>(defaultValue);
 export function UIProvider({ children }: { children: ReactNode }) {
   const [isSidebarOpen, setSidebarOpen] = useState(true);
   const [theme, setTheme] = useState<ThemeType>('light');
+  const [activeSummaryId, setActiveSummaryIdRaw] = useState<string | undefined>(undefined);
+
+  const setActiveSummaryId = useCallback((id: string | undefined) => {
+    setActiveSummaryIdRaw(prev => prev === id ? prev : id);
+  }, []);
 
   const value = useMemo<UIContextType>(() => ({
     isSidebarOpen,
     setSidebarOpen,
     theme,
     setTheme,
-  }), [isSidebarOpen, theme]);
+    activeSummaryId,
+    setActiveSummaryId,
+  }), [isSidebarOpen, theme, activeSummaryId, setActiveSummaryId]);
 
   return (
     <UIContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- **Problem**: `AxonAIAssistant` only received `summaryId` from URL params. The `/student/flashcards` route has no `:summaryId` param, so the AI assistant was disabled there — flashcard/quiz generation buttons showed "Navega a un resumen" even though FlashcardView knows the summaryId internally.
- **Fix**: Added `activeSummaryId` / `setActiveSummaryId` to `UIContext`. FlashcardView lifts its resolved summaryId into the context. StudentLayout reads it as a fallback when URL params don't have summaryId.
- FAB visibility remains tied to URL params so it correctly hides on summary pages but stays visible on flashcard pages.

## Files changed
- `src/app/context/UIContext.tsx` — added `activeSummaryId` state
- `src/app/components/content/FlashcardView.tsx` — syncs `currentSummaryId` to UIContext
- `src/app/components/layout/StudentLayout.tsx` — uses `activeSummaryId` as fallback for AI assistant

## Test plan
- [ ] Navigate to `/student/flashcards`, select a topic with flashcards
- [ ] Click the AI FAB (sparkles button) → AI panel opens
- [ ] Switch to "Flashcards" tab → generate button should be enabled (not showing "Navega a un resumen")
- [ ] Navigate away from flashcards → `activeSummaryId` clears (cleanup effect)
- [ ] Navigate to a summary page → FAB hides as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)