### PR TITLE
feat: AI organize action — reorder, delete, reschedule tasks

### DIFF
--- a/src/app/hooks/useScheduleAI.ts
+++ b/src/app/hooks/useScheduleAI.ts
@@ -24,9 +24,11 @@ import {
   aiRecommendToday,
   aiReschedule,
   aiWeeklyInsight,
+  aiOrganizePlan,
   type StudentProfilePayload,
   type PlanContextPayload,
   type AiScheduleResponse,
+  type AiOrganizeResponse,
 } from '@/app/services/aiService';
 
 // ── Hook ────────────────────────────────────────────────────
@@ -203,6 +205,24 @@ export function useScheduleAI() {
     }
   }, [buildProfile]);
 
+  /** AI-powered plan organization: reorder, delete, reschedule tasks */
+  const organizeWithAI = useCallback(async (): Promise<AiOrganizeResponse | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await aiOrganizePlan(buildProfile());
+      // Clear recommendations cache since tasks changed
+      recommendationsCache.current = null;
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'AI organize failed';
+      setError(message);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [buildProfile]);
+
   /** Clear cached recommendations (e.g., after plan changes) */
   const clearCache = useCallback(() => {
     recommendationsCache.current = null;
@@ -213,6 +233,7 @@ export function useScheduleAI() {
     getRecommendationsToday,
     rescheduleWithAI,
     getWeeklyInsight,
+    organizeWithAI,
     buildProfile,
     buildPlanContext,
     clearCache,

--- a/src/app/services/ai-service/as-schedule.ts
+++ b/src/app/services/ai-service/as-schedule.ts
@@ -214,6 +214,27 @@ function normalizeClaudeResponse(
   return base;
 }
 
+// ── Organize types ──────────────────────────────────────
+
+export interface AiOrganizeResult {
+  operations: Array<{
+    op: string;
+    taskId: string;
+    reason?: string;
+    newIndex?: number;
+    newDate?: string;
+    fields?: Record<string, unknown>;
+  }>;
+  summary: string;
+  rationale: string;
+}
+
+export interface AiOrganizeResponse {
+  result: AiOrganizeResult | null;
+  executionResults?: Array<{ op: string; taskId: string; success: boolean; error?: string }>;
+  _meta: AiScheduleMeta;
+}
+
 // ── API Functions ─────────────────────────────────────────
 
 async function callScheduleAgent(
@@ -268,4 +289,16 @@ export async function aiWeeklyInsight(
   profile: StudentProfilePayload,
 ): Promise<AiScheduleResponse> {
   return callScheduleAgent('weekly-insight', profile);
+}
+
+/** AI-powered plan organization: reorder, delete, reschedule tasks */
+export async function aiOrganizePlan(
+  profile: StudentProfilePayload,
+): Promise<AiOrganizeResponse> {
+  const body = { action: 'organize', studentProfile: profile };
+  const raw = await apiCall<AiOrganizeResponse>(
+    '/ai/schedule-agent',
+    { method: 'POST', body: JSON.stringify(body) },
+  );
+  return raw;
 }

--- a/src/app/services/aiService.ts
+++ b/src/app/services/aiService.ts
@@ -80,6 +80,7 @@ export {
   aiRecommendToday,
   aiReschedule,
   aiWeeklyInsight,
+  aiOrganizePlan,
 } from './ai-service/as-schedule';
 export type {
   StudentProfilePayload,
@@ -90,4 +91,5 @@ export type {
   AiInsight,
   AiScheduleMeta,
   AiScheduleResponse,
+  AiOrganizeResponse,
 } from './ai-service/as-schedule';


### PR DESCRIPTION
## Summary

- `aiOrganizePlan()` service function calls `POST /ai/schedule-agent` with action `"organize"`
- The backend AI analyzes all pending tasks and executes real DB operations: delete duplicates, reorder by priority, reschedule to optimal dates, update methods/duration
- `useScheduleAI.organizeWithAI()` exposed for components to call
- Clears recommendation cache after organize since tasks changed

## Test plan

- [ ] Call `organizeWithAI()` from a component — verify tasks are actually modified in DB
- [ ] Verify deleted tasks disappear from the plan
- [ ] Verify reordered tasks reflect new order
- [ ] Verify rescheduled tasks show updated dates

https://claude.ai/code/session_018GfDYqL3ScBw637ZqD1xiv