### PR TITLE
fix: quiz block filtering — load only block questions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,30 @@ src/
 
 > **Note**: `bkt-engine.ts` was deleted (TD-3). BKT computation is now inlined in `src/app/components/student/useQuizBkt.ts` and runs server-side in backend `batch-review.ts`.
 
+## Quiz Domain — Table Map (DO NOT CONFUSE)
+
+The quiz system uses 4 distinct tables. Confusing them causes bugs (e.g., filtering at wrong level).
+
+| Table | What it stores | Key columns | `block_id`? |
+|---|---|---|---|
+| **`quiz_questions`** | Individual questions (question text, options, correct answer, difficulty) | `summary_id`, `keyword_id`, `block_id`, `quiz_id` | **YES** — this is how per-block filtering works |
+| **`quizzes`** | Container/grouper with title and time limit (optional wrapper around questions) | `summary_id` | **NO** — summary-scoped only |
+| **`quiz_attempts`** | Each student answer to a question | `quiz_question_id`, `student_id`, `session_id` | No |
+| **`study_sessions`** | Study session (groups multiple attempts) | `student_id`, `course_id`, `session_type` | No |
+
+### Quiz scoping levels
+
+1. **Per-block**: Filter `quiz_questions` by `block_id`. Frontend: `loadBlockPracticeQuestions()` and `loadQuizQuestions()` (when quiz has `block_id`).
+2. **Per-summary**: Fetch all `quiz_questions` for a `summary_id` without `block_id` filter. Frontend: `loadPracticeQuestions()`.
+3. **General/multi-topic**: Not yet implemented.
+
+### Critical rules
+
+- **`quiz_questions.block_id`** is the ONLY mechanism for per-block filtering. The `quizzes` table has NO `block_id` column.
+- When loading questions for a quiz entity (`loadQuizQuestions`), always pass `block_id` if the quiz has one.
+- AI generation endpoints (`generate.ts`) must include `block_id` in the INSERT when provided.
+- `generate-smart.ts` and `pre-generate.ts` generate by keyword (no block concept) — this is intentional.
+
 ## Architecture Patterns
 
 ### Authentication Flow

--- a/src/app/components/content/quiz-selection/quiz-data-loading.ts
+++ b/src/app/components/content/quiz-selection/quiz-data-loading.ts
@@ -60,7 +60,9 @@ export async function loadQuizQuestions(
   quiz: QuizEntity,
   maxQuestions: number,
 ): Promise<{ items: QuizQuestion[]; error: string | null }> {
-  const res = await quizApi.getQuizQuestions(quiz.summary_id, { limit: 200 });
+  const filters: { limit: number; block_id?: string } = { limit: 200 };
+  if (quiz.block_id) filters.block_id = quiz.block_id;
+  const res = await quizApi.getQuizQuestions(quiz.summary_id, filters);
   let items = (res.items || []).filter(q => q.is_active);
 
   try {

--- a/src/app/components/content/quiz-selection/quiz-data-loading.ts
+++ b/src/app/components/content/quiz-selection/quiz-data-loading.ts
@@ -60,19 +60,24 @@ export async function loadQuizQuestions(
   quiz: QuizEntity,
   maxQuestions: number,
 ): Promise<{ items: QuizQuestion[]; error: string | null }> {
-  const filters: { limit: number; block_id?: string } = { limit: 200 };
-  if (quiz.block_id) filters.block_id = quiz.block_id;
-  const res = await quizApi.getQuizQuestions(quiz.summary_id, filters);
-  let items = (res.items || []).filter(q => q.is_active);
+  // Build filters: always filter by quiz_id; also by block_id when the quiz is block-scoped
+  const params = new URLSearchParams();
+  params.set('summary_id', quiz.summary_id);
+  params.set('quiz_id', quiz.id);
+  if (quiz.block_id) params.set('block_id', quiz.block_id);
+  params.set('limit', '200');
 
+  let items: QuizQuestion[] = [];
   try {
-    const filtered = await apiCall<any>(`/quiz-questions?summary_id=${quiz.summary_id}&quiz_id=${quiz.id}`);
-    const filteredItems = Array.isArray(filtered) ? filtered : (filtered?.items || []);
-    if (filteredItems.length > 0) {
-      items = filteredItems.filter((q: any) => q.is_active);
-    }
+    const res = await apiCall<any>(`/quiz-questions?${params}`);
+    const arr = Array.isArray(res) ? res : (res?.items || []);
+    items = arr.filter((q: any) => q.is_active);
   } catch {
-    // quiz_id filter failed, use all summary questions
+    // Fallback: fetch by summary + block_id only
+    const filters: { limit: number; block_id?: string } = { limit: 200 };
+    if (quiz.block_id) filters.block_id = quiz.block_id;
+    const res = await quizApi.getQuizQuestions(quiz.summary_id, filters);
+    items = (res.items || []).filter(q => q.is_active);
   }
 
   if (items.length === 0) {

--- a/src/app/services/quizzesEntityApi.ts
+++ b/src/app/services/quizzesEntityApi.ts
@@ -22,6 +22,8 @@ export interface QuizEntity {
   description: string | null;
   source: 'manual' | 'ai';
   is_active: boolean;
+  /** ADR-001: Optional block linkage — when set, quiz is scoped to a single block */
+  block_id?: string | null;
   /** Q-UX2: Per-question time limit in seconds (null/0 = no limit) */
   time_limit_seconds?: number | null;
   created_by: string;


### PR DESCRIPTION
## Summary
- `loadQuizQuestions()` now passes `block_id` + `quiz_id` to the API so only the correct block's questions load
- Fixed second fetch overwriting block-filtered results
- Added `block_id` to `QuizEntity` TypeScript type
- Added Quiz Domain table map to CLAUDE.md to prevent future confusion

## Test plan
- [x] Build compiles without errors
- [ ] Open a quiz from a specific block → only that block's questions should appear
- [ ] Open "Practice All" for a summary → all questions should still appear

https://claude.ai/code/session_01FrNdp44kRq9esV7UGfXL9f