### PR TITLE
feat: per-block quiz practice in QuizSelection

### DIFF
--- a/src/app/components/content/quiz-selection/QuizRightPanel.tsx
+++ b/src/app/components/content/quiz-selection/QuizRightPanel.tsx
@@ -37,6 +37,8 @@ interface QuizRightPanelProps {
   onSelectSummary: (summary: Summary) => void;
   onStartQuiz: (quiz: QuizEntity) => void;
   onPracticeAll: (summary: Summary) => void;
+  summaryBlocks: { id: string; title: string; type: string }[];
+  onBlockPractice: (blockId: string, blockTitle: string) => void;
 }
 
 export function QuizRightPanel({
@@ -45,6 +47,7 @@ export function QuizRightPanel({
   activeCourse, activeSemester, topicSummaries, loadingTopics,
   quizHistory, showHistory, onFilterDifficulty, onFilterType, onMaxQuestions,
   onToggleHistory, onSelectSummary, onStartQuiz, onPracticeAll,
+  summaryBlocks, onBlockPractice,
 }: QuizRightPanelProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-zinc-50">
@@ -178,26 +181,55 @@ export function QuizRightPanel({
 
                   {loosePracticeCount > 0 && (
                     <div className="mt-3 pt-3 border-t border-zinc-100">
-                      <button
-                        onClick={() => onPracticeAll(selectedSummary)}
-                        disabled={loadingQuizId === 'practice-all'}
-                        className="w-full flex items-center gap-3 p-4 rounded-2xl border border-dashed border-zinc-300 hover:border-teal-300 hover:bg-teal-50/20 transition-all text-left group bg-white"
-                      >
-                        <div className="w-10 h-10 rounded-xl bg-zinc-100 flex items-center justify-center shrink-0 group-hover:bg-teal-500 transition-colors">
-                          {loadingQuizId === 'practice-all' ? (
-                            <Loader2 size={18} className="animate-spin text-zinc-500" />
-                          ) : (
-                            <Play size={18} className="text-zinc-500 group-hover:text-white transition-colors" />
-                          )}
+                      <p className="text-[10px] uppercase tracking-wider text-zinc-400 mb-2" style={{ fontWeight: 700 }}>
+                        Practica por bloque ({summaryBlocks.length})
+                      </p>
+                      {summaryBlocks.length > 0 ? (
+                        <div className="space-y-2">
+                          {summaryBlocks.map(block => (
+                            <button
+                              key={block.id}
+                              onClick={() => onBlockPractice(block.id, block.title)}
+                              disabled={loadingQuizId === `block-${block.id}`}
+                              className="w-full flex items-center gap-3 p-3 rounded-xl border border-zinc-200 hover:border-teal-300 hover:bg-teal-50/30 transition-all text-left group bg-white"
+                            >
+                              <div className="w-8 h-8 rounded-lg bg-zinc-100 flex items-center justify-center shrink-0 group-hover:bg-teal-500 transition-colors">
+                                {loadingQuizId === `block-${block.id}` ? (
+                                  <Loader2 size={14} className="animate-spin text-zinc-500" />
+                                ) : (
+                                  <Play size={14} className="text-zinc-500 group-hover:text-white transition-colors" />
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-[13px] text-zinc-700 truncate" style={{ fontWeight: 600 }}>{block.title}</p>
+                                <p className="text-[10px] text-zinc-400 capitalize">{block.type.replace(/_/g, ' ')}</p>
+                              </div>
+                              <ChevronRight size={14} className="text-zinc-300 shrink-0 group-hover:text-teal-500" />
+                            </button>
+                          ))}
                         </div>
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm text-zinc-700" style={{ fontWeight: 600 }}>Practica libre</p>
-                          <p className="text-[11px] text-zinc-400">
-                            {loosePracticeCount} pregunta{loosePracticeCount !== 1 ? 's' : ''} disponible{loosePracticeCount !== 1 ? 's' : ''} en este resumen
-                          </p>
-                        </div>
-                        <ChevronRight size={16} className="text-zinc-300 shrink-0" />
-                      </button>
+                      ) : (
+                        <button
+                          onClick={() => onPracticeAll(selectedSummary)}
+                          disabled={loadingQuizId === 'practice-all'}
+                          className="w-full flex items-center gap-3 p-4 rounded-2xl border border-dashed border-zinc-300 hover:border-teal-300 hover:bg-teal-50/20 transition-all text-left group bg-white"
+                        >
+                          <div className="w-10 h-10 rounded-xl bg-zinc-100 flex items-center justify-center shrink-0 group-hover:bg-teal-500 transition-colors">
+                            {loadingQuizId === 'practice-all' ? (
+                              <Loader2 size={18} className="animate-spin text-zinc-500" />
+                            ) : (
+                              <Play size={18} className="text-zinc-500 group-hover:text-white transition-colors" />
+                            )}
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm text-zinc-700" style={{ fontWeight: 600 }}>Practica libre</p>
+                            <p className="text-[11px] text-zinc-400">
+                              {loosePracticeCount} pregunta{loosePracticeCount !== 1 ? 's' : ''} disponible{loosePracticeCount !== 1 ? 's' : ''} en este resumen
+                            </p>
+                          </div>
+                          <ChevronRight size={16} className="text-zinc-300 shrink-0" />
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/app/components/content/quiz-selection/QuizSelection.tsx
+++ b/src/app/components/content/quiz-selection/QuizSelection.tsx
@@ -13,7 +13,7 @@ import { motion } from 'motion/react';
 import { GraduationCap } from 'lucide-react';
 import { EmptyState } from '@/app/components/shared/EmptyState';
 import { SkeletonCard } from '@/app/components/shared/SkeletonCard';
-import { loadSummariesForTopicFn, loadQuizzesForSummary, loadQuizQuestions, loadPracticeQuestions } from './quiz-data-loading';
+import { loadSummariesForTopicFn, loadQuizzesForSummary, loadQuizQuestions, loadPracticeQuestions, loadBlocksForSummary, loadBlockPracticeQuestions } from './quiz-data-loading';
 import { QuizSidebar } from './QuizSidebar';
 import { QuizRightPanel } from './QuizRightPanel';
 
@@ -34,6 +34,7 @@ export function QuizSelection({ onStart, onBack }: QuizSelectionProps) {
   const [quizzesLoading, setQuizzesLoading] = useState(false);
   const [loadingQuizId, setLoadingQuizId] = useState<string | null>(null);
   const [loosePracticeCount, setLoosePracticeCount] = useState(0);
+  const [summaryBlocks, setSummaryBlocks] = useState<{ id: string; title: string; type: string }[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [filterDifficulty, setFilterDifficulty] = useState<Difficulty | ''>('');
   const [filterType, setFilterType] = useState<QuestionType | ''>('');
@@ -118,6 +119,8 @@ export function QuizSelection({ onStart, onBack }: QuizSelectionProps) {
     setLoosePracticeCount(result.practiceCount);
     setLoadError(result.error);
     setQuizzesLoading(false);
+    // Load blocks for per-block quiz
+    loadBlocksForSummary(summary.id).then(setSummaryBlocks);
   }, []);
 
   const handleStartQuizEntity = useCallback(async (quiz: QuizEntity) => {
@@ -147,6 +150,21 @@ export function QuizSelection({ onStart, onBack }: QuizSelectionProps) {
       setLoadingQuizId(null);
     }
   }, [filterDifficulty, filterType, maxQuestions, onStart]);
+
+  const handleBlockPractice = useCallback(async (blockId: string, blockTitle: string) => {
+    if (!selectedSummary) return;
+    setLoadingQuizId(`block-${blockId}`);
+    setLoadError(null);
+    try {
+      const result = await loadBlockPracticeQuestions(selectedSummary.id, blockId, { difficulty: filterDifficulty, type: filterType }, maxQuestions);
+      if (result.error) { setLoadError(result.error); return; }
+      onStart(result.items, blockTitle, selectedSummary.id);
+    } catch (err: any) {
+      setLoadError(err.message || 'Error al cargar preguntas del bloque');
+    } finally {
+      setLoadingQuizId(null);
+    }
+  }, [selectedSummary, filterDifficulty, filterType, maxQuestions, onStart]);
 
   const handleCourseChange = useCallback((idx: number) => {
     setActiveCourseIdx(idx);
@@ -193,6 +211,7 @@ export function QuizSelection({ onStart, onBack }: QuizSelectionProps) {
         onFilterDifficulty={setFilterDifficulty} onFilterType={setFilterType} onMaxQuestions={setMaxQuestions}
         onToggleHistory={() => setShowHistory(prev => !prev)}
         onSelectSummary={handleSelectSummary} onStartQuiz={handleStartQuizEntity} onPracticeAll={handlePracticeAll}
+        summaryBlocks={summaryBlocks} onBlockPractice={handleBlockPractice}
       />
     </motion.div>
   );

--- a/src/app/components/content/quiz-selection/quiz-data-loading.ts
+++ b/src/app/components/content/quiz-selection/quiz-data-loading.ts
@@ -108,3 +108,47 @@ export async function loadPracticeQuestions(
 
   return { items, error: null };
 }
+
+export async function loadBlockPracticeQuestions(
+  summaryId: string,
+  blockId: string,
+  filters: { difficulty: Difficulty | ''; type: QuestionType | '' },
+  maxQuestions: number,
+): Promise<{ items: QuizQuestion[]; error: string | null }> {
+  const apiFilters: any = { limit: 200, block_id: blockId };
+  if (filters.difficulty) apiFilters.difficulty = filters.difficulty;
+  if (filters.type) apiFilters.question_type = filters.type;
+
+  const res = await quizApi.getQuizQuestions(summaryId, apiFilters);
+  let items = (res.items || []).filter(q => q.is_active);
+
+  if (items.length === 0) {
+    return { items: [], error: 'Este bloque no tiene preguntas de quiz activas.' };
+  }
+
+  items = items.sort(() => Math.random() - 0.5);
+  if (maxQuestions > 0 && maxQuestions < items.length) {
+    items = items.slice(0, maxQuestions);
+  }
+
+  return { items, error: null };
+}
+
+export async function loadBlocksForSummary(
+  summaryId: string,
+): Promise<{ id: string; title: string; type: string }[]> {
+  try {
+    const res = await apiCall<any>(`/summary-blocks?summary_id=${summaryId}`);
+    const items = Array.isArray(res) ? res : (res?.items || []);
+    return items
+      .filter((b: any) => b.is_active !== false)
+      .sort((a: any, b: any) => (a.order_index ?? 0) - (b.order_index ?? 0))
+      .map((b: any) => ({
+        id: b.id,
+        title: b.content?.title || b.type || `Bloque ${b.order_index + 1}`,
+        type: b.type,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/src/app/components/student/BlockQuizModal.tsx
+++ b/src/app/components/student/BlockQuizModal.tsx
@@ -184,8 +184,11 @@ export function BlockQuizModal({
           limit: 10,
         });
 
+        console.log(`[BlockQuiz] block_id=${blockId}, DB returned ${dbResult.items.length} items`);
+
         if (!cancelled && dbResult.items.length > 0) {
           const display = dbToDisplay(dbResult.items);
+          console.log(`[BlockQuiz] dbToDisplay converted ${dbResult.items.length} → ${display.length} displayable`);
           if (display.length > 0) {
             setQuestions(display);
             setLoading(false);
@@ -194,6 +197,7 @@ export function BlockQuizModal({
         }
 
         // 2. Fallback: AI generation
+        console.log(`[BlockQuiz] Falling back to AI generation for block=${blockId}`);
         const aiResult = await apiCall('/ai/generate', {
           method: 'POST',
           body: JSON.stringify({ summary_id: summaryId, block_id: blockId, type: 'quiz' }),

--- a/src/app/components/student/BlockQuizModal.tsx
+++ b/src/app/components/student/BlockQuizModal.tsx
@@ -184,11 +184,12 @@ export function BlockQuizModal({
           limit: 10,
         });
 
-        console.log(`[BlockQuiz] block_id=${blockId}, DB returned ${dbResult.items.length} items`);
-
         if (!cancelled && dbResult.items.length > 0) {
-          const display = dbToDisplay(dbResult.items);
-          console.log(`[BlockQuiz] dbToDisplay converted ${dbResult.items.length} → ${display.length} displayable`);
+          // Client-side block_id filter as safety net — ensures only this block's questions show
+          const blockItems = dbResult.items.filter(
+            (q) => !q.block_id || q.block_id === blockId,
+          );
+          const display = dbToDisplay(blockItems);
           if (display.length > 0) {
             setQuestions(display);
             setLoading(false);


### PR DESCRIPTION
## Summary\n- Replace single \"Practica libre\" button with per-block practice buttons\n- Each block shows its own quiz practice button filtered by `block_id`\n- Falls back to original behavior when blocks aren't available\n- Uses existing `block_id` API filter (already supported by backend)\n\n## Changes\n- `quiz-data-loading.ts`: New `loadBlockPracticeQuestions()` and `loadBlocksForSummary()` functions\n- `QuizSelection.tsx`: Block state, handler, new props to panel\n- `QuizRightPanel.tsx`: Per-block practice buttons UI\n\n## Test plan\n- [ ] Select a summary in QuizSelection → see per-block practice buttons\n- [ ] Click a block → only that block's questions load\n- [ ] Verify quiz count matches block-level questions\n- [ ] Build passes (`vite build`)\n\nhttps://claude.ai/code/session_01W2rvgRzUuyuf54ezvcwRUz