### PR TITLE
feat: BlockQuizModal sends results for per-block mastery

### DIFF
--- a/src/app/components/student/BlockQuizModal.tsx
+++ b/src/app/components/student/BlockQuizModal.tsx
@@ -258,6 +258,7 @@ export function BlockQuizModal({
     if (isLastQuestion) {
       // Submit all results for block mastery BKT update before closing
       submitBlockReview(blockId, summaryId, reviewResults);
+      setReviewResults([]);
       onClose();
       return;
     }
@@ -268,9 +269,9 @@ export function BlockQuizModal({
 
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) onClose();
+      if (e.target === e.currentTarget) handleClose();
     },
-    [onClose],
+    [handleClose],
   );
 
   // Reset state when modal reopens

--- a/src/app/components/student/BlockQuizModal.tsx
+++ b/src/app/components/student/BlockQuizModal.tsx
@@ -124,6 +124,30 @@ async function recordAttempt(
   }
 }
 
+// ── Types for block review submission ────────────────────
+interface BlockReviewResult {
+  question_id: string | null;
+  is_correct: boolean;
+  time_taken_ms: number;
+}
+
+/** Submit block quiz results to update per-block BKT mastery */
+async function submitBlockReview(
+  blockId: string,
+  summaryId: string,
+  results: BlockReviewResult[],
+) {
+  if (results.length === 0) return;
+  try {
+    await apiCall('/block-review', {
+      method: 'POST',
+      body: JSON.stringify({ block_id: blockId, summary_id: summaryId, results }),
+    });
+  } catch {
+    console.warn('[BlockQuizModal] Failed to submit block review for mastery update');
+  }
+}
+
 // ── Component ────────────────────────────────────────────
 
 export function BlockQuizModal({
@@ -140,6 +164,7 @@ export function BlockQuizModal({
   const [fetchedFor, setFetchedFor] = useState<string | null>(null);
   const [questionStartTime, setQuestionStartTime] = useState<number>(Date.now());
   const [score, setScore] = useState({ correct: 0, total: 0 });
+  const [reviewResults, setReviewResults] = useState<BlockReviewResult[]>([]);
 
   // Fetch quiz: DB first (pre-generated), then AI fallback
   useEffect(() => {
@@ -204,14 +229,22 @@ export function BlockQuizModal({
     setAnswered(true);
 
     const correct = selected === question.correctIndex;
+    const timeTaken = Date.now() - questionStartTime;
+
     setScore((prev) => ({
       correct: prev.correct + (correct ? 1 : 0),
       total: prev.total + 1,
     }));
 
-    // Track attempt if question has a DB id
+    // Accumulate result for block mastery BKT update
+    setReviewResults((prev) => [...prev, {
+      question_id: question.id,
+      is_correct: correct,
+      time_taken_ms: timeTaken,
+    }]);
+
+    // Track attempt if question has a DB id (analytics)
     if (question.id) {
-      const timeTaken = Date.now() - questionStartTime;
       recordAttempt(
         question.id,
         question.options[selected],
@@ -223,13 +256,15 @@ export function BlockQuizModal({
 
   const handleNext = useCallback(() => {
     if (isLastQuestion) {
+      // Submit all results for block mastery BKT update before closing
+      submitBlockReview(blockId, summaryId, reviewResults);
       onClose();
       return;
     }
     setCurrentIndex((prev) => prev + 1);
     setSelected(null);
     setAnswered(false);
-  }, [isLastQuestion, onClose]);
+  }, [isLastQuestion, onClose, blockId, summaryId, reviewResults]);
 
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
@@ -240,13 +275,18 @@ export function BlockQuizModal({
 
   // Reset state when modal reopens
   const handleClose = useCallback(() => {
+    // Submit any accumulated results before closing (e.g., user closes mid-quiz)
+    if (reviewResults.length > 0) {
+      submitBlockReview(blockId, summaryId, reviewResults);
+    }
     setCurrentIndex(0);
     setSelected(null);
     setAnswered(false);
     setFetchedFor(null);
     setScore({ correct: 0, total: 0 });
+    setReviewResults([]);
     onClose();
-  }, [onClose]);
+  }, [onClose, blockId, summaryId, reviewResults]);
 
   if (!isOpen) return null;
 

--- a/src/app/components/student/SummaryViewer.tsx
+++ b/src/app/components/student/SummaryViewer.tsx
@@ -12,6 +12,7 @@
 // Interactions: image→lightbox, video→play, pdf→view, keyword→popup
 // ============================================================
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { Layers, Bookmark } from 'lucide-react';
 import { Skeleton } from '@/app/components/ui/skeleton';
@@ -77,8 +78,14 @@ export function SummaryViewer({ summaryId, blocks: prefetchedBlocks, onKeywordCl
     setAnnotationsOpen(prev => ({ ...prev, [blockId]: !prev[blockId] }));
   }, []);
 
-  // ── Quiz modal state ──────────────────────────────────
+  // ── Quiz modal state ──────────���───────────────────────
   const [quizBlockId, setQuizBlockId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const handleQuizClose = useCallback(() => {
+    setQuizBlockId(null);
+    // Invalidate block mastery cache so updated colors are fetched
+    queryClient.invalidateQueries({ queryKey: ['summary-block-mastery', summaryId] });
+  }, [summaryId, queryClient]);
 
   // ── Detect mobile ───────────────────────────────────────
   useEffect(() => {
@@ -284,7 +291,7 @@ export function SummaryViewer({ summaryId, blocks: prefetchedBlocks, onKeywordCl
         blockId={quizBlockId || ''}
         summaryId={summaryId}
         isOpen={!!quizBlockId}
-        onClose={() => setQuizBlockId(null)}
+        onClose={handleQuizClose}
       />
 
       {/* ── Bookmarks toggle + panel ──────────────────── */}

--- a/src/app/components/student/SummaryViewer.tsx
+++ b/src/app/components/student/SummaryViewer.tsx
@@ -78,7 +78,7 @@ export function SummaryViewer({ summaryId, blocks: prefetchedBlocks, onKeywordCl
     setAnnotationsOpen(prev => ({ ...prev, [blockId]: !prev[blockId] }));
   }, []);
 
-  // ── Quiz modal state ──────────���───────────────────────
+  // ── Quiz modal state ──────────────────────────────────
   const [quizBlockId, setQuizBlockId] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const handleQuizClose = useCallback(() => {


### PR DESCRIPTION
## Summary\n- BlockQuizModal accumulates per-question results and submits to POST /block-review on quiz completion\n- SummaryViewer invalidates block mastery query cache on quiz close so colors refresh\n- Audit fixes: overlay click routes through handleClose, reviewResults cleared after submit\n\n## Test plan\n- [ ] Open summary → click Brain on block → complete quiz → verify block color updates\n- [ ] Close quiz mid-way (X button or overlay) → verify partial results are submitted\n- [ ] Reopen quiz on same block → verify no stale data\n\nhttps://claude.ai/code/session_01VWcDMsDJhZTGum68zS1LqH