### PR TITLE
fix: resolve keyword placeholders in ListDetailBlock intro and ViewerBlock

### DIFF
--- a/src/app/components/student/ViewerBlock.tsx
+++ b/src/app/components/student/ViewerBlock.tsx
@@ -18,6 +18,7 @@ import clsx from 'clsx';
 import type { SummaryBlock, SummaryKeyword } from '@/app/services/summariesApi';
 import type { TextAnnotation } from '@/app/services/studentSummariesApi';
 import { sanitizeHtml } from '@/app/lib/sanitize';
+import { replaceKeywordPlaceholders } from './blocks/renderTextWithKeywords';
 import {
   ProseBlock, KeyPointBlock, StagesBlock, ComparisonBlock,
   ListDetailBlock, GridBlock, TwoColumnBlock, CalloutBlock as EduCalloutBlock,
@@ -344,7 +345,7 @@ export const ViewerBlock = React.memo(function ViewerBlock({
       return (
         <div
           className="axon-prose max-w-none"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(html, keywords)) }}
           role="article"
         />
       );
@@ -528,10 +529,10 @@ export const ViewerBlock = React.memo(function ViewerBlock({
             {/<[a-z][\s\S]*>/i.test(text) ? (
               <div
                 className="text-sm text-gray-700 leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0"
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(text) }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(text, keywords)) }}
               />
             ) : (
-              <p className="text-sm text-gray-700 leading-relaxed">{text}</p>
+              <p className="text-sm text-gray-700 leading-relaxed">{replaceKeywordPlaceholders(text, keywords)}</p>
             )}
           </div>
         </div>

--- a/src/app/components/student/blocks/ListDetailBlock.tsx
+++ b/src/app/components/student/blocks/ListDetailBlock.tsx
@@ -41,9 +41,9 @@ export default function ListDetailBlock({ block, keywords }: { block: SummaryBlo
         </h3>
       )}
       {intro && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-3 leading-[1.6]">
-          {intro}
-        </p>
+        <div className="text-sm text-gray-500 dark:text-gray-400 mb-3 leading-[1.6]">
+          {renderTextWithKeywords(intro, keywords)}
+        </div>
       )}
       <div className="flex flex-col gap-2">
         {items.map((item, i) => (


### PR DESCRIPTION
## Summary

- **ListDetailBlock.tsx**: El campo `intro` se renderizaba como texto plano sin llamar `renderTextWithKeywords()`, causando que UUIDs como `{{5e803834-...}}` ("Angina de Pecho") aparezcan crudos en vez de como KeywordChip
- **ViewerBlock.tsx**: Los bloques tipo `text` y `callout` legacy usaban `dangerouslySetInnerHTML` sin resolver placeholders de keywords — ahora usan `replaceKeywordPlaceholders()`

## Root cause

El resumen "Semiología del Dolor Isquémico Cardíaco" tiene un bloque `list_detail` (order_index 3) cuyo campo `intro` contiene `{{5e803834-235d-4cdf-9dda-8adc8df084d7}}`. La keyword existe en la DB (name: "Angina de Pecho", is_active: true), pero `ListDetailBlock` nunca llamaba `renderTextWithKeywords()` sobre el `intro`.

## Test plan

- [x] 30/30 tests de `renderTextWithKeywords.test.tsx` pasan
- [x] Build exitoso sin errores
- [ ] Verificar visualmente que el resumen de Semiología muestra "Angina de Pecho" como chip en el intro del bloque list_detail

https://claude.ai/code/session_01U9ZKiyZ23hMYpNb1e78Ypa