### PR TITLE
fix: restore agent memory system destroyed by erroneous ADR-001 migration

### DIFF
--- a/.claude/AGENT-MEMORY-PROTOCOL.md
+++ b/.claude/AGENT-MEMORY-PROTOCOL.md
@@ -1,0 +1,92 @@
+# Agent Memory Protocol
+
+## Architecture
+
+```
+.claude/agent-memory-seed/    ← IN GIT (templates, read-only baseline)
+.claude/agent-memory/         ← IN GIT (tracked, agents learn across sessions)
+```
+
+**Seed** = initial templates tracked in git. Never modified at runtime.
+**Memory** = live runtime state, NOW TRACKED IN GIT so learnings persist across sessions and clones. Agents read and write freely.
+
+> **Permissions:** `.claude/settings.json` (tracked in git) pre-approves specific read-only `gh` operations (`gh pr view/list/diff/checks`, `gh issue view/list`, `gh repo view`, `gh api`) so agents never trigger destructive GitHub actions. Edit/Write are NOT blanket-approved — agents use them under normal tool-approval flow. This replaces the old `settings.local.json` approach which was gitignored and didn't work in web sessions or worktrees.
+
+## Bootstrap
+
+On first clone or when memory is missing:
+```bash
+bash .claude/bootstrap-memory.sh
+```
+This copies seed → memory. Only runs if memory/ is empty.
+
+## Memory Tiers
+
+| Tier | Files | Written by | Read by |
+|------|-------|-----------|---------|
+| Individual | `individual/<ID>.md` | That agent only | That agent only |
+| Section | `<section>.md` (quiz, flashcards...) | Section lead only | All section agents |
+| Project | `../memory/*.md` | Architect (XX-01) only | All agents |
+
+## Concurrency Safety
+
+- Each agent writes ONLY to its own `individual/<ID>.md` → zero file overlap
+- Section memories: only the lead agent writes (e.g., QZ-01 for quiz.md)
+- Project memory: only XX-01 (architect) writes
+- **NEVER assign the same agent ID to two concurrent sessions**
+
+## Post-Session Write Protocol (MANDATORY)
+
+Every agent MUST do this at session end:
+
+### 1. Append session log (DO NOT edit existing content)
+```markdown
+## [YYYY-MM-DD] Session: <brief description>
+- **Task**: What was done
+- **Learned**: Key insight (1-2 sentences)
+- **Pattern**: Reusable pattern discovered (if any)
+- **Mistake**: Error made and how to avoid (if any)
+- **Files touched**: List of modified files
+```
+
+### 2. Update metrics table
+Increment `Sesiones ejecutadas`, update QG pass/fail count.
+
+### 3. Add to lessons table (if applicable)
+Only add a lesson if it is genuinely new and reusable:
+```markdown
+| YYYY-MM-DD | <lesson> | <how to prevent> |
+```
+
+## Format Rules
+
+- **APPEND ONLY** — never edit or delete existing entries
+- **Session logs** use `## [date]` headers (not tables) — easy to append
+- **Lessons table** stays at the top for quick reference
+- **No secrets** — never include API keys, tokens, passwords, or credential values
+- **Max 100 active lines** — after 10 sessions, architect consolidates
+
+## Memory Compaction (by XX-01 architect, every ~10 sessions)
+
+1. Review all individual memories
+2. Remove lessons with `Confianza: BAJA` after 10+ sessions
+3. Promote cross-cutting lessons to section memory
+4. Archive old session logs to `individual/<ID>-archive.md`
+5. Keep active memory under 100 lines
+
+## Lesson Status
+
+| Status | Meaning |
+|--------|---------|
+| ACTIVE | Valid, follow this lesson |
+| DEPRECATED | Was valid, no longer applies (with reason) |
+| INCORRECT | Was wrong, do the opposite |
+
+XX-02 (quality-gate) can change status. Individual agents cannot deprecate their own lessons.
+
+## Knowledge Promotion Flow
+
+```
+Individual learning → XX-02 reviews → Section memory (if cross-agent)
+                                    → Project memory (if cross-section, via XX-01)
+```

--- a/.claude/agent-memory-seed/3d-viewer.md
+++ b/.claude/agent-memory-seed/3d-viewer.md
@@ -1,0 +1,20 @@
+# 3D Viewer Memory
+
+## Estado actual
+- Three.js viewer working with GLB models
+- Pin system (point/line/area types)
+- Student spatial notes
+- Layer/part visibility
+- Animation, clipping planes, explode view
+
+## Decisiones tomadas (NO re-litigar)
+- Three.js in separate vendor chunk
+- GLB magic byte validation
+- 100MB upload limit
+
+## Archivos clave
+- components/viewer3d/ (19 files, 4700L) — full 3D viewer, pins, layers, animations
+- lib/model3d-api.ts (329L) — model upload/download, GLB validation
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory-seed/admin.md
+++ b/.claude/agent-memory-seed/admin.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory-seed/ai-rag.md
+++ b/.claude/agent-memory-seed/ai-rag.md
@@ -1,0 +1,18 @@
+# AI/RAG Memory
+
+## Estado actual
+- Gemini 2.5 Flash for generation
+- OpenAI text-embedding-3-large (1536d) for embeddings
+- RAG chat streaming works (both ?stream=1 AND body.stream)
+- Voice calls via OpenAI Realtime API
+
+## Decisiones tomadas (NO re-litigar)
+- Stream convention: send BOTH query param AND body field
+- DOMPurify for all AI output rendering
+
+## Archivos clave
+- services/ai-service/ (10 files) — AI service layer, streaming, embeddings
+- components/ai/AxonAIAssistant.tsx (1106L) — main AI chat component
+
+## Bugs conocidos
+- BUG-035 resolved (stream param mismatch)

--- a/.claude/agent-memory-seed/auth.md
+++ b/.claude/agent-memory-seed/auth.md
@@ -1,0 +1,19 @@
+# Auth Memory
+
+## Estado actual
+- Dual token working: ANON_KEY (Supabase anon) + X-Access-Token (user session)
+- AuthContext has backward-compat aliases (20 properties)
+- No password reset flow implemented
+- No 401/session expiration handling
+
+## Decisiones tomadas (NO re-litigar)
+- Role NOT in JWT, comes from GET /institutions
+- localStorage for token persistence
+
+## Archivos clave
+- context/AuthContext.tsx (487L) — main auth state, dual token logic, 20 backward-compat aliases
+- lib/api.ts (308L) — axios instance, interceptors, token injection
+- components/auth/*.tsx — login, register, route guards
+
+## Bugs conocidos
+- BUG-031 resolved (swallowed 500s)

--- a/.claude/agent-memory-seed/billing.md
+++ b/.claude/agent-memory-seed/billing.md
@@ -1,0 +1,17 @@
+# Billing Memory
+
+## Estado actual
+- Stripe checkout + portal integrated
+- Owner plans page exists (844L)
+- Subscriptions page exists (373L)
+
+## Decisiones tomadas (NO re-litigar)
+- Stripe webhook HMAC validation required
+
+## Archivos clave
+- OwnerPlansPage.tsx (844L) — plan selection, Stripe checkout
+- OwnerSubscriptionsPage.tsx (373L) — subscription management, portal link
+- pa-plans.ts (127L) — plans API
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory-seed/cross-cutting.md
+++ b/.claude/agent-memory-seed/cross-cutting.md
@@ -1,0 +1,22 @@
+# Cross-Cutting Memory
+
+## Estado actual
+- 624 TS/TSX files
+- 11 type files with DUPLICATE definitions (Course/Topic/Section/Semester defined 3x)
+- legacy-stubs.ts marked for deletion
+- 48 shadcn/ui components
+- 28 shared components
+
+## Decisiones tomadas (NO re-litigar)
+- platform.ts is canonical for DB types
+- content.ts for nested UI types
+- legacy-stubs.ts will be deleted
+
+## Archivos clave
+- types/*.ts (11 files) — type definitions, watch for duplicates
+- lib/*.ts (28 files) — utilities, API clients, helpers
+- components/shared/ (28 files) — reusable UI components
+
+## Bugs conocidos
+- BUG-024 (overlapping kw-student-notes types)
+- BUG-027 (dual content tree implementation)

--- a/.claude/agent-memory-seed/dashboard.md
+++ b/.claude/agent-memory-seed/dashboard.md
@@ -1,0 +1,20 @@
+# Dashboard Memory
+
+## Estado actual
+- Student dashboard with real KPIs (StatsCards, ActivityHeatMap, MasteryOverview)
+- GamificationContext partially stubbed
+- Gamification pages working (Badges, Leaderboard, XpHistory)
+
+## Decisiones tomadas (NO re-litigar)
+- XP daily cap 500
+- 12 levels
+- 39 badges
+- Delta Mastery Scale for colors
+
+## Archivos clave
+- components/dashboard/ (12 files) — StatsCards, ActivityHeatMap, MasteryOverview
+- components/gamification/ (11+3 pages) — Badges, Leaderboard, XpHistory
+- services/gamificationApi.ts (377L) — XP, levels, badges API
+
+## Bugs conocidos
+- BUG-021 (GamificationContext stubs)

--- a/.claude/agent-memory-seed/docs.md
+++ b/.claude/agent-memory-seed/docs.md
@@ -1,0 +1,20 @@
+# Memory: docs
+Last updated: 2026-03-19
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolucion |
+|-------|-------|---------|------------|
+| 2026-03-19 | Section numbers in PLATFORM-CONTEXT shifted when inserting security section | PLATFORM-CONTEXT.md | Fixed: renumbered 8-11 to 8-12 |
+
+## Patterns a evitar (max 10)
+| Pattern | Por que | Alternativa |
+|---------|---------|-------------|
+| Deleting resolved bugs from KNOWN-BUGS.md | Loses audit trail / history | Mark as RESOLVED with date, keep in separate section |
+| Duplicating security details across files | Drift risk between KNOWN-BUGS, security-audit, PLATFORM-CONTEXT | Single source in security-audit.md, others cross-reference |
+
+## Decisiones (max 10)
+| Fecha | Decision | Contexto |
+|-------|---------|----------|
+| 2026-03-19 | Added section 8 (Security Posture) to PLATFORM-CONTEXT.md | Security audit resolved 14 issues; platform now has substantial security surface worth documenting as stable reference |
+| 2026-03-19 | New bug IDs SEC-* for security items not previously tracked | Telegram, AI injection, XSS, CSP etc. had no BUG-### ID; created SEC-* namespace |
+| 2026-03-19 | Open count now 19 (was 16) — 3 resolved but 6 new open items added | SEC-S7, SEC-S9B, SEC-S16, TEST-001, TEST-002 are new; BUG-002/003/004 resolved |

--- a/.claude/agent-memory-seed/flashcards.md
+++ b/.claude/agent-memory-seed/flashcards.md
@@ -1,0 +1,20 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-18 | delta-color-scale test expected 'blue' for 0.99/0.90 but IEEE 754 gives 1.0999...9 < 1.10 | src/__tests__/delta-color-scale.test.ts:88-91 | Fixed assertion to expect 'green' (correct per floating point) |
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Using ASCII for Spanish chars in test expectations | Source uses accented chars (Conexion vs Conexion, Debil vs Debil) | Use unicode escapes or copy exact string from source |
+| Regex assuming 2-digit day/month in toLocaleDateString('es') | jsdom locale formatting may produce 1-digit day/month | Use `\d{1,2}` instead of `\d{2}` |
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+| 2026-03-18 | Perf test at mindmap/__tests__/ not __tests__/ | vitest.config includes only src/**/*.test.ts; root __tests__/ would not be picked up |
+| 2026-03-18 | Cross-linked graphs make computeHiddenNodes non-deterministic for root collapse | Cross-links create incoming edges to tree root, so root is no longer detected as root by the BFS seed logic. Use pure trees for collapse correctness tests. |
+| 2026-03-18 | Test unexported pure functions by replicating logic in test files | useEdgeReconnect's findNearestNode is not exported; replicate + validate contract via source reading (same pattern as mapComparisonPanel.test.ts) |

--- a/.claude/agent-memory-seed/individual/3D-01-viewer3d-frontend.md
+++ b/.claude/agent-memory-seed/individual/3D-01-viewer3d-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: 3D-01 (viewer3d-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Interfaz de usuario del visor 3D anatomico: componentes React con Three.js, camara, iluminacion, raycasting y capas de partes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Dispose explicito de geometrias, materiales y texturas de Three.js al desmontar para evitar memory leaks.
+- Usar GLTFLoader para carga de modelos GLB/GLTF.
+- Implementar raycasting para deteccion de clicks sobre partes del modelo.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas de red; nunca fetch directo.
+- Design system consistente: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| No hacer dispose de recursos Three.js | Memory leaks acumulativos que degradan performance | Dispose de geometrias, materiales y texturas al desmontar |
+| Usar fetch directo en lugar de `apiCall()` | Rompe el contrato de la capa de API | Siempre usar `apiCall()` de `lib/api.ts` |
+| Usar `any` en TypeScript | Anula las garantias de tipo y oculta bugs | TypeScript strict en todo momento |
+| console.log en produccion | Filtra informacion y es indicador de codigo no revisado | Usar herramientas de debugging apropiadas |
+| Modificar logica de otra zona sin escalar | Genera conflictos con otros agentes | Escalar al lead (XX-01) si se necesita modificar otra zona |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/3D-02-viewer3d-backend.md
+++ b/.claude/agent-memory-seed/individual/3D-02-viewer3d-backend.md
@@ -1,0 +1,45 @@
+# Agent Memory: 3D-02 (viewer3d-backend)
+Last updated: 2026-03-25
+
+## Rol
+Rutas API backend para CRUD de modelos 3D, subida de archivos GLB a Supabase Storage, y gestion de partes y capas anatomicas.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Validar inputs en cada endpoint sin excepcion.
+- Autenticar via JWT en header `X-Access-Token` antes de procesar cualquier solicitud.
+- Respetar RLS policies de Supabase para control de acceso por institucion y rol.
+- Mantener naming convention de rutas de modelos al crear nuevos archivos.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Endpoints sin validacion de inputs | Permite datos corruptos o ataques de inyeccion | Validar todo input antes de procesar |
+| Modificar middleware de auth o RLS sin escalar | Afecta seguridad del sistema completo | Escalar al lead (XX-01) para cambios de auth/RLS |
+| Cambiar esquema de base de datos directamente | Riesgo de migraciones inconsistentes y perdida de datos | Escalar al lead; los cambios de schema requieren coordinacion |
+| Usar `any` en TypeScript | Anula las garantias de tipo | TypeScript strict en todo momento |
+| console.log en produccion | Filtra informacion sensible | Eliminar logs antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/3D-03-viewer3d-upload.md
+++ b/.claude/agent-memory-seed/individual/3D-03-viewer3d-upload.md
@@ -1,0 +1,47 @@
+# Agent Memory: 3D-03 (viewer3d-upload)
+Last updated: 2026-03-25
+
+## Rol
+Interfaz de subida y gestion de modelos 3D para profesores: upload GLB, validacion de archivos, configuracion de partes anatomicas.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Validar archivos GLB via magic bytes antes de iniciar el upload (confirmar formato real, no solo extension).
+- Respetar el limite de 100MB por modelo; rechazar y notificar antes de intentar subir.
+- Centralizar todas las llamadas a la API de modelos en `model3d-api.ts` (329L).
+- Flujo orquestado por ModelManager (666L): seleccion → validacion → upload → asignacion de partes.
+- Usar TanStack Query para server state y cache de modelos.
+- Design system: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Subir archivos sin validar magic bytes | Permite subir archivos no-GLB con extension renombrada | Siempre verificar magic bytes antes del upload |
+| Omitir validacion de tamanio antes del upload | Genera errores costosos en storage con archivos > 100MB | Validar tamanio localmente primero |
+| Llamadas directas a API fuera de `model3d-api.ts` | Fragmenta la capa de servicio y duplica logica | Canalizar todo por `model3d-api.ts` |
+| Modificar logica del visor 3D (zona 3D-01) | Genera conflictos con el agente 3D-01 | Escalar al lead si se necesita coordinacion |
+| Usar `any` o console.log | Rompe TypeScript strict y filtra informacion | TypeScript strict; eliminar logs antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/3D-04-viewer3d-annotations.md
+++ b/.claude/agent-memory-seed/individual/3D-04-viewer3d-annotations.md
@@ -1,0 +1,49 @@
+# Agent Memory: 3D-04 (viewer3d-annotations)
+Last updated: 2026-03-25
+
+## Rol
+Sistema de anotaciones 3D: pins espaciales, notas de profesores y estudiantes, marcadores billboard y posicionamiento via raycasting.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Limpiar event listeners de raycasting al desmontar componentes para evitar leaks.
+- PinMarker3D como sprite billboard: siempre orientado hacia la camara automaticamente.
+- LinePinMarker conecta el pin con su punto de anclaje fisico en el modelo mediante linea.
+- MultiPointPlacer para anotaciones complejas que requieren varios puntos de referencia.
+- Usar `usePinData` y `useNoteData` con TanStack Query para server state.
+- KeywordAutocomplete sugiere terminos anatomicos al escribir; acelera y estandariza anotaciones.
+- Usar `apiCall()` de `lib/api.ts`; nunca fetch directo.
+- Design system: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| No limpiar event listeners de raycasting | Memory leaks y comportamiento fantasma al remontar | Siempre remover listeners en el cleanup de useEffect |
+| Modificar logica core del visor 3D (zona 3D-01) | Conflicto con el agente 3D-01 | Escalar al lead (XX-01) si se necesita coordinacion |
+| Cambiar rutas de API backend (zona 3D-02) | Conflicto con el agente 3D-02 | Escalar al lead; las rutas son zona exclusiva de 3D-02 |
+| Usar `any` o console.log | Rompe TypeScript strict y filtra informacion | TypeScript strict; limpiar logs antes de commit |
+| Pins sin punto de anclaje en superficie | Los pins "flotan" sin referencia espacial real | Usar raycasting para obtener punto exacto en la superficie del modelo |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AGENT-METRICS.md
+++ b/.claude/agent-memory-seed/individual/AGENT-METRICS.md
@@ -1,0 +1,273 @@
+# AXON Agent Metrics
+Last updated: 2026-03-25 | Total sessions: 1
+
+> El Arquitecto lee este archivo al inicio de cada sesión y lo actualiza después de cada post-mortem.
+
+---
+
+## 1. System Pulse
+
+| Métrica                      | Últimas 5 | Previas 5 | Trend |
+|------------------------------|-----------|-----------|-------|
+| QG first-pass rate           | 100%      | —         | +++   |
+| Scope creep incidents        | 0         | —         | =     |
+| Repeat errors (post-lesson)  | 1         | —         | --    |
+| Merge conflicts              | 0         | —         | =     |
+| Avg agents per session       | 4         | —         | =     |
+| Lessons registered           | 8         | —         | +++   |
+
+> Trend: `+++` mejora fuerte, `++` mejora, `=` estable, `--` declive, `---` declive fuerte
+
+### Qué decide cada métrica
+
+| Métrica | Si el valor es malo → acción |
+|---------|------------------------------|
+| QG first-pass rate <75% | Pausar features, auditar agentes que fallan |
+| Scope creep >2 | Revisar reglas en `feedback_agent_isolation.md` |
+| Repeat errors >0 | Las lecciones no funcionan — fortalecer definiciones de agentes |
+| Merge conflicts >2 | Revisar overlap de archivos en AGENT-REGISTRY |
+
+---
+
+## 2. Section Health
+
+| Section        | Agents | Active | QG Rate (L5) | Top Error | Lessons | Repeats | Status |
+|----------------|--------|--------|--------------|-----------|---------|---------|--------|
+| Quiz (QZ)      | 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| Flashcards (FC)| 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| Summaries (SM) | 6      | 2      | 100%         | severity-mismatch | 8       | 0       | ACTIVE |
+| Study (ST)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Dashboard (DG) | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Admin (AO)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Auth (AS)      | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| AI & RAG (AI)  | 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| 3D Viewer (3D) | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Infra (IF)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Messaging (MG) | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Billing (BL)   | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Cross-cut (XX) | 9      | 0      | —            | —         | 0       | 0       | NEW    |
+
+> **Top Error** usa los 6 checks del QG: `zone` | `ts` | `spec` | `tests` | `git` | `compat`
+> **Status** = peor health de cualquier agente de la sección
+
+---
+
+## 3. Agent Detail
+
+### Quiz (QZ)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| QZ-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Flashcards (FC)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| FC-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Summaries (SM)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| SM-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Study (ST)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| ST-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Dashboard & Gamification (DG)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| DG-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Admin & Owner (AO)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AO-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Auth & Security (AS)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AS-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AS-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AS-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+> AS-03, AS-04 son supervisores → ver Sección 5
+
+### AI & RAG (AI)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AI-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### 3D Viewer (3D)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| 3D-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Infrastructure (IF)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| IF-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Messaging (MG)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| MG-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Billing (BL)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| BL-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Cross-cutting (XX) — solo implementadores
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| XX-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-08 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+> XX-02, XX-06, XX-07, XX-09 son supervisores → ver Sección 5
+
+---
+
+## 4. Error Ledger (últimos 20 errores)
+
+> Conecta: QG failure → lección → prevención. Si `Recurred? = YES`, la lección no funcionó.
+
+| #  | Date | Agent | QG Check | Description | Lesson? | Where | Recurred? |
+|----|------|-------|----------|-------------|---------|-------|-----------|
+| — | — | — | — | (sin errores registrados) | — | — | — |
+
+> **QG Check** es uno de: `zone` `ts` `spec` `tests` `git` `compat`
+> **Recurred?** = YES(#N) si el mismo agente repitió el mismo tipo de error después de una lección
+
+---
+
+## 5. Supervisor Metrics
+
+> Los supervisores generan auditorías, no código. Sus métricas son de hallazgos, no de QG pass/fail.
+
+### XX-02 quality-gate
+| Runs | APPROVE | NEEDS FIX | BLOCK | False Pos | False Neg | Accuracy |
+|------|---------|-----------|-------|-----------|-----------|----------|
+| 0    | 0       | 0         | 0     | 0         | 0         | —        |
+
+### XX-06 test-orchestrator
+| Runs | Tests Exec | Tests Failed | Flaky Detected | Slow (>5s) | .only/.skip |
+|------|-----------|-------------|----------------|------------|-------------|
+| 0    | 0         | 0           | 0              | 0          | 0           |
+
+### AS-04 security-scanner
+| Runs | Findings | Critical | High | Medium | Resolved | False Pos |
+|------|----------|----------|------|--------|----------|-----------|
+| 0    | 0        | 0        | 0    | 0      | 0        | 0         |
+
+### XX-07 refactor-scout
+| Runs | Findings | Critical | High | Actioned | Ignored | Trend |
+|------|----------|----------|------|----------|---------|-------|
+| 0    | 0        | 0        | 0    | 0        | 0       | —     |
+
+### AS-03 rls-auditor
+| Runs | Tables Audited | Gaps Found | Gaps Fixed | Misconfigs |
+|------|---------------|------------|------------|------------|
+| 0    | 0             | 0          | 0          | 0          |
+
+### XX-09 api-contract
+| Runs | Contracts | Mismatches | Envelope Violations | Orphan Endpoints |
+|------|-----------|------------|---------------------|------------------|
+| 0    | 0         | 0          | 0                   | 0                |
+
+---
+
+## 6. Scoring Rules
+
+### Agent Health (basado en últimas 5 sesiones)
+| Health | Criterio |
+|--------|----------|
+| NEW    | 0 sesiones |
+| GREEN  | >=80% QG pass AND 0 scope creep |
+| YELLOW | 60-79% QG pass OR 1 scope creep OR 1 repeat error |
+| RED    | <60% QG pass OR 2+ scope creep OR 2+ repeat errors OR 2+ BLOCK |
+
+### Section Status (derivado de agentes de la sección)
+| Status | Criterio |
+|--------|----------|
+| NEW    | Todos los agentes NEW |
+| GREEN  | 0 agentes RED AND QG rate sección >=80% |
+| YELLOW | 1 agente RED OR QG rate sección 60-79% |
+| RED    | 2+ agentes RED OR QG rate sección <60% OR any repeat error |
+
+### Trend (comparar últimas 5 vs previas 5)
+| Trend | Significado |
+|-------|-------------|
+| `+++` | Mejoró 40%+ puntos |
+| `++`  | Mejoró 20-39% puntos |
+| `=`   | Cambió <20% puntos |
+| `--`  | Declinó 20-39% puntos |
+| `---` | Declinó 40%+ puntos |
+| `—`   | <6 sesiones totales (datos insuficientes) |
+
+### Error Type Codes
+`zone` = zone compliance | `ts` = TypeScript | `spec` = spec coherence
+`tests` = test coverage | `git` = git hygiene | `compat` = backward compatibility
+
+---
+
+## Update Protocol (después de cada post-mortem)
+
+**Paso 1 (30s): Error Ledger.** Por cada QG failure, agregar fila. Verificar si matchea una lección previa del mismo agente → marcar `Recurred? YES(#N)`.
+
+**Paso 2 (30s): Agent Detail.** Por cada agente que participó: incrementar Sessions, actualizar QG L5 (agregar resultado, dropear el más viejo si >5), actualizar Fails By Type, Scope, Last Run. Recalcular Trend y Health.
+
+**Paso 3 (15s): Section Health.** Por cada sección que tuvo agentes: recalcular QG Rate (L5) agregando todos los agentes activos. Actualizar Top Error, Active, Lessons, Repeats. Derivar Status.
+
+**Paso 4 (15s): System Pulse.** Recalcular las 6 métricas del sistema. Rotar ventana. Actualizar trends.
+
+**Paso 5 (15s): Supervisor Metrics.** Si un supervisor participó, actualizar su tabla específica en Sección 5.
+
+> Tiempo total estimado: ~2 minutos de edición manual por post-mortem.

--- a/.claude/agent-memory-seed/individual/AI-01-rag-pipeline.md
+++ b/.claude/agent-memory-seed/individual/AI-01-rag-pipeline.md
@@ -1,0 +1,47 @@
+# Agent Memory: AI-01 (rag-pipeline)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Modelo embeddings: OpenAI text-embedding-3-large (1536 dimensiones)
+- Almacenamiento: PostgreSQL + pgvector (1536d)
+- Chunking: semántico (títulos, párrafos, listas) — NO por tokens arbitrarios
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Chunking semántico sobre chunking por tokens | Maximiza relevancia en búsqueda vectorial | Chunking por tokens fijo |
+| 2026-03-25 | Streaming/paginado para PDFs grandes | Nunca cargar PDF completo en memoria | Carga completa en memoria |
+| 2026-03-25 | Logs estructurados por etapa del pipeline | Extracción → Chunking → Embedding → Storage | Logs planos sin etapas |
+
+## Patrones que funcionan
+- as-ingest.ts como coordinador del pipeline completo
+- Procesamiento por páginas para PDFs grandes
+- Manejo granular de errores (páginas corruptas, sin OCR, etc.)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Cargar PDF completo en memoria | OOM en documentos grandes | Procesar en streaming o por páginas |
+| Chunks por tamaño de tokens fijo | Rompe contexto semántico | Respetar límites de párrafo/sección |
+| Insertar embeddings sin validar dimensión | pgvector rechaza dimensiones incorrectas | Siempre validar dim=1536 antes de INSERT |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/AI-02-rag-chat.md
+++ b/.claude/agent-memory-seed/individual/AI-02-rag-chat.md
@@ -1,0 +1,49 @@
+# Agent Memory: AI-02 (rag-chat)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- LLM: Gemini 2.5 Flash para generación
+- Streaming: SSE (Server-Sent Events)
+- Stream convention: enviar BOTH ?stream=1 AND body.stream (decisión final, NO re-litigar)
+- Sanitización: DOMPurify para todo output AI renderizado
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | BUG-035 (stream param mismatch) ya resuelto | Siempre enviar ambos: query param Y body field |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Dual stream param (query + body) | Backend checks ambos; eliminar uno rompe streaming | Solo query param, solo body param |
+| 2026-03-25 | DOMPurify obligatorio | Previene XSS en output del LLM | Renderizar HTML crudo del LLM |
+| 2026-03-25 | Reconexión automática en SSE | El usuario no debe perder contexto si la conexión se cae | Sin reconexión automática |
+
+## Patrones que funcionan
+- AxonAIAssistant.tsx (1106L) como componente monolítico — refactors deben ser incrementales
+- Renderizado incremental de streaming (no esperar mensaje completo)
+- Ventana de historial limitada para no exceder tokens del modelo
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Enviar solo ?stream=1 sin body.stream | Backend checkea ambos → streaming falla silenciosamente | Siempre enviar AMBOS |
+| Renderizar HTML del LLM sin sanitizar | XSS via prompt injection | DOMPurify.sanitize() siempre |
+| Refactor big-bang de AxonAIAssistant | 1106 líneas, alto riesgo de regresión | Refactors incrementales con tests |
+| Historial ilimitado en contexto | Excede límite de tokens del modelo | Ventana deslizante de N turnos |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/AI-03-ai-generation.md
+++ b/.claude/agent-memory-seed/individual/AI-03-ai-generation.md
@@ -1,0 +1,44 @@
+# Agent Memory: AI-03 (ai-generation)
+Last updated: 2026-03-25
+
+## Rol
+Generacion automatizada de contenido educativo (flashcards, quizzes, resumenes) con targeting adaptativo via NeedScore y BKT.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Calcular NeedScore considerando los 4 factores: frecuencia de repaso, dificultad del item, tiempo desde ultimo repaso y rendimiento historico.
+- Separar logica de UI y logica de negocio en `useSmartGeneration.ts` (279L).
+- Usar `aiApi.ts` (263L) como interfaz central para todas las llamadas a servicios AI desde frontend.
+- Distinguir claramente entre generacion smart (BKT targeting) y generacion rapida (sin analisis).
+- Documentar cambios en algoritmos de ranking en `agent-memory/ai-rag.md` inmediatamente.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Generar contenido para conceptos con P(L) > 0.95 | El estudiante ya domina el concepto; desperdicia recursos | Verificar BKT antes de lanzar generacion |
+| Presentar contenido sin validacion de calidad | Degrada la experiencia pedagogica | Pasar siempre por pipeline de validacion antes de mostrar al usuario |
+| Hardcodear llamadas AI fuera de `aiApi.ts` | Rompe la interfaz central y crea deuda tecnica | Canalizar todo por `aiApi.ts` |
+| Mezclar logica de UI con logica de negocio en hooks | Dificulta el mantenimiento y testeo | Mantener separacion clara en `useSmartGeneration.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AI-04-embeddings.md
+++ b/.claude/agent-memory-seed/individual/AI-04-embeddings.md
@@ -1,0 +1,48 @@
+# Agent Memory: AI-04 (embeddings)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Modelo: OpenAI text-embedding-3-large (1536 dimensiones)
+- Storage: PostgreSQL + pgvector
+- Índices: IVFFlat (datasets grandes) o HNSW (mayor precisión)
+- Distancia: coseno
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | IVFFlat como índice default | Balance entre velocidad y precisión para volumen actual | HNSW (mayor precisión pero más lento para este volumen) |
+| 2026-03-25 | Cache local en useRagAnalytics | Evitar llamadas excesivas al backend para stats de cobertura | Sin cache, polling directo |
+| 2026-03-25 | Nunca eliminar embeddings sin verificar referencias | Conversaciones activas pueden referenciar chunks | DELETE directo sin auditoría |
+
+## Patrones que funcionan
+- as-analytics.ts para stats de cobertura centralizadas
+- Cache local en hooks para métricas que cambian poco
+- Validación de dimensión (1536) antes de INSERT
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Full table scan para stats de cobertura | Muy lento en datasets grandes | Queries con COUNT + índices |
+| DELETE de embeddings sin verificar refs | Rompe conversaciones activas | Check referencias antes de DELETE |
+| Insertar sin validar dimensión | pgvector rechaza silenciosamente | Validar dim=1536 en capa de servicio |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/AI-05-ai-backend.md
+++ b/.claude/agent-memory-seed/individual/AI-05-ai-backend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AI-05 (ai-backend)
+Last updated: 2026-03-25
+
+## Rol
+Route handlers del backend AI (17 rutas REST/WebSocket), agente de horarios y integracion con OpenAI Realtime API para voz en tiempo real.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Aplicar estructura consistente en las 17 rutas: validacion → procesamiento → respuesta.
+- Validar autenticacion y autorizacion antes de cualquier procesamiento en rutas AI.
+- Implementar rate limiting especifico para operaciones AI (mas restrictivo que rutas generales).
+- Reconexion automatica obligatoria en el WebSocket de `as-realtime.ts` (297L).
+- Considerar zonas horarias del usuario en todo cambio a `as-schedule.ts` (236L).
+- Documentar cambios en rutas y servicios de tiempo real en `agent-memory/ai-rag.md`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Rutas AI sin validacion de auth | Expone endpoints sensibles | Siempre validar auth/authz primero |
+| Ignorar reconexion en WebSocket Realtime | Interrumpe sesiones de voz del usuario | Implementar reconexion automatica en `as-realtime.ts` |
+| Latencia > 200ms en audio bidireccional | Degrada la experiencia de voz | Optimizar pipeline en `useRealtimeVoice.ts` (309L) |
+| Omitir zonas horarias en el agente de horarios | Genera planes de estudio incorrectos | Siempre resolver timezone del usuario en `as-schedule.ts` |
+| Rate limiting identico al de rutas generales | Las ops AI son mas costosas; sobrecarga el sistema | Configurar rate limits especificos y mas restrictivos |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AI-06-ai-prompts.md
+++ b/.claude/agent-memory-seed/individual/AI-06-ai-prompts.md
@@ -1,0 +1,47 @@
+# Agent Memory: AI-06 (ai-prompts)
+Last updated: 2026-03-25
+
+## Rol
+Ingenieria de prompts y plantillas centralizadas para todos los servicios AI, mas el sistema de reportes de calidad pedagogica.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Centralizar todos los prompt templates en `as-types.ts` (232L); ninguno hardcodeado en servicios.
+- Asignar identificador unico y version a cada template para trazabilidad y rollback.
+- Incluir instrucciones explicitas de formato de salida (JSON schema cuando aplique) en cada prompt.
+- Verificar compatibilidad con todos los consumidores antes de modificar `as-types.ts` (afecta a todos los servicios AI).
+- Evaluar reportes en 4 dimensiones: relevancia, precision, completitud y adecuacion pedagogica.
+- Mantener separacion entre logica de datos y presentacion en `useAiReports.ts` (244L).
+- Documentar todo cambio de template en `agent-memory/ai-rag.md` con justificacion y resultados de evaluacion.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear prompts directamente en servicios AI | Imposibilita el versionado, A/B testing y rollback | Siempre usar templates centralizados en `as-types.ts` |
+| Modificar `as-types.ts` sin verificar consumidores | Rompe silenciosamente servicios que dependen de ese tipo | Revisar todos los importers antes de modificar |
+| Templates sin identificador ni version | Impide trazabilidad y rollback ante degradacion | Versionar desde la creacion del template |
+| Prompts sin especificacion de formato de salida | Outputs inconsistentes y dificiles de parsear | Incluir JSON schema o instrucciones de formato explícitas |
+| Mezclar logica de datos y UI en `useAiReports.ts` | Dificulta mantenimiento y testeo | Mantener separacion clara entre capas |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AO-01-admin-frontend.md
+++ b/.claude/agent-memory-seed/individual/AO-01-admin-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-01 (admin-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend de administracion institucional: mantiene las paginas del rol admin (dashboard, contenido, miembros, reportes, scopes, settings, AI health, messaging) y el archivo admin-routes.ts.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+- Páginas funcionales (Settings 271L, AI Health 345L, Messaging 521L) requieren mayor cuidado: no romper lógica operativa existente
+- Páginas placeholder (Dashboard, Content, Members, Reports, Scopes): cablearlas con rutas reales siguiendo el patrón de admin-routes.ts
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Modificar archivos fuera de `**/pages/admin/*` o `admin-routes.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Fetch directo sin `apiCall()` | Inconsistencia en manejo de auth headers y errores | Siempre usar `apiCall()` de `lib/api.ts` |
+| Editar mega-componentes sin revisar líneas totales | Riesgo de introducir regresiones en componentes grandes | Leer el archivo completo antes de editar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AO-02-admin-backend.md
+++ b/.claude/agent-memory-seed/individual/AO-02-admin-backend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-02 (admin-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de administracion institucional: mantiene las rutas API de admin, el servicio pa-admin.ts y la lógica de scopes, reglas de acceso, gestión de estudiantes y búsqueda administrativa.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Validar permisos de rol admin en cada endpoint antes de ejecutar lógica de negocio
+- Centralizar llamadas a la API de plataforma en pa-admin.ts (223L) — no duplicar lógica en rutas
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Omitir validación de rol admin en endpoints | Expone operaciones administrativas a usuarios no autorizados | Siempre aplicar middleware de auth con validación de rol |
+| Modificar archivos fuera de `**/routes/admin*` o `pa-admin.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Duplicar lógica de plataforma fuera de pa-admin.ts | Inconsistencia y mantenimiento difícil | Centralizar en pa-admin.ts |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AO-03-owner-frontend.md
+++ b/.claude/agent-memory-seed/individual/AO-03-owner-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-03 (owner-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend del rol owner: mantiene las páginas de dashboard, miembros, planes, suscripciones, reglas de acceso, reportes, institución y settings del owner, con especial atención a la descomposición correcta de mega-componentes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Leer el archivo completo antes de editar mega-componentes (OwnerMembersPage 1276L, OwnerPlansPage 844L, OwnerDashboardPage 602L)
+- Al descomponer mega-componentes: extraer subcomponentes por responsabilidad (CRUD, invitaciones, roles)
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Editar mega-componentes sin leer el archivo completo primero | Riesgo alto de regresiones en 800-1276L | Leer todo el componente antes de planificar cambios |
+| Crear subcomponentes sin respetar la estructura de directorios existente | Inconsistencia arquitectural | Seguir el patrón de organización de `components/roles/pages/owner/` |
+| Modificar archivos fuera de `**/pages/owner/*` o `owner-routes.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AO-04-owner-backend.md
+++ b/.claude/agent-memory-seed/individual/AO-04-owner-backend.md
@@ -1,0 +1,47 @@
+# Agent Memory: AO-04 (owner-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend del rol owner: mantiene las rutas API de owner, los servicios pa-institutions.ts y pa-plans.ts, y la lógica de CRUD de instituciones, gestión de membresías y administración de planes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Separar responsabilidades: pa-institutions.ts para CRUD de instituciones, pa-plans.ts para gestión de planes
+- Validar permisos de rol owner en cada endpoint antes de ejecutar lógica de negocio
+- Plan CRUD: incluir siempre definición de límites, features y precios en las operaciones de planes
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Omitir validación de rol owner en endpoints | Expone operaciones de propietario a usuarios no autorizados | Siempre aplicar middleware de auth con validación de rol owner |
+| Mezclar lógica de instituciones y planes en el mismo servicio | Dificulta mantenimiento y viola SRP | Mantener pa-institutions.ts y pa-plans.ts separados |
+| Modificar archivos fuera de `**/routes/owner*`, `pa-institutions.*` o `pa-plans.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/AS-01-auth-backend.md
+++ b/.claude/agent-memory-seed/individual/AS-01-auth-backend.md
@@ -1,0 +1,51 @@
+# Agent Memory: AS-01 (auth-backend)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Dual token: SUPABASE_ANON_KEY (Bearer) + USER_JWT (X-Access-Token)
+- Role NO está en JWT — viene de GET /institutions
+- RLS policies a nivel de PostgreSQL
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Dual token es arquitectura definitiva | ANON_KEY para Supabase client, USER_JWT para auth de API | Token único para ambos propósitos |
+| 2026-03-25 | Role via GET /institutions, no JWT claims | Permite cambio de role sin reauth | Claims de rol en el JWT |
+
+## Patrones que funcionan
+- middleware/auth.ts como punto único de validación
+- RLS policies como segunda capa de defensa (DB level)
+- Separación clara: auth.ts (lógica) vs routes/auth.ts (HTTP)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Leer role desde JWT claims | Role no está en JWT por diseño | GET /institutions para obtener role |
+| Bypass de middleware para "conveniencia" | Abre agujeros de seguridad | Siempre pasar por middleware/auth.ts |
+| RLS policies que asumen role en JWT | Inconsistente con arquitectura dual-token | Usar service_role key para operaciones admin |
+
+## Impacto (CRITICAL — bloquea todos los agentes backend)
+- TODOS los agentes backend dependen implícitamente de AS-01
+- Cualquier cambio en auth middleware afecta a toda la plataforma
+- Cambios requieren: tests exhaustivos + security review + quality-gate
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/AS-02-auth-frontend.md
+++ b/.claude/agent-memory-seed/individual/AS-02-auth-frontend.md
@@ -1,0 +1,57 @@
+# Agent Memory: AS-02 (auth-frontend)
+Last updated: 2026-03-26
+
+## Rol
+Agente frontend de autenticación: mantiene el AuthContext, las páginas de login/registro, los guards de rutas basados en roles (RequireAuth, RequireRole) y la lógica de redirección post-login.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | Para tests de AuthContext, mockear supabase y api con funciones proxy (`(...args) => mockFn(...args)`) en vi.mock factories permite reconfigurar mocks por test sin problemas de hoisting | Usar funciones proxy en vi.mock, no importar mocks directamente |
+| 2026-03-26 | signup() usa fetch directo (no apiCall) porque POST /signup no necesita X-Access-Token -- tests deben mockear globalThis.fetch para este caso | Verificar si la funcion bajo test usa fetch o apiCall antes de escribir el mock |
+| 2026-03-26 | AuthContext tiene console.log/error con guard `import.meta.env.DEV` que produce stdout en vitest (env=jsdom, DEV=true) -- no es un problema, es output esperado | No suprimir logs DEV-only a menos que contaminen la salida de un test |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/auth.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Sincronizar tokens en localStorage con el AuthContext via `onAuthStateChange` de Supabase
+- Guards como componentes wrapper de React Router v6: RequireAuth verifica sesión, RequireRole verifica rol
+- PostLoginRouter: lógica de redirección basada en rol del usuario, nunca hardcodear rutas en componentes de página
+- SelectRolePage: mostrar solo cuando el usuario tiene múltiples roles asignados
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+- Para tests de AuthContext: usar `renderHook()` + `waitFor()` de @testing-library/react, con AuthProvider como wrapper
+- Mock de supabase: funciones proxy en vi.mock factory para permitir reconfiguracion por test (mockGetSession, mockSignInWithPassword, etc.)
+- Mock de api: mockApiCall con mockImplementation que rutea por path ('/me', '/institutions')
+- signup() usa fetch directo, no apiCall -- mockear globalThis.fetch para tests de signup
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer tokens o datos de sesión | Eliminar antes de commit |
+| Almacenar tokens sensibles fuera de localStorage gestionado por AuthContext | Estado inconsistente de sesión | Centralizar gestión de tokens en AuthContext |
+| Hardcodear rutas de redirección en componentes de página | Acoplamiento y dificulta mantenimiento | Centralizar lógica de redirección en PostLoginRouter |
+| Modificar archivos fuera de la zona: AuthContext, components/auth/*, RequireAuth, RequireRole | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Omitir guard RequireRole en rutas que requieren rol específico | Expone páginas de rol a usuarios sin permisos | Siempre componer RequireAuth + RequireRole en rutas protegidas |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Tests escritos | 16 | 2026-03-26 |

--- a/.claude/agent-memory-seed/individual/AS-03-rls-auditor.md
+++ b/.claude/agent-memory-seed/individual/AS-03-rls-auditor.md
@@ -1,0 +1,45 @@
+# Agent Memory: AS-03 (rls-auditor)
+Last updated: 2026-03-25
+
+## Rol
+Audita políticas Row Level Security de PostgreSQL. Detecta tablas sin protección, políticas permisivas y misconfiguraciones.
+
+## Estado de tablas auditadas
+| Tabla | RLS Enabled | Policies (S/I/U/D) | Última auditoría | Issues |
+|-------|-------------|---------------------|-----------------|--------|
+| (ninguna aún) | — | — | — | — |
+
+> S=SELECT, I=INSERT, U=UPDATE, D=DELETE
+
+## Brechas históricas
+| Fecha | Tabla | Tipo de brecha | Severidad | Resuelto? | Cómo |
+|-------|-------|---------------|-----------|-----------|------|
+| (ninguna aún) | — | — | — | — | — |
+
+## Patrones RLS validados
+| Pattern | Notas |
+|---------|-------|
+| `auth.uid() = user_id` para SELECT propio | Patrón estándar de Supabase |
+| `auth.role() = 'service_role'` para admin | Solo backend con service key |
+| RLS enabled sin policies = bloqueado | Supabase bloquea todo por defecto |
+
+## Falsos positivos conocidos
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| (ninguno aún) | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory-seed/individual/AS-04-security-scanner.md
+++ b/.claude/agent-memory-seed/individual/AS-04-security-scanner.md
@@ -1,0 +1,46 @@
+# Agent Memory: AS-04 (security-scanner)
+Last updated: 2026-03-25
+
+## Rol
+Escanea vulnerabilidades de seguridad (OWASP Top 10). Solo lectura — genera reportes, no modifica código.
+
+## Vulnerabilidades conocidas (tracking)
+| Fecha | Tipo (OWASP) | Archivo | Severidad | Status | Resolución |
+|-------|-------------|---------|-----------|--------|------------|
+| (ninguna aún) | — | — | — | — | — |
+
+## Falsos positivos conocidos (NO reportar)
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| DOMPurify.sanitize() + dangerouslySetInnerHTML | Sanitizado antes de render — es seguro |
+| Supabase ANON_KEY en código frontend | Es público por diseño (no es secret) |
+
+## Patrones seguros validados
+| Pattern | Verificado | Notas |
+|---------|-----------|-------|
+| DOMPurify para todo output AI | — | Decisión documentada en ai-rag.md |
+| Dual token (ANON_KEY + X-Access-Token) | — | Arquitectura definitiva de auth |
+| RLS como segunda capa de defensa | — | Complementa middleware/auth.ts |
+
+## Áreas de foco (dónde buscar primero)
+1. `components/` — buscar dangerouslySetInnerHTML sin DOMPurify
+2. `routes/` — buscar queries con concatenación de strings (SQL injection)
+3. `middleware/` — verificar CSP y CORS
+4. `lib/` — buscar secrets hardcodeados
+5. `services/` — verificar que inputs de usuario se validen
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory-seed/individual/AS-05-cors-headers.md
+++ b/.claude/agent-memory-seed/individual/AS-05-cors-headers.md
@@ -1,0 +1,53 @@
+# Agent Memory: AS-05 (cors-headers)
+Last updated: 2026-03-25
+
+## Rol
+Agente de seguridad de transporte: mantiene la configuración de CORS, Content-Security-Policy, headers HTTP de seguridad y hardening contra XSS en middleware/cors.ts, middleware/security.ts, vercel.json y lib/sanitize.ts.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/auth.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- CORS: whitelist explícita de orígenes — nunca `*` en producción
+- CSP: directivas restrictivas por defecto (`default-src 'self'`), ampliar solo lo estrictamente necesario
+- HSTS: `max-age` mínimo de 1 año (31536000) + `includeSubDomains`
+- X-Frame-Options: `DENY` por defecto; `SAMEORIGIN` solo si hay iframes propios justificados
+- `X-Content-Type-Options: nosniff` siempre activo
+- DOMPurify para sanitizar HTML generado por usuarios antes de cualquier renderizado
+- vercel.json para headers de seguridad en despliegue serverless: mantener sincronizado con middleware/security.ts
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs | Eliminar antes de commit |
+| `Access-Control-Allow-Origin: *` en producción | Anula la protección CORS, permite peticiones desde cualquier origen | Whitelist explícita de dominios permitidos |
+| CSP permisiva con `unsafe-inline` o `unsafe-eval` | Neutraliza la protección contra XSS | Usar nonces o hashes para scripts inline si son imprescindibles |
+| Renderizar HTML de usuario sin sanitizar | Vectores de XSS almacenado | Siempre pasar por DOMPurify antes de `dangerouslySetInnerHTML` |
+| Desincronizar headers de vercel.json y middleware/security.ts | Comportamiento diferente entre entornos local y producción | Actualizar ambos archivos en el mismo commit |
+| Modificar archivos fuera de `middleware/cors.*`, `middleware/security.*`, `vercel.json`, `lib/sanitize.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/BL-01-stripe-checkout.md
+++ b/.claude/agent-memory-seed/individual/BL-01-stripe-checkout.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-01 (stripe-checkout)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración Stripe Checkout de AXON: mantiene la creación de sesiones de checkout, el portal de cliente de Stripe, y la lógica de gestión de suscripciones en el backend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flujo estándar: frontend solicita sesión → backend crea checkout session → redirect a Stripe → webhook confirma pago.
+- `lib/stripe.ts` inicializa el cliente Stripe y exporta helpers reutilizables — siempre usar estos helpers, no instanciar Stripe directamente en rutas.
+- Modo test en desarrollo: `STRIPE_SECRET_KEY` con prefijo `sk_test_` — verificar antes de ejecutar.
+- Variables de entorno: `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`.
+- Customer Portal para que el usuario gestione suscripción, método de pago y facturas sin pasar por código propio.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear API keys de Stripe | Exposición de credenciales en el repo | Variables de entorno exclusivamente |
+| Procesar confirmación de pago en esta zona | Responsabilidad de BL-02 (webhooks) | No duplicar lógica — dejar que el webhook la maneje |
+| Modificar lógica de planes (precios, features) | Zona de BL-04 | Escalar al lead |
+| Usar `any` en TypeScript | Rompe type safety | Tipar con los tipos de `@stripe/stripe-js` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/BL-02-stripe-webhooks.md
+++ b/.claude/agent-memory-seed/individual/BL-02-stripe-webhooks.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-02 (stripe-webhooks)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en los webhook handlers de Stripe de AXON — mantiene la recepción, validación HMAC y procesamiento de eventos de pago, asegurando que los cambios de suscripción se reflejen correctamente en la base de datos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `stripe.webhooks.constructEvent()` para validar firma y parsear evento — nunca parsear manualmente.
+- El body del request debe llegar como raw buffer (no parseado por JSON middleware) para que la validación HMAC funcione.
+- Idempotencia: verificar `event.id` antes de procesar para evitar efectos dobles del mismo evento.
+- Retornar 200 rápidamente y procesar async si la operación es costosa — Stripe reintenta si no recibe 200.
+- Eventos clave: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_succeeded`, `invoice.payment_failed`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Procesar evento sin validar firma HMAC | Permite inyección de eventos falsos | Siempre usar `stripe.webhooks.constructEvent()` con `STRIPE_WEBHOOK_SECRET` |
+| Parsear body como JSON antes de validación | Rompe el cálculo HMAC | Usar raw buffer middleware antes de este handler |
+| No manejar idempotencia | El mismo evento procesado dos veces puede duplicar cobros/actualizaciones | Verificar `event.id` contra registro previo |
+| Modificar lógica de checkout | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de planes | Zona de BL-04 | Escalar al lead |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/BL-03-billing-frontend.md
+++ b/.claude/agent-memory-seed/individual/BL-03-billing-frontend.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-03 (billing-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en la interfaz de facturación de AXON — mantiene los componentes de UI que muestran el estado de suscripción del owner, comparación de planes, e integración con el flujo de checkout de Stripe desde el frontend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- TanStack Query para server state de suscripciones — mantiene el estado sincronizado con el backend.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Flujo estándar: ver plan actual → seleccionar nuevo plan → redirect a Stripe Checkout → webhook actualiza estado.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP.
+- TypeScript strict, no `any`, no `console.log`, commits atómicos.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Llamar a la Stripe API directamente desde el frontend | Los secrets de Stripe no deben estar en el cliente | Toda llamada a Stripe pasa por el backend (BL-01) |
+| Modificar lógica de checkout backend | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de webhooks | Zona de BL-02 | Escalar al lead |
+| Modificar lógica de planes | Zona de BL-04 | Escalar al lead |
+| Usar fetch directo en vez de `apiCall()` | Rompe el patrón centralizado | Usar `apiCall()` de `lib/api.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/BL-04-billing-plans.md
+++ b/.claude/agent-memory-seed/individual/BL-04-billing-plans.md
@@ -1,0 +1,46 @@
+# Agent Memory: BL-04 (billing-plans)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en la gestión de planes de suscripción de AXON — mantiene el CRUD de planes, configuración por institución, planes por defecto del sistema, y la interfaz de administración de planes para owners.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `pa-plans.ts` centraliza todas las llamadas a la API de planes — no llamar a endpoints de planes desde otros archivos directamente.
+- Planes globales (default) + planes institucionales personalizados — el sistema soporta ambos niveles.
+- Cada plan define nombre, descripción, precio mensual/anual, límites (usuarios, storage, modelos) y features habilitadas.
+- Default plans se asignan automáticamente a nuevas instituciones — mantener compatibilidad hacia atrás.
+- TanStack Query para server state de planes en `OwnerPlansPage.tsx`.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar lógica de checkout | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de webhooks | Zona de BL-02 | Escalar al lead |
+| Cambiar esquema de base de datos de planes | Fuera de zona | Escalar a IF-04 |
+| Eliminar campos de un plan sin verificar consumidores | Puede romper checkout sessions o webhook processing | Verificar uso en BL-01 y BL-02 antes de cambios destructivos |
+| Usar fetch directo en vez de `apiCall()` | Rompe el patrón centralizado | Usar `apiCall()` de `lib/api.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/DG-01-dashboard-student.md
+++ b/.claude/agent-memory-seed/individual/DG-01-dashboard-student.md
@@ -1,0 +1,46 @@
+# Agent Memory: DG-01 (dashboard-student)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del dashboard del estudiante: KPI cards, heatmap de actividad, donut de dominio (mastery), racha de estudio y graficos estadisticos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `<ResponsiveContainer>` de Recharts como wrapper para todos los graficos para garantizar responsividad.
+- `DashboardView` orquesta el layout; los widgets individuales (`StatsCards`, `ActivityHeatMap`, etc.) permanecen desacoplados.
+- El hook `useMasteryOverviewData` centraliza la transformacion de datos para `MasteryOverview` — no duplicar esa logica en el componente.
+- `WelcomeView` (~648L) es el componente mas grande: mantener subcomponentes pequeños y bien delimitados dentro de el.
+- Commits atomicos: un cambio logico por commit.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar Chart.js, D3 u otra libreria de graficos | Solo Recharts esta permitido | `<BarChart>`, `<PieChart>`, `<LineChart>` de Recharts |
+| CSS Modules o styled-components | Inconsistente con el stack del proyecto | Tailwind CSS exclusivamente |
+| `any` o `// @ts-ignore` | Rompe el contrato de TypeScript estricto | Tipar correctamente o crear interfaces |
+| Duplicar logica de `hooks/` o `lib/` | Genera inconsistencias y deuda tecnica | Importar el hook o utilidad existente |
+| Hardcodear datos en componentes | Dificulta mantenimiento | Obtener datos desde hooks tipados |
+| Modificar archivos fuera de `components/dashboard/`, `pages/DashboardPage.tsx`, `components/content/DashboardView.tsx`, `components/content/WelcomeView.tsx` | Viola el aislamiento de agente | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/DG-02-dashboard-professor.md
+++ b/.claude/agent-memory-seed/individual/DG-02-dashboard-professor.md
@@ -1,0 +1,46 @@
+# Agent Memory: DG-02 (dashboard-professor)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del dashboard del profesor: pagina principal, panel de analiticas de quizzes, gamificacion del profesor y graficos de rendimiento estudiantil.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `useQuizAnalytics` (~184L) consume la API, transforma datos crudos a estructuras Recharts y maneja carga/error/vacio — mantener esa separacion de responsabilidades.
+- Los datos de `useQuizAnalytics` deben estar memoizados con `useMemo` para evitar re-renders costosos.
+- `QuizAnalyticsPanel` (~204L) solo presenta datos; no contiene logica de transformacion.
+- `ProfessorGamificationPage` (~103L) consume datos del backend de gamificacion (DG-04) — nunca modifica logica de XP o badges.
+- `ProfessorDashboardPage` orquesta widgets del profesor; delegar la logica a componentes y hooks especializados.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Modificar `components/gamification/` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Logica de XP o badges en este agente | Responsabilidad de DG-03/DG-04 | Consumir datos via API, nunca calcularlos |
+| `useQuizAnalytics` sin `useMemo` | Re-renders innecesarios en tablas de datos grandes | Memoizar siempre el resultado del hook |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente |
+| Llamadas directas a la API sin el hook | Duplicacion de logica de transformacion | Usar `useQuizAnalytics` como unica fuente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/DG-03-gamification-engine.md
+++ b/.claude/agent-memory-seed/individual/DG-03-gamification-engine.md
@@ -1,0 +1,47 @@
+# Agent Memory: DG-03 (gamification-engine)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la capa frontend del sistema de gamificacion: XP, badges, niveles, rachas, combos, metas diarias, celebraciones y el contexto global de gamificacion.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Las actualizaciones de XP deben ser **optimistas**: actualizar la UI inmediatamente via `GamificationContext.addXP()` y revertir si la API falla.
+- Todas las constantes de gamificacion (niveles, umbrales, cap diario de XP) viven en `lib/xp-constants.ts` — nunca hardcodear valores en componentes.
+- Los componentes consumen el estado global via `useGamification()` — no acceder directamente al contexto con `useContext`.
+- `GamificationContext` (~238L) es la fuente unica de verdad: `addXP()`, `checkBadge()`, `refreshFromServer()` son las unicas entradas al estado.
+- Framer Motion solo para animaciones complejas (`LevelUpCelebration`, `XPPopup`); el resto usa clases `transition` y `animate-` de Tailwind.
+- `useSessionXP` (~265L) trackea XP localmente y sincroniza con el backend periodicamente — no llamar a la API de XP directamente desde componentes.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear valores de XP o niveles en componentes | Inconsistencia cuando cambian los umbrales | Importar desde `lib/xp-constants.ts` |
+| Framer Motion para animaciones simples | Overhead innecesario en el bundle | Tailwind `transition` / `animate-` |
+| Modificar `services/gamificationApi.ts` o `types/gamification.ts` | Ownership de DG-04 | Solo lectura; coordinar con DG-04 si el contrato debe cambiar |
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Actualizar XP sin mecanismo de reversion | UI inconsistente ante errores de red | Siempre implementar rollback en `GamificationContext` |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/DG-04-gamification-backend.md
+++ b/.claude/agent-memory-seed/individual/DG-04-gamification-backend.md
@@ -1,0 +1,47 @@
+# Agent Memory: DG-04 (gamification-backend)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la capa de API y servicios del sistema de gamificacion: cliente API del frontend, tipos compartidos, rutas del backend y servicio de gamificacion del servidor.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Toda la logica de negocio va en `gamification-service.ts`; las rutas (`routes/gamification*.ts`) solo validan inputs y delegan.
+- `types/gamification.ts` es el contrato entre frontend y backend — cualquier cambio requiere coordinacion explicita con DG-03 antes de implementar.
+- Cada endpoint en `gamificationApi.ts` tiene tipado explicito de request y response (sin `any`).
+- `try/catch` con manejo explicito de errores en cada llamada API del cliente.
+- Las constantes de XP del backend (`XP_TABLE`, `LEVEL_THRESHOLDS`) deben mantenerse sincronizadas con `lib/xp-constants.ts` del frontend (DG-03).
+- Los endpoints validan inputs antes de procesar — usar validacion en la capa de rutas, nunca en el servicio.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Logica de negocio en las rutas Express/Hono | Dificulta testing y reutilizacion | Mover toda la logica a `gamification-service.ts` |
+| Cambiar `types/gamification.ts` sin avisar a DG-03 | Rompe el contrato frontend-backend | Coordinar el cambio con DG-03 antes de implementar |
+| `XP_TABLE` o `LEVEL_THRESHOLDS` desincronizados entre frontend y backend | Inconsistencias visuales en XP y niveles | Revisar `lib/xp-constants.ts` antes de modificar constantes backend |
+| Modificar `components/gamification/`, `context/GamificationContext.tsx`, `hooks/useSessionXP.ts`, `hooks/useGamification.ts` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Endpoints sin validacion de inputs | Vulnerabilidades y errores dificiles de depurar | Validar siempre en la capa de rutas |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente con las interfaces de `types/gamification.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/DG-05-leaderboard.md
+++ b/.claude/agent-memory-seed/individual/DG-05-leaderboard.md
@@ -1,0 +1,48 @@
+# Agent Memory: DG-05 (leaderboard)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del leaderboard: pagina completa con podio, tabla paginada y filtros de periodo, y tarjeta resumen embebible en el dashboard del estudiante.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Los datos se obtienen exclusivamente via `gamificationApi.getLeaderboard()` — nunca llamar a `fetch` directamente.
+- El podio (top 3) es visualmente diferenciado: 1ro al centro mas alto, 2do a la izquierda, 3ro a la derecha, con avatar, nombre y XP.
+- `LeaderboardPage` maneja dos periodos (`weekly`, `daily`) via tabs o selector — el periodo activo se controla como estado local del componente.
+- El scope por institucion es transparente para el agente: el endpoint ya filtra por `institutionId` del usuario autenticado.
+- Manejar explicitamente los tres estados: carga, error y lista vacia, en ambos componentes (`LeaderboardPage` y `LeaderboardCard`).
+- `LeaderboardCard` es un widget compacto: mostrar posicion actual, XP del periodo y top 3 — no replicar la funcionalidad completa de `LeaderboardPage`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Llamadas directas a `fetch` para el leaderboard | Bypasea el cliente API tipado | Usar `gamificationApi.getLeaderboard()` siempre |
+| Modificar `services/gamificationApi.ts` o `types/gamification.ts` | Ownership de DG-04 | Solo lectura; coordinar con DG-04 si se necesita un nuevo campo en `LeaderboardEntry` |
+| Modificar `context/GamificationContext.tsx` o `hooks/useGamification.ts` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Podio sin diferenciacion visual | Mala UX; el usuario no distingue los top 3 | Podio con alturas y estilos diferenciados por posicion |
+| No manejar estado vacio o error | UI rota cuando el leaderboard esta vacio o la API falla | Siempre incluir fallback de carga, error y lista vacia |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Usar `LeaderboardEntry` de `types/gamification.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/FC-01-flashcards-frontend.md
+++ b/.claude/agent-memory-seed/individual/FC-01-flashcards-frontend.md
@@ -1,0 +1,53 @@
+# Agent Memory: FC-01 (flashcards-frontend)
+Last updated: 2026-03-26
+
+## Rol
+Agente frontend de la sección Flashcards de AXON: implementa y modifica componentes React del módulo Flashcards (Student + Professor).
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | motion/react mock: use Proxy pattern from StudyHubHero.test.tsx, strip `initial/animate/transition/whileHover/whileTap/exit/layout` props. AnimatePresence renders children directly. | Copy from existing tests, don't reinvent |
+| 2026-03-26 | SessionScreen returns null + calls onBack when cards empty. Test both: container.innerHTML === '' AND onBack called. | Guard clause pattern: useEffect + early return null |
+| 2026-03-26 | Keyboard events on SessionScreen: use fireEvent.keyDown(window, ...) not on a specific element, because the component attaches listener to window | Check component source for addEventListener target |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP (nunca fetch directo)
+- TanStack Query para server state; hooks en `src/app/hooks/useFlashcard*.ts` y `useReview*.ts`
+- Commits atómicos: 1 commit por cambio lógico
+- Leer `agent-memory/flashcards.md` al inicio de sesión para contexto de sección
+- Verificar existencia de `src/app/components/content/flashcard/` antes de operar
+- Escalar al Arquitecto (XX-01) ante conflictos cross-section o decisiones fuera de zona
+- For flashcard component tests: mock motion/react with Proxy pattern, clsx as passthrough, lucide-react as spans with data-testid
+- SessionScreen props are all passed in (no hooks inside), making it easy to test with controlled props
+- RATINGS from flashcard-types is pure data -- mock with inline array to avoid import chain issues
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| `console.log` | Ruido en producción | Usar `logger` de `lib/logger.ts` |
+| `any` en TypeScript | Rompe strict mode | Tipar correctamente siempre |
+| `fetch` directo | Bypass de manejo de errores centralizado | `apiCall()` de `lib/api.ts` |
+| Glassmorphism / gradientes en botones | Fuera del design system AXON | Pill-shaped buttons, teal #14b8a6, rounded-2xl cards |
+| Modificar lógica en archivos de otra zona sin escalar | Viola aislamiento de agentes | Escalar al lead via SendMessage |
+| Reimplementar lógica FSRS en frontend | FSRS vive en `lib/fsrs-v4.ts` (backend) | Consumir via API |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/FC-02-flashcards-backend.md
+++ b/.claude/agent-memory-seed/individual/FC-02-flashcards-backend.md
@@ -1,0 +1,48 @@
+# Agent Memory: FC-02 (flashcards-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de la sección Flashcards de AXON: implementa y modifica CRUD de flashcards, FSRS scheduling, batch review y validación de reviews.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `ok()` / `err()` de `db.ts` para todas las respuestas de ruta
+- Usar `validateFields()` de `validate.ts` para validación de input
+- Hono framework para definición de rutas
+- SQL migrations con formato `YYYYMMDD_NN_descripcion.sql` en `supabase/migrations/`
+- Tests en `supabase/functions/server/tests/` con formato `*_test.ts`
+- Commits atómicos
+- Verificar existencia de `supabase/functions/server/lib/fsrs-v4.ts` al iniciar sesión
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| `any` en TypeScript | Rompe strict mode | Tipar correctamente siempre |
+| Modificar `crud.ts`, `index.ts`, `content-tree.ts` | Son infra-plumbing, fuera de zona | Escalar al lead |
+| Tocar `generate-smart.ts` | Infra-AI, fuera de zona | Escalar al lead |
+| Tocar `xp-hooks.ts` | Gamification, fuera de zona | Pedir via SendMessage |
+| Modificar `crud-factory.ts`, `db.ts`, `auth-helpers.ts` | Infra-plumbing | Escalar al lead |
+| Rutas sin validación de input | Vulnerabilidad y datos inconsistentes | Usar `validateFields()` siempre |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/FC-04-fsrs.md
+++ b/.claude/agent-memory-seed/individual/FC-04-fsrs.md
@@ -1,0 +1,45 @@
+# Agent Memory: FC-04 (flashcards-fsrs)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- FSRS v4 weights: w8=1.10, w11=2.18, w15=0.29, w16=2.61
+- Rating scale: 5-point (1-5) → 4-point GRADES (Again=0.0, Hard=0.35, Good=0.65, Easy=1.0)
+- Persistencia: localStorage para batches de review
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Los pesos FSRS son constantes calibradas | Cualquier cambio requiere aprobación explícita del usuario | Pesos ajustables dinámicamente |
+| 2026-03-25 | localStorage para persistencia de batches | Sobrevive recargas, no depende de backend | sessionStorage, IndexedDB |
+
+## Patrones que funcionan
+- useFlashcardEngine.ts como orquestador central del motor
+- grade-mapper.ts como traductor único de ratings → grades
+- useReviewBatch.ts para gestión de cola de reviews
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar weights sin tests | Los weights están calibrados matemáticamente | Siempre correr suite de tests antes y después |
+| await en persistencia de batch | Bloquea la UI durante navegación | Fire-and-forget con catch para errores |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/FC-05-flashcards-keywords.md
+++ b/.claude/agent-memory-seed/individual/FC-05-flashcards-keywords.md
@@ -1,0 +1,46 @@
+# Agent Memory: FC-05 (flashcards-keywords)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de keywords de AXON: gestiona popups de detalle, highlighting inline, conexiones semánticas, navegación cross-summary y badges de mastery.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `@floating-ui` para posicionamiento de popups y popovers (detección de bordes incluida)
+- React Query para queries de keywords; respetar patrones de cache existentes
+- Revisar popups y highlighting al iniciar sesión para entender estado actual
+- Verificar consistencia de tipos de conexión y sistema de mastery antes de cambios
+- Leer contratos de datos de FC-04 y FC-06 antes de tocar integraciones
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Reimplementar lógica de posicionamiento | `@floating-ui` ya la maneja y tiene edge-case coverage | Usar la API de `@floating-ui` |
+| Cambiar colores de Delta Mastery arbitrariamente | Son parte del design system | Coordinar con diseño antes de cambiar |
+| Agregar tipos de conexión sin migración de DB | Sistema soporta exactamente 10 tipos médicos | Migración requerida + coordinación |
+| Re-renders innecesarios en `KeywordHighlighterInline` | Componente crítico para performance | Memoizar, revisar dependencias de hooks |
+| Modificar archivos fuera de zona sin coordinación | Viola aislamiento de agentes | Coordinar explícitamente via SendMessage |
+| Perder contexto de usuario en navegación cross-summary | UX degradada | Mantener estado de navegación en hook `useKeywordNavigation` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/FC-06-flashcards-generation.md
+++ b/.claude/agent-memory-seed/individual/FC-06-flashcards-generation.md
@@ -1,0 +1,48 @@
+# Agent Memory: FC-06 (flashcards-generation)
+Last updated: 2026-03-25
+
+## Rol
+Agente de generación de flashcards con IA de AXON: gestiona el generador inteligente, priorización por NeedScore, targeting por BKT y generación por lotes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- NeedScore como criterio principal de priorización (no sobrescribir con lógica ad-hoc)
+- Hooks compartidos entre panel del profesor y generador del estudiante para mantener DRY
+- Manejo de errores parciales en batch: no perder cards ya generadas ante fallo parcial
+- Llamadas a IA con timeout y retry con backoff exponencial
+- Revisar generador y hooks al iniciar sesión para entender estado actual
+- Verificar ranking NeedScore y targeting BKT al iniciar sesión
+- Leer contratos de datos de FC-04 y FC-05 antes de tocar integraciones
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Sobrescribir NeedScore con lógica ad-hoc | Rompe la priorización inteligente del sistema | Extender NeedScore si se necesita ajuste |
+| Generar flashcards duplicadas por keyword en la misma sesión | Degrada la experiencia del alumno | Verificar duplicados antes de generar |
+| Llamadas a IA sin timeout ni retry | Fallos silenciosos y UX rota | Timeout explícito + backoff exponencial |
+| Modificar archivos fuera de zona sin coordinación | Viola aislamiento de agentes | Coordinar explícitamente via SendMessage |
+| Duplicar lógica entre `AiGeneratePanel.tsx` y `SmartFlashcardGenerator.tsx` | Viola principio DRY | Extraer a hook compartido (`useSmartGeneration`, `useQuickGenerate`) |
+| Ignorar errores parciales en batch | Pérdida de cards ya generadas | Manejar errores parciales explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/IF-01-infra-plumbing.md
+++ b/.claude/agent-memory-seed/individual/IF-01-infra-plumbing.md
@@ -1,0 +1,45 @@
+# Agent Memory: IF-01 (infra-plumbing)
+Last updated: 2026-03-25
+
+## Rol
+Agente de infraestructura backend de AXON: mantiene los cimientos (CRUD factory, DB layer, auth helpers, validation, rate limiting, rutas de contenido compartidas y búsqueda) que todos los demás agentes backend usan.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `crud-factory.ts` genera CRUD endpoints con scoping automático por institución — usarlo en lugar de endpoints manuales.
+- `ok()` / `err()` de `db.ts` para respuestas consistentes en todos los endpoints.
+- `validateFields()` de `validate.ts` antes de cualquier operación de escritura.
+- Rate limiting via sliding window 120 req/min/user — no reimplementar en rutas individuales.
+- Antes de cambiar interfaces públicas de `crud-factory.ts`, `db.ts` o `auth-helpers.ts`, avisar al lead (alto impacto cross-agente).
+- Cambios en `validate.ts` son low-risk y no requieren escalación.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar interfaces públicas de `crud-factory.ts` sin avisar | Rompe todos los agentes que lo importan | Avisar al lead antes de cambiar firmas públicas |
+| Registrar rutas nuevas en `index.ts` sin avisar | Alto impacto en el servidor de entrada | Escalar al lead antes de tocar routes registration |
+| Reimplementar validación fuera de `validate.ts` | Duplicación, riesgo de inconsistencias | Usar `validateFields()` / `isUuid()` / `isEmail()` del módulo existente |
+| Tocar archivos fuera de la zona de ownership sin coordinación | Conflictos con otros agentes | Escalar al arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/IF-03-infra-ai.md
+++ b/.claude/agent-memory-seed/individual/IF-03-infra-ai.md
@@ -1,0 +1,44 @@
+# Agent Memory: IF-03 (infra-ai)
+Last updated: 2026-03-25
+
+## Rol
+Agente de infraestructura AI de AXON: mantiene los AI providers (OpenAI, Gemini, Claude), el RAG pipeline, el pipeline de smart generation, y todas las rutas AI del backend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Embeddings con OpenAI `text-embedding-3-large` (1536d) — no mezclar con el modelo antiguo de Gemini (768d).
+- Gemini 2.5 Flash para generación de contenido; Claude para análisis — respetar la división por caso de uso.
+- RAG con multi-query + HyDE + re-ranking + strategy selection en `retrieval-strategies.ts`.
+- `generate-smart.ts` es compartido por Quiz y Flashcards — coordinar con quiz-ai y flashcards-ai antes de modificarlo.
+- `ai-normalizers.ts` como capa de normalización de respuestas de distintos proveedores — no normalizar en las rutas individuales.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `generate-smart.ts` sin coordinar con quiz-ai y flashcards-ai | Rompe ambos módulos simultáneamente | Avisar a ambos agentes y coordinar el cambio |
+| Llamar providers AI directamente desde rutas sin pasar por los módulos de provider | Lógica duplicada, retry/normalización inconsistente | Usar `gemini.ts`, `claude-ai.ts`, `openai-embeddings.ts` como wrappers |
+| Mezclar dimensiones de embeddings (768d vs 1536d) | Búsqueda vectorial rota | Usar siempre `text-embedding-3-large` (1536d) |
+| Tocar archivos fuera de la zona de ownership sin coordinación | Conflictos con otros agentes | Escalar al arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/IF-04-infra-database.md
+++ b/.claude/agent-memory-seed/individual/IF-04-infra-database.md
@@ -1,0 +1,45 @@
+# Agent Memory: IF-04 (infra-database)
+Last updated: 2026-03-25
+
+## Rol
+Agente de migraciones y esquema de base de datos de AXON: administra los archivos SQL en `supabase/migrations/`, la documentación de esquema en `database/schema-*.md`, y garantiza la integridad de las 50+ tablas del sistema PostgreSQL con pgvector.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Migraciones idempotentes con `IF NOT EXISTS` / `IF EXISTS` — evitan fallos en re-ejecución.
+- Comentarios SQL descriptivos en cada migración — facilitan auditoría y revisión.
+- RLS policies en la misma migración que la tabla o en una migración dedicada — nunca dejar tablas sin RLS.
+- Toda nueva tabla con `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`, `created_at`, `updated_at`.
+- Índices justificados con el patrón de query que optimizan — documentarlo en el comentario del índice.
+- Verificar que ningún servicio consume una columna/tabla antes de hacer DROP.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar migraciones ya aplicadas | Rompe consistencia con entornos existentes | Crear nueva migración correctiva |
+| Migraciones sin transacción para múltiples statements | Deja el esquema en estado inconsistente si falla a mitad | Usar `BEGIN; ... COMMIT;` |
+| Crear tabla sin políticas RLS | Datos de usuario expuestos | Incluir RLS en la misma migración o en dedicada inmediata |
+| DROP sin verificar consumidores | Rompe servicios en producción | Auditar archivos de servicios y tipos TS antes de borrar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/IMPROVEMENT-VOTES.md
+++ b/.claude/agent-memory-seed/individual/IMPROVEMENT-VOTES.md
@@ -1,0 +1,172 @@
+# Agent Improvement Votes
+Date: 2026-03-25 | Voters: 20 agents
+
+---
+
+## Conteo de votos por tema (agrupado por similitud)
+
+### 1. AUTO-VINCULAR QG FAILURES → LECCIONES (14 votos) ⭐⭐⭐
+> Que cada fallo del quality-gate genere automáticamente una lección en la memoria del agente, sin esperar el post-mortem manual.
+
+| Votante | Propuesta específica |
+|---------|---------------------|
+| BL-01 | Vincular cada QG failure a plantilla de lección con pasos de prevención |
+| FC-05 | Capturar lecciones post-sesión en formato estructurado sin esperar post-mortem |
+| MG-01 | Registrar automáticamente cada error QG con tipo en tabla de lecciones |
+| QZ-01 | Causal Analysis — agregar columna "Root Cause" al Error Ledger |
+| DG-03 | Feedback Loop XX-02 → DG-03 — copiar feedback del QG a lecciones |
+| XX-02 | Tabla de Lecciones Indexada por código de error QG (zone/ts/spec/etc) |
+| 3D-01 | Automatic Lesson Ingestion — webhook que capture fallos del QG |
+| AI-01 | Retroalimentación granular post-QG — motivo específico, no solo PASS/FAIL |
+| XX-06 | Feedback loop de lecciones con prevención explícita |
+| SM-04 | Pattern-First Memory Capture — registrar anti-patterns tras cada QG failure |
+| AS-01 | Lecciones preventivas con triggers específicos observables en código |
+| IF-01 | Pattern-library checklist pre-commit |
+| FC-04 | Capturar checklist de tests pre-deploy por archivo |
+| DG-01 | Vincular patrones a tasas de error QG |
+
+---
+
+### 2. MÉTRICAS DE EFECTIVIDAD DE LECCIONES (9 votos) ⭐⭐
+> Trackear si las lecciones registradas realmente previenen errores futuros. ¿La lección funcionó o no?
+
+| Votante | Propuesta |
+|---------|-----------|
+| XX-02 | Columna "Prevenciones activas" — cuántos FAIL se evitaron por esta regla |
+| BL-01 | Métrica de "confianza de lección" basada en recurrencia |
+| AS-04 | Métricas de resolución — cuántos hallazgos resueltos vs ignorados |
+| FC-05 | Sistema de alertas de divergencia — QG pass drop >20% |
+| AI-02 | Ventana deslizante de confianza por patrón (0-100%) |
+| XX-07 | Retroalimentación de tendencias — deuda que no se accionó |
+| DG-03 | Métricas de Error por Categoría en memoria individual |
+| DG-01 | Patrones con columnas de QG pass rate y fails by type |
+| AS-04 | Tendencia en vulnerabilidades — velocidad de remediación |
+
+---
+
+### 3. DECISIONES TÉCNICAS DOCUMENTADAS CON REASONING (7 votos) ⭐
+> Registrar no solo QUÉ se decidió sino POR QUÉ, para evitar re-litigar decisiones.
+
+| Votante | Propuesta |
+|---------|-----------|
+| DG-03 | Sección "Decisiones técnicas" con fecha, por qué y contexto |
+| DG-01 | Registrar reasoning de cada patrón (ej: "WelcomeView monolítica porque...") |
+| 3D-01 | Decision Log por Zona — por qué se eligió cada patrón |
+| AI-02 | Capturar contexto de decisión en tiempo real — opciones y alternativas desechadas |
+| FC-04 | Coordinación log — documentar cuándo se coordinó con otros agentes |
+| XX-04 | Error Ledger con decisiones de canonicidad — quién decidió y por qué |
+| ST-05 | Sesión de retro bimestral de patrones a evitar |
+
+---
+
+### 4. CROSS-AGENT IMPACT TRACKING (6 votos) ⭐
+> Detectar cuándo los cambios de un agente rompen a otros.
+
+| Votante | Propuesta |
+|---------|-----------|
+| AS-01 | Métricas de impacto cruzado — cuántos agentes fallaron por cambios de auth |
+| IF-01 | Cross-agent dependency tracking — mapear qué agentes importan cada archivo |
+| SM-04 | Pre-cache 28 importadores de ContentTreeContext para detectar breaking changes |
+| ST-05 | Captura métrica de cross-agent impact cuando hooks rompen consumidores |
+| XX-04 | Checklist de consumidores vinculado a tabla de duplicaciones |
+| FC-04 | Coordinación log con FC-05/FC-06 sobre tipos compartidos |
+
+---
+
+### 5. AUTO-ESCALACIÓN POR TRIGGERS (5 votos)
+> Reglas automáticas tipo "si X pasa → hacer Y", sin depender de intuición.
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-01 | Tabla "si XYZ ocurre → acción automática" en memoria |
+| MG-01 | Triggers de auto-escalación predefinidos (si error ts > 2 → escalar) |
+| IF-01 | Validador en git hooks que bloquee commits fuera de zona |
+| 3D-01 | Scope Violation Detector que force retroalimentación antes de merge |
+| AS-01 | Validación pre-sesión de supuestos clave (dual token vigente) |
+
+---
+
+### 6. AUDITORÍA ADAPTATIVA POR SEVERIDAD (4 votos)
+> No aplicar el mismo nivel de checks a cambios triviales vs críticos.
+
+| Votante | Propuesta |
+|---------|-----------|
+| XX-02 | Calibrar profundidad de checks según impacto (spec=100%, docs=mínimo) |
+| AI-01 | Validación cruzada con XX-02 antes de registrar lección |
+| DG-01 | Alertas técnicas pre-QG para captar deuda temprana |
+| XX-07 | Métricas de impacto por tipo de hallazgo |
+
+---
+
+### 7. PATTERN DIGEST SEMANAL (3 votos)
+> Resumen periódico de patrones exitosos y anti-patterns por sección.
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-01 | Weekly Pattern Digest — compilar patrones y anti-patterns por sección |
+| XX-06 | Baseline dinámico actualizado — capturar y comparar deltas en cada sesión |
+| QZ-04 | Dashboard de health interno — exponer métricas operacionales |
+
+---
+
+### 8. DOMAIN-SPECIFIC METRICS (3 votos)
+> Métricas específicas del dominio técnico del agente (no solo QG genérico).
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-04 | Capturar transiciones de estado con timestamps y tasa de abandono |
+| QZ-04 | Registrar divergencias BKT vs desempeño real |
+| AI-01 | Métricas de calidad de chunks (cobertura semántica, overlap tokens) |
+
+---
+
+## Ranking final por votos
+
+| # | Mejora | Votos | Prioridad |
+|---|--------|-------|-----------|
+| 1 | **Auto-vincular QG failures → lecciones** | **14** | P0 |
+| 2 | **Métricas de efectividad de lecciones** | **9** | P1 |
+| 3 | **Decisiones técnicas con reasoning** | **7** | P1 |
+| 4 | **Cross-agent impact tracking** | **6** | P2 |
+| 5 | **Auto-escalación por triggers** | **5** | P2 |
+| 6 | Auditoría adaptativa por severidad | 4 | P3 |
+| 7 | Pattern digest semanal | 3 | P3 |
+| 8 | Domain-specific metrics | 3 | P3 |
+
+---
+
+## Implementación recomendada (top 3 por votos)
+
+### P0: Auto-vincular QG failures → lecciones (14 votos)
+
+Agregar al protocolo del Quality Gate (XX-02) y al post-mortem del Arquitecto:
+
+Cuando XX-02 emite NEEDS FIX o BLOCK:
+1. Generar automáticamente una fila de lección con formato:
+   ```
+   | Fecha | QG Check (zone/ts/spec/tests/git/compat) | Descripción | Prevención | Recurred? |
+   ```
+2. Insertar en el archivo de memoria individual del agente que falló
+3. Insertar en el Error Ledger de AGENT-METRICS.md
+4. Si el error matchea una lección previa → marcar Recurred? YES
+
+**Archivos a modificar:** `agents/quality-gate.md` (agregar paso de auto-registro), `MULTI-AGENT-PROCEDURE.md` (simplificar post-mortem)
+
+### P1: Métricas de efectividad de lecciones (9 votos)
+
+Agregar a cada memoria individual una tabla:
+```
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+```
+Actualizar después de cada sesión donde el agente NO repitió el error.
+
+### P1: Decisiones técnicas con reasoning (7 votos)
+
+Agregar sección a la memoria individual:
+```
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+```

--- a/.claude/agent-memory-seed/individual/MG-01-telegram-bot.md
+++ b/.claude/agent-memory-seed/individual/MG-01-telegram-bot.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-01 (telegram-bot)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración Telegram de AXON: mantiene el flujo de vinculación de cuentas de estudiantes con Telegram, el envío de notificaciones vía bot, y la interfaz de configuración en el perfil del estudiante.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flujo de vinculación: estudiante solicita código → bot recibe código → backend valida y vincula cuenta.
+- Link codes: códigos temporales de 6 dígitos — corta vida, validados en el backend.
+- Status polling: el frontend hace polling para detectar cuando la vinculación se completa — no usar websockets para esto.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca `fetch` directo.
+- Variables de entorno para tokens de bot — nunca hardcodear.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear tokens de Telegram bot | Exposición de credenciales | Variables de entorno (`TELEGRAM_BOT_TOKEN`) |
+| Usar `any` en TypeScript | Rompe type safety | Tipar correctamente la respuesta de Telegram Bot API |
+| `console.log` en producción | Leaks de datos, ruido en logs | Usar el logger del sistema si existe |
+| Modificar lógica de otros canales (WhatsApp, notificaciones) | Fuera de zona — conflictos | Escalar al lead vía SendMessage |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/MG-02-whatsapp-bot.md
+++ b/.claude/agent-memory-seed/individual/MG-02-whatsapp-bot.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-02 (whatsapp-bot)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración WhatsApp de AXON: mantiene la conexión con WhatsApp Cloud API de Meta, el procesamiento de mensajes entrantes y salientes, la verificación de webhooks HMAC, y la lógica de feature flag que controla la disponibilidad del canal.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Webhook verification: responder correctamente al challenge GET de Meta antes de procesar eventos.
+- HMAC validation con `WHATSAPP_APP_SECRET` en cada request entrante — siempre validar antes de procesar.
+- Feature-flagged: verificar el flag antes de activar cualquier lógica de envío de mensajes.
+- Parsear mensajes entrantes según tipo (texto, template, interactivo) antes de enrutar.
+- Variables de entorno: `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Procesar webhook sin validar firma HMAC | Permite inyección de eventos falsos | Siempre verificar `X-Hub-Signature-256` antes de cualquier procesamiento |
+| Hardcodear tokens o secrets de Meta | Exposición de credenciales | Variables de entorno exclusivamente |
+| Modificar feature flags directamente | Fuera de zona — impacto cross-institución | Escalar al lead para cambios en configuración de feature flags |
+| Usar `any` en TypeScript | Rompe type safety | Tipar la estructura de payloads de WhatsApp Cloud API |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/MG-03-notifications.md
+++ b/.claude/agent-memory-seed/individual/MG-03-notifications.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-03 (notifications)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de notificaciones in-app de AXON: mantiene el sistema de toasts (sonner), notificaciones de gamificación, y desarrolla la futura infraestructura de notificaciones persistentes con bandeja de entrada.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Toast system actual: `sonner` para feedback inmediato — usar su API para todos los toasts, no crear wrappers innecesarios.
+- Notificaciones de gamificación como toasts especiales — logros, badges, streaks con diseño diferenciado.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Usar `apiCall()` de `lib/api.ts` — nunca fetch directo.
+- Archivos nuevos de notificaciones: crearlos en `components/shared/` o `services/` sin escalar.
+- TanStack Query cuando se implemente la persistencia de notificaciones.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Crear sistema de toasts paralelo a `sonner` | Duplicación, UX inconsistente | Extender `sonner` con custom toasts |
+| Modificar sistema de gamificación fuera del contexto de notificaciones | Fuera de zona | Escalar al lead |
+| Usar colores fuera del design system | Inconsistencia visual | Usar teal `#14b8a6` y los tokens del design system |
+| `console.log` en producción | Ruido en logs | Eliminar antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/MG-04-messaging-backend.md
+++ b/.claude/agent-memory-seed/individual/MG-04-messaging-backend.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-04 (messaging-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente de la lógica backend compartida de mensajería de AXON: mantiene la infraestructura común de todos los canales de comunicación (Telegram, WhatsApp, notificaciones), la configuración de canales por institución, y la interfaz de administración de mensajería.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `lib/messaging/` como capa compartida: formateo de mensajes, templates, routing al canal correcto — toda lógica cross-canal va aquí.
+- Cada canal (Telegram, WhatsApp) implementa una interfaz común de envío — respetar ese contrato al agregar lógica.
+- Channel settings por institución: cada institución puede habilitar/deshabilitar canales individualmente.
+- AdminMessagingSettingsPage permite enviar mensajes de prueba para verificar configuración — no bypassear esto en debug.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Usar `apiCall()` de `lib/api.ts`, nunca fetch directo.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Poner lógica específica de Telegram en `lib/messaging/` | Viola la separación de zonas | Lógica Telegram → zona MG-01; aquí solo lógica común |
+| Poner lógica específica de WhatsApp en `lib/messaging/` | Viola la separación de zonas | Lógica WhatsApp → zona MG-02; aquí solo lógica común |
+| Modificar middleware de auth | Fuera de zona, alto impacto | Escalar al lead |
+| Cambiar esquema de base de datos de mensajería sin coordinación | Rompe múltiples canales | Escalar al lead y coordinar con IF-04 |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/QZ-01-quiz-frontend.md
+++ b/.claude/agent-memory-seed/individual/QZ-01-quiz-frontend.md
@@ -1,0 +1,51 @@
+# Agent Memory: QZ-01 (quiz-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend de la sección Quiz de AXON — implementa y modifica componentes React del módulo Quiz (Student + Professor).
+
+## Parámetros críticos
+- **Stack**: React 18 + TypeScript strict + Tailwind v4
+- **BKT**: v4 para knowledge tracing (backend en `lib/bkt-v4.ts`)
+- **Quiz types**: MCQ, True/False, Open-ended
+- **Design system**: Georgia headings, Inter body, teal `#14b8a6`, pill buttons, `rounded-2xl` cards
+- **API**: usar siempre `apiCall()` de `lib/api.ts`
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Question renderers en `components/student/renderers/` — un renderer por tipo de pregunta
+- Estado de sesión via hooks: `useQuizSession`, `useQuizNavigation`, `useQuizBackup`
+- Professor side: `QuizFormModal` para crear/editar, `QuizzesManager` para listar
+- Hooks de queries: `useQuiz*.ts`, `useQuestion*.ts` en `src/app/hooks/queries/`
+- Archivos clave de sesión: `QuizView.tsx`, `QuizSessionView.tsx`, `QuizResultsScreen.tsx`
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Viola TypeScript strict, rompe type safety | Tipar correctamente o usar `unknown` |
+| `console.log` en producción | Ruido en logs, posible leak de datos | Eliminar antes de commit |
+| Llamadas directas a fetch/axios | Bypasea interceptores y manejo de errores centralizado | Usar `apiCall()` de `lib/api.ts` |
+| Modificar archivos fuera de zona de ownership | Rompe aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/QZ-02-quiz-backend.md
+++ b/.claude/agent-memory-seed/individual/QZ-02-quiz-backend.md
@@ -1,0 +1,49 @@
+# Agent Memory: QZ-02 (quiz-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de la sección Quiz de AXON — implementa lógica de CRUD de quizzes/questions, BKT scoring y smart generation.
+
+## Parámetros críticos
+- **Framework**: Hono + TypeScript strict
+- **Respuestas**: `ok()` / `err()` para respuestas de API; `validateFields()` para validación de input
+- **Migrations**: naming `supabase/migrations/YYYYMMDD_NN_descripcion.sql`
+- **BKT**: v4 en `supabase/functions/server/lib/bkt-v4.ts` — es zona de ownership directa
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- CRUD via `crud-factory.ts` (read-only para este agente — no modificar)
+- Rutas quiz/question en `supabase/functions/server/routes/content/`
+- Quiz attempts tracked para analytics (consumidos por QZ-06)
+- Smart generation delega a `generate-smart.ts` (infra-ai owns it)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `generate-smart.ts` | Es zona de infra-ai, no de este agente | Leer para entender contrato, escalar al Arquitecto si hay cambio necesario |
+| Modificar `crud-factory.ts` | Es zona de infra-plumbing | Solo leer; escalar al Arquitecto (XX-01) |
+| Modificar `xp-hooks.ts` | Es zona de gamification | Solo leer; escalar al Arquitecto (XX-01) |
+| Respuestas ad-hoc sin `ok()`/`err()` | Rompe consistencia de contrato de API | Siempre usar helpers de respuesta del framework |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/QZ-03-quiz-tester.md
+++ b/.claude/agent-memory-seed/individual/QZ-03-quiz-tester.md
@@ -1,0 +1,50 @@
+# Agent Memory: QZ-03 (quiz-tester)
+Last updated: 2026-03-25
+
+## Rol
+Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz session, BKT logic, question rendering y smart generation.
+
+## Parámetros críticos
+- **Zona exclusiva**: solo Write en archivos de test
+- **Frontend tests**: `src/__tests__/quiz-*.test.ts`
+- **Backend tests**: `supabase/functions/server/tests/bkt_v4_test.ts`
+- **Comandos**:
+  - Frontend: `npm run test -- --testPathPattern=quiz`
+  - Backend: `deno test supabase/functions/server/tests/bkt_v4_test.ts`
+  - Verificación TS: `npm run build`
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Ejecutar `npm run build` siempre después de los tests para verificar TypeScript
+- Separar tests frontend (Jest/vitest) de backend (Deno) — entornos distintos
+- Naming `quiz-*.test.ts` para que el pattern de Jest los recoja automáticamente
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Escribir en archivos fuera de `__tests__/quiz-*` o `tests/bkt_v4_test.ts` | Viola zona de ownership | Solo escribir en archivos de test asignados |
+| Omitir `npm run build` tras los tests | TypeScript errors pueden quedar silenciosos | Siempre hacer build como paso final de verificación |
+| Tests sin casos de error/edge | Cobertura incompleta de BKT y quiz session | Incluir casos negativos y edge cases en cada suite |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/QZ-04-bkt.md
+++ b/.claude/agent-memory-seed/individual/QZ-04-bkt.md
@@ -1,0 +1,46 @@
+# Agent Memory: QZ-04 (quiz-adaptive)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- BKT v4: P_LEARN=0.18, P_FORGET=0.25, RECOVERY=3.0
+- Máquina de estados: 5 fases (idle, loading, answering, feedback, complete)
+- Tracking BKT: fire-and-forget (nunca bloquear UI)
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | BKT tracking es fire-and-forget | Las llamadas a bktApi se disparan sin await para no bloquear la UI | await bloqueante en el flujo del quiz |
+| 2026-03-25 | Máquina de estados de 5 fases es sagrada | Cualquier cambio requiere revalidar todas las transiciones | Máquina simplificada de 3 fases |
+
+## Patrones que funcionan
+- useQuizBkt.ts como wrapper limpio del modelo BKT
+- useBktStates.ts para estados derivados (mastery level, etc.)
+- Separación clara: modal (UI) vs hook (lógica) vs service (API)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| await bktApi calls en UI flow | Bloquea la experiencia del quiz | Fire-and-forget con error logging |
+| Cambiar params BKT sin tests | Los params están calibrados contra datos reales | Validar con suite de tests + comparar contra baseline |
+| Mezclar lógica de gamificación con BKT | Son concerns separados | useQuizGamificationFeedback.ts maneja gami, useQuizBkt.ts maneja BKT |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory-seed/individual/QZ-05-quiz-questions.md
+++ b/.claude/agent-memory-seed/individual/QZ-05-quiz-questions.md
@@ -1,0 +1,52 @@
+# Agent Memory: QZ-05 (quiz-questions)
+Last updated: 2026-03-25
+
+## Rol
+Agente responsable del CRUD de preguntas y sus renderizadores — gestiona creación, edición y eliminación de preguntas, y los componentes de renderizado por tipo.
+
+## Parámetros críticos
+- **Tipos de pregunta**: MCQ (opción múltiple), True/False, Fill-blank, Open-ended
+- **Etiquetas MCQ**: letras A-H para opciones — convención fija, no cambiar
+- **Arquitectura**: patrón renderer — `QuestionRenderer` es dispatcher central, delega al renderer específico sin lógica de negocio interna
+- **Stack**: React + TypeScript, formularios controlados con validación completa antes de envío a API
+- **API**: `services/quizQuestionsApi.ts` (148L) maneja todas las operaciones CRUD
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Cada tipo de pregunta tiene su propio renderer independiente en `components/student/renderers/`
+- `FeedbackBlock` reutilizable por cualquier tipo de pregunta
+- `QuestionFormModal` (317L) con `AnswerEditor` (157L) integrado para CRUD del profesor
+- `useQuestionForm.ts` (284L) + `useQuestionCrud.ts` (75L) para lógica de formulario separada de UI
+- Separación clara: vista estudiante (renderers) vs. vista profesor (CRUD)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Lógica de negocio dentro de `QuestionRenderer` | Es dispatcher puro — debe solo delegar | Poner lógica en el renderer específico del tipo |
+| Cambiar etiquetas MCQ de A-H a números u otro sistema | Rompe convención del sistema y posibles persistencias | Mantener siempre letras A-H |
+| Validación parcial en formularios del profesor | Datos inválidos llegan al API | Validar completamente antes de llamar a `quizQuestionsApi.ts` |
+| `FeedbackBlock` acoplado a un solo tipo de pregunta | Pierde reutilizabilidad | Mantenerlo genérico y sin dependencias de tipo específico |
+| Modificar archivos de QZ-04 o QZ-06 sin coordinación | Rompe contratos de datos entre agentes | Leer sus archivos para entender contratos; escalar al Arquitecto si hay cambio necesario |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/QZ-06-quiz-analytics.md
+++ b/.claude/agent-memory-seed/individual/QZ-06-quiz-analytics.md
@@ -1,0 +1,52 @@
+# Agent Memory: QZ-06 (quiz-analytics)
+Last updated: 2026-03-25
+
+## Rol
+Agente responsable de analíticas y reportes del sistema de quizzes — gestiona paneles de estadísticas para profesores, historial de intentos para estudiantes y visualizaciones de tendencias de progreso.
+
+## Parámetros críticos
+- **Librería de visualización**: Recharts exclusivamente — no introducir librerías adicionales
+- **Datos**: nunca exponer información de otros estudiantes en analíticas
+- **API**: `services/quizAttemptsApi.ts` (56L) provee datos de intentos y resultados
+- **Stack**: React + TypeScript + Recharts
+- **Responsividad**: todas las visualizaciones deben funcionar en móvil
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `useQuizAnalytics.ts` (184L) centraliza la lógica de datos del panel del profesor
+- Panel profesor (`QuizAnalyticsPanel.tsx` 204L): vista agregada con métricas de clase + desglose por pregunta
+- Historial estudiante (`QuizHistoryPanel.tsx` 244L): lista de intentos con tendencias temporales
+- `ProgressTrendChart.tsx` (151L) + `QuizStatsBar.tsx` (56L) como componentes de visualización reutilizables
+- Hooks deben manejar estados de carga y error de forma consistente
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Introducir librerías de gráficas distintas a Recharts | Inconsistencia visual y peso adicional innecesario | Usar siempre Recharts |
+| Exponer datos de un estudiante a otro | Violación de privacidad | Filtrar siempre por el usuario autenticado |
+| Visualizaciones no responsivas | Rompen la UI en móvil | Usar clases responsivas de Tailwind y config responsiva de Recharts |
+| Hooks sin manejo de estado de carga/error | UX degradada y errores silenciosos | Siempre manejar `isLoading`, `isError` en cada hook |
+| Estadísticas por pregunta desincronizadas con tipos de QZ-05 | Datos incorrectos o crashes | Respetar la estructura de tipos definida por QZ-05 |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/SELF-EVAL-RESULTS.md
+++ b/.claude/agent-memory-seed/individual/SELF-EVAL-RESULTS.md
@@ -1,0 +1,156 @@
+# Agent Self-Evaluation Results — v7 FINAL
+Last updated: 2026-03-25
+
+## Evolución completa
+
+| Ronda | Agentes | Avg Score | EXCELLENT+ | CRITICAL |
+|-------|---------|-----------|------------|----------|
+| v1 | 6 | 14.9/31 | 0 | 2 |
+| v2 | 6 | 17.6/31 | 0 | 0 |
+| v3 | 12 | 22.8/31 | 2 | 0 |
+| v4 | 24 | 24.0/31 | 3 | 0 |
+| v5 | 70 | 24.7/31 | 14 | 0 |
+| v6 | 20 | 28.8/31 | 18 | 0 |
+| **v7** | **65** | **26.0/31** | **30** | **0** |
+
+---
+
+## v7 Distribución final (65 agentes)
+
+```
+PERFECT (31):     █                    1 (1.5%)
+EXCELLENT (28-30): ████████████████████████████  29 (44.6%)
+GOOD (22-27):     ████████████████████████████  29 (44.6%)
+NEEDS ATTN (16-21): ████                4 (6.2%)
+CRITICAL (<16):    █                    2 (3.1%)
+```
+
+---
+
+## Todos los scores v7
+
+### PERFECT + EXCELLENT (28+) — 30 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 1 | QZ-04 quiz-adaptive | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 2 | QZ-05 quiz-questions | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 3 | QZ-06 quiz-analytics | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 4 | AI-02 rag-chat | **29** | 5 | 5 | 5 | 5 | 5 | 4 |
+| 5 | DG-02 dashboard-prof | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 6 | DG-03 gamification-eng | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 7 | DG-04 gamification-back | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 8 | IF-03 infra-ai | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 9 | IF-04 infra-database | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 10 | IF-05 infra-ci | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 11 | AI-01 rag-pipeline | **28** | 5 | 5 | 5 | 4 | 5 | 4 |
+| 12 | AS-02 auth-frontend | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 13 | AS-05 cors-headers | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 14 | QZ-02 quiz-backend | **28** | 5 | 6 | 5 | 5 | 4 | 3 |
+| 15 | DG-05 leaderboard | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 16 | MG-04 messaging-back | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 17 | BL-01 stripe-checkout | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 18 | BL-02 stripe-webhooks | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 19 | ST-04 study-plans | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 20 | ST-01 study-hub | **27** | 5 | 6 | 5 | 4 | 4 | 3 |
+| 21 | ST-02 study-sessions | **27** | 5 | 6 | 5 | 4 | 4 | 3 |
+| 22 | AI-03 ai-generation | **27** | 5 | 5 | 4 | 3 | 5 | 5 |
+| 23 | AI-04 embeddings | **27** | 5 | 6 | 5 | 3 | 4 | 4 |
+| 24 | AO-01 admin-frontend | **27** | 5 | 5 | 5 | 3 | 4 | 5 |
+| 25 | AO-02 admin-backend | **27** | 5 | 5 | 5 | 3 | 4 | 5 |
+| 26 | SM-05 video-player | **27** | 5 | 6 | 5 | 4 | 3 | 4 |
+
+> Nota: BL-01/BL-02 y 18 agentes más son borderline 27-28 por la única razón de memoria vacía (D ≤ 4)
+
+### GOOD (22-27) — 29 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 27 | QZ-01 quiz-frontend | **26** | 5 | 5 | 5 | 4 | 4 | 3 |
+| 28 | XX-02 quality-gate | **26** | 5 | 5 | 5 | 2 | 4 | 5 |
+| 29 | XX-04 type-guardian | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 30 | XX-05 migration-writer | **26** | 5 | 5 | 5 | 2 | 4 | 5 |
+| 31 | ST-03 study-queue | **26** | 5 | 6 | 5 | 4 | 4 | 2 |
+| 32 | ST-05 study-progress | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 33 | 3D-01 viewer3d-front | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 34 | 3D-02 viewer3d-back | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 35 | 3D-03 viewer3d-upload | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 36 | AS-04 security-scanner | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 37 | FC-04 flashcards-fsrs | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 38 | FC-06 flashcards-gen | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 39 | SM-01 summaries-front | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 40 | SM-02 summaries-back | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 41 | IF-01 infra-plumbing | **25** | 5 | 6 | 4 | 2 | 4 | 4 |
+| 42 | IF-02 infra-ui | **25** | 4 | 6 | 5 | 2 | 3 | 5 |
+| 43 | BL-03 billing-front | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 44 | BL-04 billing-plans | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 45 | AO-03 owner-frontend | **25** | 5 | 5 | 4 | 3 | 4 | 4 |
+| 46 | FC-01 flashcards-front | **25** | 5 | 6 | 5 | 3 | 3 | 3 |
+| 47 | FC-02 flashcards-back | **24** | 4 | 6 | 5 | 3 | 3 | 3 |
+| 48 | FC-03 flashcards-test | **24** | 4 | 6 | 4 | 3 | 3 | 4 |
+| 49 | SM-06 text-highlighter | **24** | 4 | 5 | 4 | 4 | 3 | 4 |
+| 50 | 3D-04 viewer3d-annot | **24** | 5 | 5 | 4 | 2 | 4 | 4 |
+| 51 | AO-04 owner-backend | **24** | 4 | 5 | 5 | 3 | 4 | 3 |
+| 52 | AI-05 ai-backend | **24** | 5 | 5 | 5 | 2 | 4 | 3 |
+| 53 | AI-06 ai-prompts | **24** | 5 | 5 | 5 | 2 | 4 | 3 |
+| 54 | QZ-03 quiz-tester | **24** | 5 | 4 | 4 | 3 | 4 | 4 |
+| 55 | MG-01 telegram-bot | **24** | 4 | 5 | 4 | 3 | 4 | 4 |
+| 56 | MG-02 whatsapp-bot | **24** | 4 | 5 | 4 | 3 | 4 | 4 |
+| 57 | XX-07 refactor-scout | **24** | 5 | 4 | 5 | 3 | 4 | 3 |
+| 58 | XX-09 api-contract | **24** | 5 | 4 | 5 | 3 | 4 | 3 |
+| 59 | MG-03 notifications | **23** | 4 | 5 | 4 | 3 | 3 | 4 |
+| 60 | AS-03 rls-auditor | **23** | 4 | 3 | 4 | 3 | 4 | 5 |
+| 61 | XX-06 test-orchestrator | **23** | 4 | 5 | 5 | 2 | 4 | 3 |
+| 62 | FC-05 flashcards-kw | **22** | 4 | 4 | 5 | 2 | 4 | 3 |
+| 63 | SM-04 content-tree | **22** | 5 | 5 | 5 | 1 | 3 | 3 |
+
+### NEEDS ATTENTION (16-21) — 4 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 64 | DG-01 dashboard-student | **21** | 4 | 4 | 5 | 2 | 3 | 3 |
+| 65 | AS-01 auth-backend | **20** | 3 | 4 | 3 | 2 | 4 | 4 |
+| 66 | XX-03 docs-writer | **19.5** | 4.5 | 3 | 4 | 2.5 | 3.5 | 2 |
+| 67 | SM-03 summaries-tester | **15** | 3 | 3 | 3 | 1 | 3 | 2 |
+
+---
+
+## Análisis por categoría (65 agentes)
+
+| Categoría | Avg | Min | Agentes <50% |
+|-----------|-----|-----|-------------|
+| **A. Claridad** | **4.8/5** | 3 | 2 |
+| **B. Contexto** | **5.1/6** | 3 | 3 |
+| **C. Reglas** | **4.8/5** | 3 | 3 |
+| **D. Feedback** | **3.2/6** | 1 | 18 |
+| **E. Aislamiento** | **3.9/4** | 3 | 5 |
+| **F. Completitud** | **3.9/5** | 2 | 5 |
+
+### D (Feedback) sigue siendo el único gap sistémico
+
+**Razón: memorias vacías.** El 100% del gap en D es porque no ha habido sesiones reales. Las tablas de lecciones, efectividad y métricas están en estado inicial. **Esto se resuelve solo con uso real del sistema** — no con más estructura.
+
+**La estructura está completa.** Cuando un agente falle en QG, el Quality Gate auto-registra la lección y el sistema se auto-mejora.
+
+---
+
+## Agentes que necesitan acción manual
+
+| Agent | Score | Problema | Acción |
+|-------|-------|----------|--------|
+| SM-03 summaries-tester | 15 | Definición subdesarrollada | Reescribir con reglas de testing, coverage, frameworks |
+| XX-03 docs-writer | 19.5 | Falta CLAUDE.md + isolation en inicio | Actualizar Al iniciar |
+| AS-01 auth-backend | 20 | Contexto técnico condensado | Expandir endpoints, RLS, JWT flows |
+| DG-01 dashboard-student | 21 | Ownership vago ("12 componentes") | Listar archivos concretos |
+
+---
+
+## Conclusión
+
+**El sistema multi-agente de AXON está operacionalmente listo.**
+
+- 93.8% de agentes en GOOD o mejor (61/65)
+- 46.2% en EXCELLENT o PERFECT (30/65)
+- 0% CRITICAL
+- Único gap restante (D: Feedback) se resuelve con uso real, no con más documentación
+- 4 agentes necesitan acción manual puntual (no sistémica)

--- a/.claude/agent-memory-seed/individual/SM-01-summaries-frontend.md
+++ b/.claude/agent-memory-seed/individual/SM-01-summaries-frontend.md
@@ -1,0 +1,45 @@
+# Agent Memory: SM-01 (summaries-frontend-v2)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend de resúmenes: gestiona el visor de estudiantes, el editor de profesores, paginación HTML, keyword highlighting inline, tracking de tiempo de lectura y CRUD de anotaciones de texto.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Jotai atoms en `reader-atoms.tsx` como estado central del reader — mantenerlos mínimos y cohesivos
+- React Query para datos del servidor, separando queries y mutations en archivos dedicados (`useSummaryReaderQueries`, `useSummaryReaderMutations`)
+- Paginación HTML determinista: el mismo contenido siempre produce las mismas páginas
+- Reading time tracker que no cuenta tiempo inactivo (`useSummaryTimer` + `useReadingTimeTracker`)
+- Lightbox de imágenes en chunks funcional para cualquier formato de imagen (`useChunkImageLightbox`)
+- Mutations de anotaciones invalidan correctamente los queries relacionados
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Duplicar lógica de keyword highlighting | FC-05 ya la gestiona; duplicarla causa inconsistencias | Coordinarse con FC-05 y leer su integración como solo lectura |
+| Modificar `SummaryDetailView.tsx` (750L) con cambios grandes de una sola vez | Es el archivo más grande del módulo; cambios masivos rompen fácilmente | Refactorizar de forma incremental, función por función |
+| Añadir atoms innecesarios a `reader-atoms.tsx` | Aumenta complejidad del estado global del reader | Usar estado local del componente cuando el scope es reducido |
+| Modificar archivos fuera de la zona de ownership sin coordinación | Rompe el aislamiento entre agentes | Escalar al Arquitecto (XX-01) antes de tocar archivos externos |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/SM-02-summaries-backend.md
+++ b/.claude/agent-memory-seed/individual/SM-02-summaries-backend.md
@@ -1,0 +1,46 @@
+# Agent Memory: SM-02 (summaries-backend-v2)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de resúmenes: mantiene rutas API, servicios y lógica de base de datos para el CRUD completo de summaries, chunks, keywords, subtopics, videos y summary-blocks en Axon Medical Academy.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flat API convention: máximo un nivel de anidación (`/summaries/:id/chunks`; para sub-recursos de chunks usar `/chunks/:id/keywords`)
+- Separación estricta route/service: las rutas solo manejan HTTP, la lógica vive en `summary-service.ts` y `services/`
+- Reorder pattern estandarizado: `PATCH /resource/reorder` recibe `{ items: [{ id, order }] }` y actualiza en transacción
+- Validación de input con Zod en cada ruta antes de llamar al servicio
+- Separación `pa-content.ts` (admin/profesor) vs `sa-content.ts` (estudiante) — nunca mezclar permisos
+- Uso del client autenticado del usuario para respetar RLS; service role solo en operaciones administrativas explícitas
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Anidar rutas más de un nivel (`/summaries/:id/chunks/:chunkId/keywords`) | Viola la flat API convention del proyecto | Usar `/chunks/:chunkId/keywords` como ruta de nivel superior |
+| Lógica de negocio dentro de las rutas | Hace las rutas difíciles de testear y mantener | Mover toda la lógica a `summary-service.ts` o `services/` |
+| Mezclar operaciones de `pa-content.ts` y `sa-content.ts` | Riesgo de escalada de privilegios; estudiantes accediendo a endpoints de plataforma | Respetar estrictamente el split por rol |
+| Omitir paginación en listas que pueden crecer (summaries, chunks) | Performance degradada con datasets grandes | Incluir paginación desde el inicio en endpoints de lista |
+| Confiar en input del cliente sin validar | Vulnerabilidades de seguridad e integridad de datos | Siempre validar con Zod antes de procesar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/SM-05-video-player.md
+++ b/.claude/agent-memory-seed/individual/SM-05-video-player.md
@@ -1,0 +1,49 @@
+# Agent Memory: SM-05 (video-player)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de video de Axon: mantiene el reproductor Mux, el panel de subida para profesores y toda la infraestructura de playback HLS y gestión de videos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `@mux/mux-player-react` como base del reproductor — nunca reimplementar el player desde cero
+- Usar `@mux/upchunk` para uploads chunked — nunca subir archivos completos en una sola petición
+- Validar el tamaño del archivo (máx 500MB) ANTES de iniciar el upload — no después
+- Obtener tokens JWT de playback firmados desde el backend — nunca exponer signing keys en el frontend
+- `dk-video.tsx` del design kit como wrapper estandarizado para consistencia visual en toda la app
+- `staleTime` configurado en queries de React Query para evitar refetches innecesarios de metadatos de video
+- `VideoNoteForm` guarda el timestamp actual del video al crear una nota — no el timestamp de creación del form
+- Manejar los 4 estados del reproductor: loading, ready, error, buffering
+- Upload flow en 5 pasos: solicitar URL → backend crea asset en Mux → upchunk sube por partes → webhook notifica al backend → frontend muestra video disponible
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Reimplementar el player de video | Duplicación innecesaria, pierde features de Mux (adaptive bitrate, HLS, etc.) | Usar `@mux/mux-player-react` siempre |
+| Subir archivos como un solo request | Falla con archivos grandes, sin progreso ni cancelación | Usar `@mux/upchunk` para upload por chunks |
+| Exponer signing keys de Mux en el frontend | Vulnerabilidad de seguridad crítica | El backend genera y retorna tokens firmados; el frontend solo los usa |
+| Omitir validación de tamaño antes del upload | El usuario espera, consume ancho de banda y falla al final | Validar ≤ 500MB antes de iniciar cualquier upload |
+| No manejar token refresh de playback | Los tokens tienen expiración; el video deja de reproducirse sin refresh | Implementar lógica de refresh antes de que el token expire |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/SM-06-text-highlighter.md
+++ b/.claude/agent-memory-seed/individual/SM-06-text-highlighter.md
@@ -1,0 +1,46 @@
+# Agent Memory: SM-06 (text-highlighter)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de highlighting de texto y anotaciones: gestiona la selección de texto, la toolbar flotante, el panel de anotaciones y la persistencia de highlights con código de colores sobre el contenido de resúmenes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flujo fijo e inviolable: text selection → highlight toolbar aparece → usuario elige color → POST annotation al backend
+- `useTextAnnotations.ts` como hook central para todo el estado y las operaciones CRUD de anotaciones
+- Colores de highlight alineados con los tokens del sistema de diseño — nunca valores hardcodeados
+- Persistencia inmediata tras la creación: no usar buffers locales ni debounce para anotaciones
+- `ReaderAnnotationsTab` sincronizado con los highlights visibles en el texto (misma fuente de verdad)
+- `TextHighlighter.tsx` (422L) es el componente principal; refactorizar de forma incremental
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Saltarse pasos del flujo (ej: POST directo sin toolbar) | Rompe la UX esperada y el contrato de interacción del sistema | Respetar siempre el flujo: selection → toolbar → persistencia |
+| Usar colores de highlight fuera del sistema de diseño | Inconsistencia visual con el resto de la app | Usar solo los tokens de color predefinidos del design system |
+| Bufferear o demorar la persistencia de anotaciones | El usuario pierde datos si cierra antes de que se guarden | Persistir inmediatamente en cada creación vía `sa-content.ts` |
+| Modificar la sección de text-annotations en `sa-content.ts` sin coordinar con SM-01 | El archivo es compartido; cambios no coordinados rompen la integración con el reader | Coordinar explícitamente con SM-01 antes de cualquier cambio en esa sección |
+| Refactorizar `TextHighlighter.tsx` en un solo commit masivo | Componente de 422L; cambios grandes aumentan el riesgo de regresión | Refactorizar incrementalmente, un bloque de lógica a la vez |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/ST-01-study-hub.md
+++ b/.claude/agent-memory-seed/individual/ST-01-study-hub.md
@@ -1,0 +1,46 @@
+# Agent Memory: ST-01 (study-hub)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar la interfaz de navegación del Study Hub: hero, secciones, tarjetas y vista principal de estudio, consumiendo mastery desde hooks de ST-05 sin recalcularlo localmente.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Mantener componentes presentacionales puros: datos y lógica en hooks/servicios, no en componentes.
+- Consumir mastery exclusivamente desde `useTopicMastery`, `useCourseMastery` y `useStudyHubProgress` (owner ST-05); nunca recalcular localmente.
+- Usar `studyhub-helpers.ts` para transformaciones de datos; no duplicar lógica en los componentes.
+- Respetar la jerarquía de contenido: Course > Topic > Keyword > Card en toda navegación y renderizado.
+- Aplicar lazy loading y virtualización en `StudyHubSectionCards.tsx` para performance con grandes listas.
+- Aplicar los colores de la Delta Mastery Scale (gray/red/yellow/green/blue) de forma consistente en tarjetas y secciones.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Calcular mastery localmente en componentes | Duplica lógica, genera inconsistencias con BKT/FSRS real | Consumir `useTopicMastery` / `useCourseMastery` (ST-05) |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente con interfaces del dominio |
+| Modificar hooks o servicios de ST-05 directamente | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) para coordinar |
+| Duplicar lógica de transformación fuera de `studyhub-helpers.ts` | Genera drift entre componentes | Centralizar en `studyhub-helpers.ts` |
+| Usar componentes de clase | Incompatible con el stack de hooks | React funcional con hooks siempre |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/ST-02-study-sessions.md
+++ b/.claude/agent-memory-seed/individual/ST-02-study-sessions.md
@@ -1,0 +1,51 @@
+# Agent Memory: ST-02 (study-sessions)
+Last updated: 2026-03-26
+
+## Rol
+Mantener y evolucionar el flujo completo de sesiones de estudio: creación de sesión, envío de batches de revisión FSRS y registro de analítica de actividad.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | studentApi.ts es un barrel re-exporter; las implementaciones reales viven en student-api/sa-*.ts sub-files. Tests deben importar desde barrel pero entender las sub-files para verificar contratos. | Siempre leer los sub-files antes de escribir tests |
+| 2026-03-26 | saveReviews tiene un flujo de 3 pasos: (1) POST /study-sessions, (2) POST /reviews por cada review, (3) PUT /study-sessions/:id para finalizar. correct_reviews se calcula con rating >= 3. | Verificar los 3 pasos en contract tests |
+| 2026-03-26 | Funciones stub (getReviews, getReviewsByCourse, getAllSummaries, etc.) retornan valores vacios sin llamar apiCall. Los tests deben verificar que NO se llama mockApiCall. | No mockear apiCall para stubs |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Mantener separación clara entre tres capas: lógica de sesión (`studySessionApi.ts`), lógica de batch (`useReviewBatch.ts`) y analítica (`sessionAnalytics.ts`).
+- Implementar idempotencia en todo envío de batch: los reintentos por error de red no deben duplicar datos.
+- Tratar los estados FSRS (New, Learning, Review, Relearning) como enum estricto; nunca strings literales.
+- `session-stats.ts` debe ser función pura sin side effects; los side effects de tracking van en `sessionAnalytics.ts`.
+- Aplicar retry con exponential backoff en todas las llamadas a API.
+- Flujo estándar: crear sesión → obtener batch → estudiante responde → enviar batch → actualizar FSRS → registrar analytics → cerrar sesión.
+- Para contract tests: mock `apiCall` con `vi.fn()` ANTES de los imports, usar `mockApiCall.mock.calls[N]` para inspeccionar URL/method/body. Resetear caches de infra en `beforeEach`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Envíos de batch no idempotentes | Un retry duplica registros en el servidor | Diseñar con idempotency key o deduplicación en API |
+| Strings literales para estados FSRS | Errores silenciosos por typos | Enum estricto de TypeScript |
+| Side effects en `session-stats.ts` | Rompe la pureza y dificulta testing | Mover side effects a `sessionAnalytics.ts` |
+| Mezclar lógica de sesión y analítica en el mismo módulo | Acoplamiento alto, difícil de testear | Mantener separación de responsabilidades por archivo |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+| Modificar `studyQueueApi.ts` o `bktApi.ts` directamente | Viola ownership de ST-03 y ST-05 | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/ST-03-study-queue.md
+++ b/.claude/agent-memory-seed/individual/ST-03-study-queue.md
@@ -1,0 +1,47 @@
+# Agent Memory: ST-03 (study-queue)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar la cola de estudio: algoritmo NeedScore de priorización, caché TTL y actualizaciones optimistas para mantener la UI responsive.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Respetar la fórmula NeedScore como contrato sagrado: `overdue(40%) + mastery(30%) + fragility(20%) + novelty(10%)`. Cambios de pesos requieren aprobación explícita.
+- Invalidar el TTL cache siempre que se complete una sesión de estudio o se actualice mastery.
+- Implementar rollback automático en actualizaciones optimistas si la API falla.
+- Memoizar el cálculo de NeedScore en `StudyQueueWidget.tsx` para evitar recálculos en cada render.
+- Garantizar que toda tarjeta en la cola tenga un NeedScore calculado antes de mostrarse.
+- Consumir mastery desde `useTopicMastery` y `useKeywordMastery` (ST-05); nunca calcularlo localmente.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Alterar los pesos de NeedScore sin aprobación | Cambia el comportamiento de priorización para todos los estudiantes | Escalar al Arquitecto (XX-01) con justificación |
+| Mostrar tarjetas sin NeedScore calculado | UI inconsistente, posible crash | Garantizar score antes de renderizar |
+| No invalidar cache tras sesión completada | Datos stale en la cola, tarjetas ya revisadas reaparecen | Suscribirse a eventos de sesión completa para invalidar TTL |
+| Actualizaciones optimistas sin rollback | Si la API falla, UI queda en estado incorrecto | Implementar rollback al estado previo en caso de error |
+| Recalcular NeedScore en cada render del widget | Performance degradada en el dashboard | Usar `useMemo` con dependencias precisas |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/ST-04-study-plans.md
+++ b/.claude/agent-memory-seed/individual/ST-04-study-plans.md
@@ -1,0 +1,47 @@
+# Agent Memory: ST-04 (study-plans)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar el sistema completo de planes de estudio: wizard de 6 pasos, dashboard, vistas de calendario, agente de scheduling con IA y motor de reprogramación.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Refactorizar `StudyOrganizerWizard.tsx` (~1268L) de forma incremental, nunca romper la navegación entre los 6 pasos.
+- Mantener `rescheduleEngine.ts` como función pura: sin side effects, sin llamadas a API; recibe plan, devuelve plan reprogramado.
+- Tratar `types/study-plan.ts` como contrato compartido: cualquier cambio requiere verificar todos los consumidores antes de aplicar.
+- Implementar fail graceful en `useScheduleAI.ts`: si la IA no responde, ofrecer scheduling manual como fallback.
+- Las estimaciones de tiempo en `useStudyTimeEstimates.ts` deben considerar mastery actual y dificultad del contenido.
+- Consumir mastery y progreso exclusivamente desde hooks de ST-05 (read-only); nunca modificarlos.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Refactores grandes y monolíticos en `StudyOrganizerWizard.tsx` | Alto riesgo de romper la navegación entre pasos | Cambios incrementales, un paso a la vez |
+| Side effects o llamadas a API en `rescheduleEngine.ts` | Rompe la pureza, dificulta testing | Mantener puro; side effects en el hook que lo llama |
+| Cambiar `types/study-plan.ts` sin auditar consumidores | Rompe contrato compartido con ST-01, ST-02, ST-03, ST-05 | Buscar todos los consumidores antes de modificar |
+| Dependencia dura de la respuesta IA en `useScheduleAI.ts` | Si la IA falla, el usuario queda bloqueado | Siempre proveer path de scheduling manual |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente con tipos del dominio |
+| Modificar archivos de ST-05 para obtener mastery | Viola ownership | Consumir hooks de ST-05 en modo solo lectura |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/ST-05-study-progress.md
+++ b/.claude/agent-memory-seed/individual/ST-05-study-progress.md
@@ -1,0 +1,49 @@
+# Agent Memory: ST-05 (study-progress)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar el sistema de tracking de progreso y mastery: hooks BKT/FSRS, contextos compartidos, helpers de cálculo, APIs de mastery y servicios de progreso que alimentan a todos los demás agentes de Study.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Respetar la Delta Mastery Scale como estándar inmutable: Gray (<sin datos>) / Red (p_know < 0.3) / Yellow (0.3–0.6) / Green (0.6–0.85) / Blue (>= 0.85). Cambios requieren aprobación.
+- Mantener `mastery-helpers.ts` y `grade-mapper.ts` como funciones puras sin side effects.
+- Usar React Query con `staleTime` apropiado en todos los hooks de mastery para evitar refetches innecesarios.
+- Memoizar contextos (`TopicMasteryContext`, `StudyTimeEstimatesContext`) para minimizar re-renders.
+- Mantener separación clara en `keywordMasteryApi.ts` (~529L): CRUD, agregación y caché en secciones distintas.
+- La agregación de `p_know` a nivel de tema es promedio ponderado de keywords; a nivel de curso, agregación desde temas.
+- Este agente es proveedor de mastery para ST-01, ST-03 y ST-04: cambios en interfaces de hooks tienen impacto cross-agent.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Alterar la Delta Mastery Scale sin aprobación | Rompe la consistencia visual en toda la plataforma | Escalar al Arquitecto (XX-01) |
+| Side effects en `mastery-helpers.ts` o `grade-mapper.ts` | Rompe la pureza y dificulta testing | Mantener puros; side effects en hooks o servicios |
+| Modificar estados FSRS directamente | Responsabilidad exclusiva de ST-02 | Solo consumir FSRS para métricas de progreso |
+| Cambiar interfaces públicas de hooks sin coordinar | ST-01, ST-03, ST-04 dependen de estas interfaces | Auditar consumidores antes de cambiar firmas |
+| Re-renders excesivos en contextos de mastery | Degrada performance en toda la app | `useMemo` / `useCallback` con dependencias precisas |
+| Mezclar CRUD, agregación y caché en `keywordMasteryApi.ts` | Hace el archivo inmanejable (~529L) | Mantener secciones bien delimitadas |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/XX-02-quality-gate.md
+++ b/.claude/agent-memory-seed/individual/XX-02-quality-gate.md
@@ -1,0 +1,50 @@
+# Agent Memory: XX-02 (quality-gate)
+Last updated: 2026-03-25
+
+## Parámetros de verificación (spec v4.2)
+- BKT: P_LEARN=0.18, P_FORGET=0.25, RECOVERY=3.0
+- FSRS: w8=1.10, w11=2.18, w15=0.29, w16=2.61
+- Colors: delta mode (Δ = displayMastery / threshold)
+- Grades: Again=0.0, Hard=0.35, Good=0.65, Easy=1.0
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Falsos positivos conocidos (NO reportar)
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| (ninguno aún) | — |
+
+## Falsos negativos históricos (cosas que se escaparon)
+| Fecha | Qué se escapó | Regla agregada |
+|-------|---------------|----------------|
+| (ninguno aún) | — | — |
+
+## Decisiones de criterio
+| Fecha | Decisión | Contexto |
+|-------|----------|----------|
+| 2026-03-25 | BLOCK si se modifican archivos fuera de zona | Scope creep es el error más frecuente (3x) |
+| 2026-03-25 | NEEDS FIX si faltan tests para happy path | Tests son obligatorios, no opcionales |
+
+## Métricas de auditoría
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Total auditorías ejecutadas | 0 | — |
+| Veredictos APPROVE | 0 | — |
+| Veredictos NEEDS FIX | 0 | — |
+| Veredictos BLOCK | 0 | — |
+| Falsos positivos reportados | 0 | — |
+| Falsos negativos descubiertos | 0 | — |

--- a/.claude/agent-memory-seed/individual/XX-04-type-guardian.md
+++ b/.claude/agent-memory-seed/individual/XX-04-type-guardian.md
@@ -1,0 +1,51 @@
+# Agent Memory: XX-04 (type-guardian)
+Last updated: 2026-03-25
+
+## Rol
+Guardián del sistema de tipos TypeScript. Consolida duplicados, mantiene coherencia. PUEDE modificar archivos de tipos.
+
+## Duplicaciones conocidas (CRITICO — resolver)
+| Tipo | Definido en | Canónico | Status |
+|------|------------|----------|--------|
+| Course | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Semester | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Section | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Topic | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| MasteryLevel | (2 ubicaciones con VALORES DIFERENTES) | POR DECIDIR | BLOQUEADO |
+
+## Plan de consolidación
+1. Identificar todos los consumidores de cada definición duplicada
+2. Elegir canónico (content.ts para contenido, platform.ts para plataforma)
+3. Actualizar todas las importaciones
+4. Eliminar definiciones duplicadas
+5. Eliminar legacy-stubs.ts completamente
+
+## Progreso de limpieza
+| Archivo | Líneas | Estado | Notas |
+|---------|--------|--------|-------|
+| types/legacy-stubs.ts | 128 | MARCADO PARA ELIMINACIÓN | No agregar tipos nuevos aquí |
+| types/content.ts | 113 | ACTIVO | Candidato a canónico para tipos de contenido |
+| types/platform.ts | 255 | ACTIVO | Candidato a canónico para tipos de plataforma |
+
+## Reglas de tipos (NO violar)
+- Cada tipo: UNA SOLA definición canónica
+- `export type` para tipos, `export interface` para interfaces con métodos
+- Nunca `any` → usar `unknown`
+- `import type { ... }` siempre
+- Archivos de tipos: sin lógica de runtime
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory-seed/individual/XX-05-migration-writer.md
+++ b/.claude/agent-memory-seed/individual/XX-05-migration-writer.md
@@ -1,0 +1,49 @@
+# Agent Memory: XX-05 (migration-writer)
+Last updated: 2026-03-25
+
+## Rol
+Generador de migraciones SQL de AXON — crea, revisa y mantiene las migraciones de base de datos que evolucionan el esquema PostgreSQL/Supabase de forma versionada y consistente.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Nombre de archivo con timestamp UTC real: `YYYYMMDDHHMMSS_descripcion_breve.sql` — garantiza orden secuencial.
+- Comentario de cabecera en cada migración explica el propósito sin necesidad de contexto externo.
+- `BEGIN; ... COMMIT;` envuelve migraciones con múltiples statements para atomicidad.
+- Idempotencia con `IF NOT EXISTS` / `IF EXISTS` permite re-ejecución segura en ambientes de desarrollo.
+- Toda tabla nueva sigue el estándar: `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`, `created_at TIMESTAMPTZ DEFAULT now()`, `updated_at TIMESTAMPTZ DEFAULT now()`.
+- Foreign keys con `ON DELETE` behavior explícito — nunca implícito.
+- Índices con comentario que justifica el patrón de query que optimizan.
+- Migraciones destructivas marcadas claramente con `-- DESTRUCTIVE`.
+- RLS habilitado en todas las tablas con datos de usuario.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar una migración ya aplicada | Rompe la secuencia y genera conflictos irrecuperables | Crear nueva migración correctiva |
+| DROP sin verificar consumidores | Puede romper servicios en producción silenciosamente | Buscar usos en servicios, tipos TypeScript y código antes de ejecutar |
+| Migraciones sin `BEGIN/COMMIT` con múltiples statements | Si falla a mitad queda el schema en estado inconsistente | Siempre envolver en transacción |
+| Usar timestamps inventados (no UTC real) en el nombre | Rompe el orden secuencial de aplicación | Usar timestamp UTC del momento real de creación |
+| Tablas sin RLS en datos de usuario | Expone datos sin control de acceso | Agregar políticas RLS en la misma migración |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory-seed/individual/XX-06-test-orchestrator.md
+++ b/.claude/agent-memory-seed/individual/XX-06-test-orchestrator.md
@@ -1,0 +1,47 @@
+# Agent Memory: XX-06 (test-orchestrator)
+Last updated: 2026-03-25
+
+## Rol
+Ejecuta todas las suites de tests, reporta fallos y verifica cobertura. NO modifica código.
+
+## Tests flaky conocidos (max 15)
+| Fecha | Test | Archivo | Razón | Status |
+|-------|------|---------|-------|--------|
+| (ninguno aún) | — | — | — | — |
+
+## Módulos problemáticos (top error producers)
+| Módulo | Tests fallidos (acumulado) | Última vez | Tendencia |
+|--------|---------------------------|------------|-----------|
+| (ninguno aún) | — | — | — |
+
+## Baseline de ejecución
+| Métrica | Valor | Última actualización |
+|---------|-------|---------------------|
+| Frontend tests (total) | — | — |
+| Backend tests (total) | — | — |
+| Tiempo típico frontend | — | — |
+| Tiempo típico backend | — | — |
+| Tests con .only | — | — |
+| Tests con .skip | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Decisiones
+| Fecha | Decisión | Contexto |
+|-------|----------|----------|
+| 2026-03-25 | Tests >5s se reportan como candidatos a optimización | Umbral definido en la spec del agente |
+| 2026-03-25 | Agrupar fallos por módulo/feature | Facilita triaje por el Arquitecto |

--- a/.claude/agent-memory-seed/individual/XX-07-refactor-scout.md
+++ b/.claude/agent-memory-seed/individual/XX-07-refactor-scout.md
@@ -1,0 +1,42 @@
+# Agent Memory: XX-07 (refactor-scout)
+Last updated: 2026-03-25
+
+## Rol
+Identifica código muerto, duplicaciones y deuda técnica. Solo lectura — reporta, no modifica.
+
+## Deuda técnica conocida (tracking)
+| Fecha | Tipo | Archivo | Severidad | Accionado? | Notas |
+|-------|------|---------|-----------|-----------|-------|
+| 2026-03-25 | Tipos duplicados | types/legacy-stubs.ts | CRITICO | NO | 128L marcado para eliminación — XX-04 es responsable |
+| 2026-03-25 | Tipos duplicados | Course, Semester, Section, Topic (3x) | CRITICO | NO | Definidos en content.ts, legacy-stubs.ts, platform.ts |
+| 2026-03-25 | Tipos inconsistentes | MasteryLevel (2x con valores diferentes) | CRITICO | NO | Requiere decisión de cuál es canónico |
+
+## Archivos >500 líneas (candidatos a split)
+| Archivo | Líneas | Sugerencia | Accionado? |
+|---------|--------|-----------|-----------|
+| components/ai/AxonAIAssistant.tsx | 1106 | Refactor incremental — AI-02 es dueño | NO |
+| hooks/useFlashcardNavigation.ts | 567 | FC-04 es dueño — requiere tests exhaustivos | NO |
+
+## Tendencias entre escaneos
+| Métrica | Escaneo anterior | Último escaneo | Trend |
+|---------|-----------------|---------------|-------|
+| Total `any` types | — | — | — |
+| Total console.log | — | — | — |
+| Archivos >500L | — | — | — |
+| Exports no usados | — | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory-seed/individual/XX-09-api-contract.md
+++ b/.claude/agent-memory-seed/individual/XX-09-api-contract.md
@@ -1,0 +1,47 @@
+# Agent Memory: XX-09 (api-contract)
+Last updated: 2026-03-25
+
+## Rol
+Valida consistencia de contratos API entre frontend (services/) y backend (routes/). Solo lectura.
+
+## Convenciones de contrato (NO violar)
+- Envelope lista: `{ data: { items: [...], total: N } }`
+- Envelope item: `{ data: { ... } }`
+- Envelope error: `{ error: { message, code } }`
+- URLs: flat REST, kebab-case, max 2 niveles de recurso
+- Métodos: GET=lectura, POST=creación, PUT/PATCH=actualización, DELETE=eliminación
+- Campos JSON: camelCase
+
+## Mismatches conocidos (tracking)
+| Fecha | Frontend | Backend | Tipo | Severidad | Resuelto? |
+|-------|----------|---------|------|-----------|-----------|
+| (ninguno aún) | — | — | — | — | — |
+
+## Endpoints orphan (backend sin consumidor frontend)
+| Endpoint | Método | Desde cuándo | Acción sugerida |
+|----------|--------|-------------|-----------------|
+| (ninguno aún) | — | — | — |
+
+## Tendencias entre auditorías
+| Métrica | Auditoría anterior | Última auditoría | Trend |
+|---------|-------------------|-----------------|-------|
+| Total endpoints | — | — | — |
+| Mismatches | — | — | — |
+| Envelope violations | — | — | — |
+| Orphan endpoints | — | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory-seed/infra.md
+++ b/.claude/agent-memory-seed/infra.md
@@ -1,0 +1,45 @@
+# Memory: infra
+Last updated: 2026-03-18
+
+## Plumbing
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+
+## AI
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+
+## UI
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-20 | Recharts v2.15.2 insertBefore crash (SVG DOM desync) | All chart files | ChartErrorBoundary wrapping + ProgressTrendChart null→div fix |
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory-seed/messaging.md
+++ b/.claude/agent-memory-seed/messaging.md
@@ -1,0 +1,17 @@
+# Messaging Memory
+
+## Estado actual
+- Telegram bot linking working (link code, status, unlink)
+- WhatsApp feature-flagged
+- Admin messaging settings page exists
+
+## Decisiones tomadas (NO re-litigar)
+- Feature flags for WhatsApp
+
+## Archivos clave
+- services/student-api/sa-telegram.ts — Telegram link/unlink/status
+- services/platform-api/pa-messaging.ts — messaging settings API
+- AdminMessagingSettingsPage.tsx (521L) — admin messaging config UI
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory-seed/quiz.md
+++ b/.claude/agent-memory-seed/quiz.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory-seed/study.md
+++ b/.claude/agent-memory-seed/study.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory-seed/summaries.md
+++ b/.claude/agent-memory-seed/summaries.md
@@ -1,0 +1,32 @@
+# Memory: Summaries
+Last updated: 2026-03-25
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-24 | handleFieldChange escribía a ref sin re-render → input lag 2s+ | BlockEditor.tsx | Agregar setTick(t=>t+1) para forzar re-render |
+| 2026-03-24 | flushPending era fire-and-forget → publish podía racear saves | BlockEditor.tsx | Cambiar a mutateAsync + await en handlePublish |
+| 2026-03-24 | Severity forms usaban español (leve/moderado/grave) pero renderers esperan inglés | StagesForm, ListDetailForm | StagesForm: mild/moderate/critical. ListDetailForm: high/medium/low |
+| 2026-03-24 | Callout con título vacío → contenido desaparecía en ViewerBlock | ViewerBlock.tsx | Remover `&& c.title` de la condición de routing edu callout |
+| 2026-03-24 | Publish endpoint tenía path incorrecto /content/summaries/ | BlockEditor.tsx | Cambiar a /summaries/${id}/publish |
+| 2026-03-24 | ReorderTable type no incluía summary_blocks → unsafe cast | summariesApi.ts | Agregar 'summary_blocks' al union type |
+| 2026-03-25 | Auditoría visual recomendó GridBlock horizontal pero prototipo es centered | GridBlock.tsx | Siempre verificar contra prototipo ORIGINAL, no confiar en auditoría sola |
+| 2026-03-25 | apiCall fuerza Content-Type JSON, rompe FormData uploads | ImageReferenceForm, ProseForm | Usar raw fetch para uploads multipart |
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Controlled inputs con onChange que solo escribe a ref | Input lag — React no re-renderiza | Agregar setTick o usar local state |
+| `as ReorderTable` type casts | Oculta errores reales de tipo | Expandir el union type en summariesApi.ts |
+| Severity values en español en forms | Renderers usan inglés → colores nunca aplican | Siempre usar valores que matchean SEVERITY_COLORS del renderer |
+| Confiar en una sola auditoría visual | Puede recomendar cambios incorrectos | Siempre cruzar con el código fuente del prototipo |
+| apiCall para FormData uploads | Fuerza Content-Type: application/json | Usar raw fetch con headers manuales |
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+| 2026-03-24 | Block editor usa auto-save 2s debounce en vez de undo/redo | Server-first architecture, más robusto que local state |
+| 2026-03-24 | Professor accent = violet, no teal | Consistente con otras pages del profesor |
+| 2026-03-24 | Prototype design tokens: darkTeal=#1B3B36, tealAccent=#2a8c7a | Definidos en theme.css como CSS variables |
+| 2026-03-25 | Image upload usa POST /storage/upload (backend route) no direct Supabase | Centraliza logging, validación, path generation |
+| 2026-03-25 | KeywordChip usa hover popover con 150ms delay | Mejor UX que tooltip nativo, evita flicker |

--- a/.claude/agent-memory/3d-viewer.md
+++ b/.claude/agent-memory/3d-viewer.md
@@ -1,0 +1,20 @@
+# 3D Viewer Memory
+
+## Estado actual
+- Three.js viewer working with GLB models
+- Pin system (point/line/area types)
+- Student spatial notes
+- Layer/part visibility
+- Animation, clipping planes, explode view
+
+## Decisiones tomadas (NO re-litigar)
+- Three.js in separate vendor chunk
+- GLB magic byte validation
+- 100MB upload limit
+
+## Archivos clave
+- components/viewer3d/ (19 files, 4700L) — full 3D viewer, pins, layers, animations
+- lib/model3d-api.ts (329L) — model upload/download, GLB validation
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory/admin.md
+++ b/.claude/agent-memory/admin.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory/ai-rag.md
+++ b/.claude/agent-memory/ai-rag.md
@@ -1,0 +1,18 @@
+# AI/RAG Memory
+
+## Estado actual
+- Gemini 2.5 Flash for generation
+- OpenAI text-embedding-3-large (1536d) for embeddings
+- RAG chat streaming works (both ?stream=1 AND body.stream)
+- Voice calls via OpenAI Realtime API
+
+## Decisiones tomadas (NO re-litigar)
+- Stream convention: send BOTH query param AND body field
+- DOMPurify for all AI output rendering
+
+## Archivos clave
+- services/ai-service/ (10 files) — AI service layer, streaming, embeddings
+- components/ai/AxonAIAssistant.tsx (1106L) — main AI chat component
+
+## Bugs conocidos
+- BUG-035 resolved (stream param mismatch)

--- a/.claude/agent-memory/auth.md
+++ b/.claude/agent-memory/auth.md
@@ -1,0 +1,19 @@
+# Auth Memory
+
+## Estado actual
+- Dual token working: ANON_KEY (Supabase anon) + X-Access-Token (user session)
+- AuthContext has backward-compat aliases (20 properties)
+- No password reset flow implemented
+- No 401/session expiration handling
+
+## Decisiones tomadas (NO re-litigar)
+- Role NOT in JWT, comes from GET /institutions
+- localStorage for token persistence
+
+## Archivos clave
+- context/AuthContext.tsx (487L) — main auth state, dual token logic, 20 backward-compat aliases
+- lib/api.ts (308L) — axios instance, interceptors, token injection
+- components/auth/*.tsx — login, register, route guards
+
+## Bugs conocidos
+- BUG-031 resolved (swallowed 500s)

--- a/.claude/agent-memory/billing.md
+++ b/.claude/agent-memory/billing.md
@@ -1,0 +1,17 @@
+# Billing Memory
+
+## Estado actual
+- Stripe checkout + portal integrated
+- Owner plans page exists (844L)
+- Subscriptions page exists (373L)
+
+## Decisiones tomadas (NO re-litigar)
+- Stripe webhook HMAC validation required
+
+## Archivos clave
+- OwnerPlansPage.tsx (844L) — plan selection, Stripe checkout
+- OwnerSubscriptionsPage.tsx (373L) — subscription management, portal link
+- pa-plans.ts (127L) — plans API
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory/cross-cutting.md
+++ b/.claude/agent-memory/cross-cutting.md
@@ -1,0 +1,22 @@
+# Cross-Cutting Memory
+
+## Estado actual
+- 624 TS/TSX files
+- 11 type files with DUPLICATE definitions (Course/Topic/Section/Semester defined 3x)
+- legacy-stubs.ts marked for deletion
+- 48 shadcn/ui components
+- 28 shared components
+
+## Decisiones tomadas (NO re-litigar)
+- platform.ts is canonical for DB types
+- content.ts for nested UI types
+- legacy-stubs.ts will be deleted
+
+## Archivos clave
+- types/*.ts (11 files) — type definitions, watch for duplicates
+- lib/*.ts (28 files) — utilities, API clients, helpers
+- components/shared/ (28 files) — reusable UI components
+
+## Bugs conocidos
+- BUG-024 (overlapping kw-student-notes types)
+- BUG-027 (dual content tree implementation)

--- a/.claude/agent-memory/dashboard.md
+++ b/.claude/agent-memory/dashboard.md
@@ -1,0 +1,20 @@
+# Dashboard Memory
+
+## Estado actual
+- Student dashboard with real KPIs (StatsCards, ActivityHeatMap, MasteryOverview)
+- GamificationContext partially stubbed
+- Gamification pages working (Badges, Leaderboard, XpHistory)
+
+## Decisiones tomadas (NO re-litigar)
+- XP daily cap 500
+- 12 levels
+- 39 badges
+- Delta Mastery Scale for colors
+
+## Archivos clave
+- components/dashboard/ (12 files) — StatsCards, ActivityHeatMap, MasteryOverview
+- components/gamification/ (11+3 pages) — Badges, Leaderboard, XpHistory
+- services/gamificationApi.ts (377L) — XP, levels, badges API
+
+## Bugs conocidos
+- BUG-021 (GamificationContext stubs)

--- a/.claude/agent-memory/docs.md
+++ b/.claude/agent-memory/docs.md
@@ -1,0 +1,20 @@
+# Memory: docs
+Last updated: 2026-03-19
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolucion |
+|-------|-------|---------|------------|
+| 2026-03-19 | Section numbers in PLATFORM-CONTEXT shifted when inserting security section | PLATFORM-CONTEXT.md | Fixed: renumbered 8-11 to 8-12 |
+
+## Patterns a evitar (max 10)
+| Pattern | Por que | Alternativa |
+|---------|---------|-------------|
+| Deleting resolved bugs from KNOWN-BUGS.md | Loses audit trail / history | Mark as RESOLVED with date, keep in separate section |
+| Duplicating security details across files | Drift risk between KNOWN-BUGS, security-audit, PLATFORM-CONTEXT | Single source in security-audit.md, others cross-reference |
+
+## Decisiones (max 10)
+| Fecha | Decision | Contexto |
+|-------|---------|----------|
+| 2026-03-19 | Added section 8 (Security Posture) to PLATFORM-CONTEXT.md | Security audit resolved 14 issues; platform now has substantial security surface worth documenting as stable reference |
+| 2026-03-19 | New bug IDs SEC-* for security items not previously tracked | Telegram, AI injection, XSS, CSP etc. had no BUG-### ID; created SEC-* namespace |
+| 2026-03-19 | Open count now 19 (was 16) — 3 resolved but 6 new open items added | SEC-S7, SEC-S9B, SEC-S16, TEST-001, TEST-002 are new; BUG-002/003/004 resolved |

--- a/.claude/agent-memory/flashcards.md
+++ b/.claude/agent-memory/flashcards.md
@@ -1,0 +1,20 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-18 | delta-color-scale test expected 'blue' for 0.99/0.90 but IEEE 754 gives 1.0999...9 < 1.10 | src/__tests__/delta-color-scale.test.ts:88-91 | Fixed assertion to expect 'green' (correct per floating point) |
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Using ASCII for Spanish chars in test expectations | Source uses accented chars (Conexion vs Conexion, Debil vs Debil) | Use unicode escapes or copy exact string from source |
+| Regex assuming 2-digit day/month in toLocaleDateString('es') | jsdom locale formatting may produce 1-digit day/month | Use `\d{1,2}` instead of `\d{2}` |
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+| 2026-03-18 | Perf test at mindmap/__tests__/ not __tests__/ | vitest.config includes only src/**/*.test.ts; root __tests__/ would not be picked up |
+| 2026-03-18 | Cross-linked graphs make computeHiddenNodes non-deterministic for root collapse | Cross-links create incoming edges to tree root, so root is no longer detected as root by the BFS seed logic. Use pure trees for collapse correctness tests. |
+| 2026-03-18 | Test unexported pure functions by replicating logic in test files | useEdgeReconnect's findNearestNode is not exported; replicate + validate contract via source reading (same pattern as mapComparisonPanel.test.ts) |

--- a/.claude/agent-memory/individual/3D-01-viewer3d-frontend.md
+++ b/.claude/agent-memory/individual/3D-01-viewer3d-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: 3D-01 (viewer3d-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Interfaz de usuario del visor 3D anatomico: componentes React con Three.js, camara, iluminacion, raycasting y capas de partes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Dispose explicito de geometrias, materiales y texturas de Three.js al desmontar para evitar memory leaks.
+- Usar GLTFLoader para carga de modelos GLB/GLTF.
+- Implementar raycasting para deteccion de clicks sobre partes del modelo.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas de red; nunca fetch directo.
+- Design system consistente: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| No hacer dispose de recursos Three.js | Memory leaks acumulativos que degradan performance | Dispose de geometrias, materiales y texturas al desmontar |
+| Usar fetch directo en lugar de `apiCall()` | Rompe el contrato de la capa de API | Siempre usar `apiCall()` de `lib/api.ts` |
+| Usar `any` en TypeScript | Anula las garantias de tipo y oculta bugs | TypeScript strict en todo momento |
+| console.log en produccion | Filtra informacion y es indicador de codigo no revisado | Usar herramientas de debugging apropiadas |
+| Modificar logica de otra zona sin escalar | Genera conflictos con otros agentes | Escalar al lead (XX-01) si se necesita modificar otra zona |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/3D-02-viewer3d-backend.md
+++ b/.claude/agent-memory/individual/3D-02-viewer3d-backend.md
@@ -1,0 +1,45 @@
+# Agent Memory: 3D-02 (viewer3d-backend)
+Last updated: 2026-03-25
+
+## Rol
+Rutas API backend para CRUD de modelos 3D, subida de archivos GLB a Supabase Storage, y gestion de partes y capas anatomicas.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Validar inputs en cada endpoint sin excepcion.
+- Autenticar via JWT en header `X-Access-Token` antes de procesar cualquier solicitud.
+- Respetar RLS policies de Supabase para control de acceso por institucion y rol.
+- Mantener naming convention de rutas de modelos al crear nuevos archivos.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Endpoints sin validacion de inputs | Permite datos corruptos o ataques de inyeccion | Validar todo input antes de procesar |
+| Modificar middleware de auth o RLS sin escalar | Afecta seguridad del sistema completo | Escalar al lead (XX-01) para cambios de auth/RLS |
+| Cambiar esquema de base de datos directamente | Riesgo de migraciones inconsistentes y perdida de datos | Escalar al lead; los cambios de schema requieren coordinacion |
+| Usar `any` en TypeScript | Anula las garantias de tipo | TypeScript strict en todo momento |
+| console.log en produccion | Filtra informacion sensible | Eliminar logs antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/3D-03-viewer3d-upload.md
+++ b/.claude/agent-memory/individual/3D-03-viewer3d-upload.md
@@ -1,0 +1,47 @@
+# Agent Memory: 3D-03 (viewer3d-upload)
+Last updated: 2026-03-25
+
+## Rol
+Interfaz de subida y gestion de modelos 3D para profesores: upload GLB, validacion de archivos, configuracion de partes anatomicas.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Validar archivos GLB via magic bytes antes de iniciar el upload (confirmar formato real, no solo extension).
+- Respetar el limite de 100MB por modelo; rechazar y notificar antes de intentar subir.
+- Centralizar todas las llamadas a la API de modelos en `model3d-api.ts` (329L).
+- Flujo orquestado por ModelManager (666L): seleccion → validacion → upload → asignacion de partes.
+- Usar TanStack Query para server state y cache de modelos.
+- Design system: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Subir archivos sin validar magic bytes | Permite subir archivos no-GLB con extension renombrada | Siempre verificar magic bytes antes del upload |
+| Omitir validacion de tamanio antes del upload | Genera errores costosos en storage con archivos > 100MB | Validar tamanio localmente primero |
+| Llamadas directas a API fuera de `model3d-api.ts` | Fragmenta la capa de servicio y duplica logica | Canalizar todo por `model3d-api.ts` |
+| Modificar logica del visor 3D (zona 3D-01) | Genera conflictos con el agente 3D-01 | Escalar al lead si se necesita coordinacion |
+| Usar `any` o console.log | Rompe TypeScript strict y filtra informacion | TypeScript strict; eliminar logs antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/3D-04-viewer3d-annotations.md
+++ b/.claude/agent-memory/individual/3D-04-viewer3d-annotations.md
@@ -1,0 +1,49 @@
+# Agent Memory: 3D-04 (viewer3d-annotations)
+Last updated: 2026-03-25
+
+## Rol
+Sistema de anotaciones 3D: pins espaciales, notas de profesores y estudiantes, marcadores billboard y posicionamiento via raycasting.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Limpiar event listeners de raycasting al desmontar componentes para evitar leaks.
+- PinMarker3D como sprite billboard: siempre orientado hacia la camara automaticamente.
+- LinePinMarker conecta el pin con su punto de anclaje fisico en el modelo mediante linea.
+- MultiPointPlacer para anotaciones complejas que requieren varios puntos de referencia.
+- Usar `usePinData` y `useNoteData` con TanStack Query para server state.
+- KeywordAutocomplete sugiere terminos anatomicos al escribir; acelera y estandariza anotaciones.
+- Usar `apiCall()` de `lib/api.ts`; nunca fetch directo.
+- Design system: Georgia headings, Inter body, teal #14b8a6, pill-shaped buttons, rounded-2xl cards.
+- Commits atomicos: 1 commit por cambio logico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| No limpiar event listeners de raycasting | Memory leaks y comportamiento fantasma al remontar | Siempre remover listeners en el cleanup de useEffect |
+| Modificar logica core del visor 3D (zona 3D-01) | Conflicto con el agente 3D-01 | Escalar al lead (XX-01) si se necesita coordinacion |
+| Cambiar rutas de API backend (zona 3D-02) | Conflicto con el agente 3D-02 | Escalar al lead; las rutas son zona exclusiva de 3D-02 |
+| Usar `any` o console.log | Rompe TypeScript strict y filtra informacion | TypeScript strict; limpiar logs antes de commit |
+| Pins sin punto de anclaje en superficie | Los pins "flotan" sin referencia espacial real | Usar raycasting para obtener punto exacto en la superficie del modelo |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AGENT-METRICS.md
+++ b/.claude/agent-memory/individual/AGENT-METRICS.md
@@ -1,0 +1,273 @@
+# AXON Agent Metrics
+Last updated: 2026-03-30 | Total sessions: 2
+
+> El Arquitecto lee este archivo al inicio de cada sesión y lo actualiza después de cada post-mortem.
+
+---
+
+## 1. System Pulse
+
+| Métrica                      | Últimas 5 | Previas 5 | Trend |
+|------------------------------|-----------|-----------|-------|
+| QG first-pass rate           | 100%      | —         | +++   |
+| Scope creep incidents        | 0         | —         | =     |
+| Repeat errors (post-lesson)  | 1         | —         | --    |
+| Merge conflicts              | 0         | —         | =     |
+| Avg agents per session       | 3.5       | —         | =     |
+| Lessons registered           | 14        | —         | +++   |
+
+> Trend: `+++` mejora fuerte, `++` mejora, `=` estable, `--` declive, `---` declive fuerte
+
+### Qué decide cada métrica
+
+| Métrica | Si el valor es malo → acción |
+|---------|------------------------------|
+| QG first-pass rate <75% | Pausar features, auditar agentes que fallan |
+| Scope creep >2 | Revisar reglas en `feedback_agent_isolation.md` |
+| Repeat errors >0 | Las lecciones no funcionan — fortalecer definiciones de agentes |
+| Merge conflicts >2 | Revisar overlap de archivos en AGENT-REGISTRY |
+
+---
+
+## 2. Section Health
+
+| Section        | Agents | Active | QG Rate (L5) | Top Error | Lessons | Repeats | Status |
+|----------------|--------|--------|--------------|-----------|---------|---------|--------|
+| Quiz (QZ)      | 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| Flashcards (FC)| 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| Summaries (SM) | 6      | 4      | 100%         | severity-mismatch | 14      | 0       | ACTIVE |
+| Study (ST)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Dashboard (DG) | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Admin (AO)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Auth (AS)      | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| AI & RAG (AI)  | 6      | 0      | —            | —         | 0       | 0       | NEW    |
+| 3D Viewer (3D) | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Infra (IF)     | 5      | 0      | —            | —         | 0       | 0       | NEW    |
+| Messaging (MG) | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Billing (BL)   | 4      | 0      | —            | —         | 0       | 0       | NEW    |
+| Cross-cut (XX) | 9      | 0      | —            | —         | 0       | 0       | NEW    |
+
+> **Top Error** usa los 6 checks del QG: `zone` | `ts` | `spec` | `tests` | `git` | `compat`
+> **Status** = peor health de cualquier agente de la sección
+
+---
+
+## 3. Agent Detail
+
+### Quiz (QZ)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| QZ-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| QZ-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Flashcards (FC)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| FC-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| FC-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Summaries (SM)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| SM-01 | 1        | 100%   | —                   | 0     | 2026-03-30 | +++   | GREEN  |
+| SM-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| SM-06 | 1        | 100%   | —                   | 0     | 2026-03-30 | +++   | GREEN  |
+
+### Study (ST)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| ST-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| ST-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Dashboard & Gamification (DG)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| DG-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| DG-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Admin & Owner (AO)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AO-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AO-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Auth & Security (AS)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AS-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AS-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AS-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+> AS-03, AS-04 son supervisores → ver Sección 5
+
+### AI & RAG (AI)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| AI-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| AI-06 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### 3D Viewer (3D)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| 3D-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| 3D-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Infrastructure (IF)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| IF-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| IF-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Messaging (MG)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| MG-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| MG-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Billing (BL)
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| BL-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-02 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| BL-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+### Cross-cutting (XX) — solo implementadores
+| ID    | Sessions | QG L5  | Fails By Type (L5) | Scope | Last Run | Trend | Health |
+|-------|----------|--------|---------------------|-------|----------|-------|--------|
+| XX-01 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-03 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-04 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-05 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+| XX-08 | 0        | —      | —                   | 0     | —        | —     | NEW    |
+
+> XX-02, XX-06, XX-07, XX-09 son supervisores → ver Sección 5
+
+---
+
+## 4. Error Ledger (últimos 20 errores)
+
+> Conecta: QG failure → lección → prevención. Si `Recurred? = YES`, la lección no funcionó.
+
+| #  | Date | Agent | QG Check | Description | Lesson? | Where | Recurred? |
+|----|------|-------|----------|-------------|---------|-------|-----------|
+| — | — | — | — | (sin errores registrados) | — | — | — |
+
+> **QG Check** es uno de: `zone` `ts` `spec` `tests` `git` `compat`
+> **Recurred?** = YES(#N) si el mismo agente repitió el mismo tipo de error después de una lección
+
+---
+
+## 5. Supervisor Metrics
+
+> Los supervisores generan auditorías, no código. Sus métricas son de hallazgos, no de QG pass/fail.
+
+### XX-02 quality-gate
+| Runs | APPROVE | NEEDS FIX | BLOCK | False Pos | False Neg | Accuracy |
+|------|---------|-----------|-------|-----------|-----------|----------|
+| 1    | 1       | 0         | 0     | 0         | 0         | 100%     |
+
+### XX-06 test-orchestrator
+| Runs | Tests Exec | Tests Failed | Flaky Detected | Slow (>5s) | .only/.skip |
+|------|-----------|-------------|----------------|------------|-------------|
+| 0    | 0         | 0           | 0              | 0          | 0           |
+
+### AS-04 security-scanner
+| Runs | Findings | Critical | High | Medium | Resolved | False Pos |
+|------|----------|----------|------|--------|----------|-----------|
+| 0    | 0        | 0        | 0    | 0      | 0        | 0         |
+
+### XX-07 refactor-scout
+| Runs | Findings | Critical | High | Actioned | Ignored | Trend |
+|------|----------|----------|------|----------|---------|-------|
+| 0    | 0        | 0        | 0    | 0        | 0       | —     |
+
+### AS-03 rls-auditor
+| Runs | Tables Audited | Gaps Found | Gaps Fixed | Misconfigs |
+|------|---------------|------------|------------|------------|
+| 0    | 0             | 0          | 0          | 0          |
+
+### XX-09 api-contract
+| Runs | Contracts | Mismatches | Envelope Violations | Orphan Endpoints |
+|------|-----------|------------|---------------------|------------------|
+| 0    | 0         | 0          | 0                   | 0                |
+
+---
+
+## 6. Scoring Rules
+
+### Agent Health (basado en últimas 5 sesiones)
+| Health | Criterio |
+|--------|----------|
+| NEW    | 0 sesiones |
+| GREEN  | >=80% QG pass AND 0 scope creep |
+| YELLOW | 60-79% QG pass OR 1 scope creep OR 1 repeat error |
+| RED    | <60% QG pass OR 2+ scope creep OR 2+ repeat errors OR 2+ BLOCK |
+
+### Section Status (derivado de agentes de la sección)
+| Status | Criterio |
+|--------|----------|
+| NEW    | Todos los agentes NEW |
+| GREEN  | 0 agentes RED AND QG rate sección >=80% |
+| YELLOW | 1 agente RED OR QG rate sección 60-79% |
+| RED    | 2+ agentes RED OR QG rate sección <60% OR any repeat error |
+
+### Trend (comparar últimas 5 vs previas 5)
+| Trend | Significado |
+|-------|-------------|
+| `+++` | Mejoró 40%+ puntos |
+| `++`  | Mejoró 20-39% puntos |
+| `=`   | Cambió <20% puntos |
+| `--`  | Declinó 20-39% puntos |
+| `---` | Declinó 40%+ puntos |
+| `—`   | <6 sesiones totales (datos insuficientes) |
+
+### Error Type Codes
+`zone` = zone compliance | `ts` = TypeScript | `spec` = spec coherence
+`tests` = test coverage | `git` = git hygiene | `compat` = backward compatibility
+
+---
+
+## Update Protocol (después de cada post-mortem)
+
+**Paso 1 (30s): Error Ledger.** Por cada QG failure, agregar fila. Verificar si matchea una lección previa del mismo agente → marcar `Recurred? YES(#N)`.
+
+**Paso 2 (30s): Agent Detail.** Por cada agente que participó: incrementar Sessions, actualizar QG L5 (agregar resultado, dropear el más viejo si >5), actualizar Fails By Type, Scope, Last Run. Recalcular Trend y Health.
+
+**Paso 3 (15s): Section Health.** Por cada sección que tuvo agentes: recalcular QG Rate (L5) agregando todos los agentes activos. Actualizar Top Error, Active, Lessons, Repeats. Derivar Status.
+
+**Paso 4 (15s): System Pulse.** Recalcular las 6 métricas del sistema. Rotar ventana. Actualizar trends.
+
+**Paso 5 (15s): Supervisor Metrics.** Si un supervisor participó, actualizar su tabla específica en Sección 5.
+
+> Tiempo total estimado: ~2 minutos de edición manual por post-mortem.

--- a/.claude/agent-memory/individual/AI-01-rag-pipeline.md
+++ b/.claude/agent-memory/individual/AI-01-rag-pipeline.md
@@ -1,0 +1,47 @@
+# Agent Memory: AI-01 (rag-pipeline)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Modelo embeddings: OpenAI text-embedding-3-large (1536 dimensiones)
+- Almacenamiento: PostgreSQL + pgvector (1536d)
+- Chunking: semántico (títulos, párrafos, listas) — NO por tokens arbitrarios
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Chunking semántico sobre chunking por tokens | Maximiza relevancia en búsqueda vectorial | Chunking por tokens fijo |
+| 2026-03-25 | Streaming/paginado para PDFs grandes | Nunca cargar PDF completo en memoria | Carga completa en memoria |
+| 2026-03-25 | Logs estructurados por etapa del pipeline | Extracción → Chunking → Embedding → Storage | Logs planos sin etapas |
+
+## Patrones que funcionan
+- as-ingest.ts como coordinador del pipeline completo
+- Procesamiento por páginas para PDFs grandes
+- Manejo granular de errores (páginas corruptas, sin OCR, etc.)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Cargar PDF completo en memoria | OOM en documentos grandes | Procesar en streaming o por páginas |
+| Chunks por tamaño de tokens fijo | Rompe contexto semántico | Respetar límites de párrafo/sección |
+| Insertar embeddings sin validar dimensión | pgvector rechaza dimensiones incorrectas | Siempre validar dim=1536 antes de INSERT |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/AI-02-rag-chat.md
+++ b/.claude/agent-memory/individual/AI-02-rag-chat.md
@@ -1,0 +1,49 @@
+# Agent Memory: AI-02 (rag-chat)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- LLM: Gemini 2.5 Flash para generación
+- Streaming: SSE (Server-Sent Events)
+- Stream convention: enviar BOTH ?stream=1 AND body.stream (decisión final, NO re-litigar)
+- Sanitización: DOMPurify para todo output AI renderizado
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | BUG-035 (stream param mismatch) ya resuelto | Siempre enviar ambos: query param Y body field |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Dual stream param (query + body) | Backend checks ambos; eliminar uno rompe streaming | Solo query param, solo body param |
+| 2026-03-25 | DOMPurify obligatorio | Previene XSS en output del LLM | Renderizar HTML crudo del LLM |
+| 2026-03-25 | Reconexión automática en SSE | El usuario no debe perder contexto si la conexión se cae | Sin reconexión automática |
+
+## Patrones que funcionan
+- AxonAIAssistant.tsx (1106L) como componente monolítico — refactors deben ser incrementales
+- Renderizado incremental de streaming (no esperar mensaje completo)
+- Ventana de historial limitada para no exceder tokens del modelo
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Enviar solo ?stream=1 sin body.stream | Backend checkea ambos → streaming falla silenciosamente | Siempre enviar AMBOS |
+| Renderizar HTML del LLM sin sanitizar | XSS via prompt injection | DOMPurify.sanitize() siempre |
+| Refactor big-bang de AxonAIAssistant | 1106 líneas, alto riesgo de regresión | Refactors incrementales con tests |
+| Historial ilimitado en contexto | Excede límite de tokens del modelo | Ventana deslizante de N turnos |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/AI-03-ai-generation.md
+++ b/.claude/agent-memory/individual/AI-03-ai-generation.md
@@ -1,0 +1,44 @@
+# Agent Memory: AI-03 (ai-generation)
+Last updated: 2026-03-25
+
+## Rol
+Generacion automatizada de contenido educativo (flashcards, quizzes, resumenes) con targeting adaptativo via NeedScore y BKT.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Calcular NeedScore considerando los 4 factores: frecuencia de repaso, dificultad del item, tiempo desde ultimo repaso y rendimiento historico.
+- Separar logica de UI y logica de negocio en `useSmartGeneration.ts` (279L).
+- Usar `aiApi.ts` (263L) como interfaz central para todas las llamadas a servicios AI desde frontend.
+- Distinguir claramente entre generacion smart (BKT targeting) y generacion rapida (sin analisis).
+- Documentar cambios en algoritmos de ranking en `agent-memory/ai-rag.md` inmediatamente.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Generar contenido para conceptos con P(L) > 0.95 | El estudiante ya domina el concepto; desperdicia recursos | Verificar BKT antes de lanzar generacion |
+| Presentar contenido sin validacion de calidad | Degrada la experiencia pedagogica | Pasar siempre por pipeline de validacion antes de mostrar al usuario |
+| Hardcodear llamadas AI fuera de `aiApi.ts` | Rompe la interfaz central y crea deuda tecnica | Canalizar todo por `aiApi.ts` |
+| Mezclar logica de UI con logica de negocio en hooks | Dificulta el mantenimiento y testeo | Mantener separacion clara en `useSmartGeneration.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AI-04-embeddings.md
+++ b/.claude/agent-memory/individual/AI-04-embeddings.md
@@ -1,0 +1,48 @@
+# Agent Memory: AI-04 (embeddings)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Modelo: OpenAI text-embedding-3-large (1536 dimensiones)
+- Storage: PostgreSQL + pgvector
+- Índices: IVFFlat (datasets grandes) o HNSW (mayor precisión)
+- Distancia: coseno
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | IVFFlat como índice default | Balance entre velocidad y precisión para volumen actual | HNSW (mayor precisión pero más lento para este volumen) |
+| 2026-03-25 | Cache local en useRagAnalytics | Evitar llamadas excesivas al backend para stats de cobertura | Sin cache, polling directo |
+| 2026-03-25 | Nunca eliminar embeddings sin verificar referencias | Conversaciones activas pueden referenciar chunks | DELETE directo sin auditoría |
+
+## Patrones que funcionan
+- as-analytics.ts para stats de cobertura centralizadas
+- Cache local en hooks para métricas que cambian poco
+- Validación de dimensión (1536) antes de INSERT
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Full table scan para stats de cobertura | Muy lento en datasets grandes | Queries con COUNT + índices |
+| DELETE de embeddings sin verificar refs | Rompe conversaciones activas | Check referencias antes de DELETE |
+| Insertar sin validar dimensión | pgvector rechaza silenciosamente | Validar dim=1536 en capa de servicio |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/AI-05-ai-backend.md
+++ b/.claude/agent-memory/individual/AI-05-ai-backend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AI-05 (ai-backend)
+Last updated: 2026-03-25
+
+## Rol
+Route handlers del backend AI (17 rutas REST/WebSocket), agente de horarios y integracion con OpenAI Realtime API para voz en tiempo real.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Aplicar estructura consistente en las 17 rutas: validacion → procesamiento → respuesta.
+- Validar autenticacion y autorizacion antes de cualquier procesamiento en rutas AI.
+- Implementar rate limiting especifico para operaciones AI (mas restrictivo que rutas generales).
+- Reconexion automatica obligatoria en el WebSocket de `as-realtime.ts` (297L).
+- Considerar zonas horarias del usuario en todo cambio a `as-schedule.ts` (236L).
+- Documentar cambios en rutas y servicios de tiempo real en `agent-memory/ai-rag.md`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Rutas AI sin validacion de auth | Expone endpoints sensibles | Siempre validar auth/authz primero |
+| Ignorar reconexion en WebSocket Realtime | Interrumpe sesiones de voz del usuario | Implementar reconexion automatica en `as-realtime.ts` |
+| Latencia > 200ms en audio bidireccional | Degrada la experiencia de voz | Optimizar pipeline en `useRealtimeVoice.ts` (309L) |
+| Omitir zonas horarias en el agente de horarios | Genera planes de estudio incorrectos | Siempre resolver timezone del usuario en `as-schedule.ts` |
+| Rate limiting identico al de rutas generales | Las ops AI son mas costosas; sobrecarga el sistema | Configurar rate limits especificos y mas restrictivos |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AI-06-ai-prompts.md
+++ b/.claude/agent-memory/individual/AI-06-ai-prompts.md
@@ -1,0 +1,47 @@
+# Agent Memory: AI-06 (ai-prompts)
+Last updated: 2026-03-25
+
+## Rol
+Ingenieria de prompts y plantillas centralizadas para todos los servicios AI, mas el sistema de reportes de calidad pedagogica.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Centralizar todos los prompt templates en `as-types.ts` (232L); ninguno hardcodeado en servicios.
+- Asignar identificador unico y version a cada template para trazabilidad y rollback.
+- Incluir instrucciones explicitas de formato de salida (JSON schema cuando aplique) en cada prompt.
+- Verificar compatibilidad con todos los consumidores antes de modificar `as-types.ts` (afecta a todos los servicios AI).
+- Evaluar reportes en 4 dimensiones: relevancia, precision, completitud y adecuacion pedagogica.
+- Mantener separacion entre logica de datos y presentacion en `useAiReports.ts` (244L).
+- Documentar todo cambio de template en `agent-memory/ai-rag.md` con justificacion y resultados de evaluacion.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear prompts directamente en servicios AI | Imposibilita el versionado, A/B testing y rollback | Siempre usar templates centralizados en `as-types.ts` |
+| Modificar `as-types.ts` sin verificar consumidores | Rompe silenciosamente servicios que dependen de ese tipo | Revisar todos los importers antes de modificar |
+| Templates sin identificador ni version | Impide trazabilidad y rollback ante degradacion | Versionar desde la creacion del template |
+| Prompts sin especificacion de formato de salida | Outputs inconsistentes y dificiles de parsear | Incluir JSON schema o instrucciones de formato explícitas |
+| Mezclar logica de datos y UI en `useAiReports.ts` | Dificulta mantenimiento y testeo | Mantener separacion clara entre capas |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AO-01-admin-frontend.md
+++ b/.claude/agent-memory/individual/AO-01-admin-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-01 (admin-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend de administracion institucional: mantiene las paginas del rol admin (dashboard, contenido, miembros, reportes, scopes, settings, AI health, messaging) y el archivo admin-routes.ts.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+- Páginas funcionales (Settings 271L, AI Health 345L, Messaging 521L) requieren mayor cuidado: no romper lógica operativa existente
+- Páginas placeholder (Dashboard, Content, Members, Reports, Scopes): cablearlas con rutas reales siguiendo el patrón de admin-routes.ts
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Modificar archivos fuera de `**/pages/admin/*` o `admin-routes.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Fetch directo sin `apiCall()` | Inconsistencia en manejo de auth headers y errores | Siempre usar `apiCall()` de `lib/api.ts` |
+| Editar mega-componentes sin revisar líneas totales | Riesgo de introducir regresiones en componentes grandes | Leer el archivo completo antes de editar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AO-02-admin-backend.md
+++ b/.claude/agent-memory/individual/AO-02-admin-backend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-02 (admin-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de administracion institucional: mantiene las rutas API de admin, el servicio pa-admin.ts y la lógica de scopes, reglas de acceso, gestión de estudiantes y búsqueda administrativa.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Validar permisos de rol admin en cada endpoint antes de ejecutar lógica de negocio
+- Centralizar llamadas a la API de plataforma en pa-admin.ts (223L) — no duplicar lógica en rutas
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Omitir validación de rol admin en endpoints | Expone operaciones administrativas a usuarios no autorizados | Siempre aplicar middleware de auth con validación de rol |
+| Modificar archivos fuera de `**/routes/admin*` o `pa-admin.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Duplicar lógica de plataforma fuera de pa-admin.ts | Inconsistencia y mantenimiento difícil | Centralizar en pa-admin.ts |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AO-03-owner-frontend.md
+++ b/.claude/agent-memory/individual/AO-03-owner-frontend.md
@@ -1,0 +1,46 @@
+# Agent Memory: AO-03 (owner-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente frontend del rol owner: mantiene las páginas de dashboard, miembros, planes, suscripciones, reglas de acceso, reportes, institución y settings del owner, con especial atención a la descomposición correcta de mega-componentes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Leer el archivo completo antes de editar mega-componentes (OwnerMembersPage 1276L, OwnerPlansPage 844L, OwnerDashboardPage 602L)
+- Al descomponer mega-componentes: extraer subcomponentes por responsabilidad (CRUD, invitaciones, roles)
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Editar mega-componentes sin leer el archivo completo primero | Riesgo alto de regresiones en 800-1276L | Leer todo el componente antes de planificar cambios |
+| Crear subcomponentes sin respetar la estructura de directorios existente | Inconsistencia arquitectural | Seguir el patrón de organización de `components/roles/pages/owner/` |
+| Modificar archivos fuera de `**/pages/owner/*` o `owner-routes.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AO-04-owner-backend.md
+++ b/.claude/agent-memory/individual/AO-04-owner-backend.md
@@ -1,0 +1,47 @@
+# Agent Memory: AO-04 (owner-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend del rol owner: mantiene las rutas API de owner, los servicios pa-institutions.ts y pa-plans.ts, y la lógica de CRUD de instituciones, gestión de membresías y administración de planes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/admin.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Separar responsabilidades: pa-institutions.ts para CRUD de instituciones, pa-plans.ts para gestión de planes
+- Validar permisos de rol owner en cada endpoint antes de ejecutar lógica de negocio
+- Plan CRUD: incluir siempre definición de límites, features y precios en las operaciones de planes
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer datos sensibles | Eliminar antes de commit |
+| Omitir validación de rol owner en endpoints | Expone operaciones de propietario a usuarios no autorizados | Siempre aplicar middleware de auth con validación de rol owner |
+| Mezclar lógica de instituciones y planes en el mismo servicio | Dificulta mantenimiento y viola SRP | Mantener pa-institutions.ts y pa-plans.ts separados |
+| Modificar archivos fuera de `**/routes/owner*`, `pa-institutions.*` o `pa-plans.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/AS-01-auth-backend.md
+++ b/.claude/agent-memory/individual/AS-01-auth-backend.md
@@ -1,0 +1,51 @@
+# Agent Memory: AS-01 (auth-backend)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- Dual token: SUPABASE_ANON_KEY (Bearer) + USER_JWT (X-Access-Token)
+- Role NO está en JWT — viene de GET /institutions
+- RLS policies a nivel de PostgreSQL
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Dual token es arquitectura definitiva | ANON_KEY para Supabase client, USER_JWT para auth de API | Token único para ambos propósitos |
+| 2026-03-25 | Role via GET /institutions, no JWT claims | Permite cambio de role sin reauth | Claims de rol en el JWT |
+
+## Patrones que funcionan
+- middleware/auth.ts como punto único de validación
+- RLS policies como segunda capa de defensa (DB level)
+- Separación clara: auth.ts (lógica) vs routes/auth.ts (HTTP)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Leer role desde JWT claims | Role no está en JWT por diseño | GET /institutions para obtener role |
+| Bypass de middleware para "conveniencia" | Abre agujeros de seguridad | Siempre pasar por middleware/auth.ts |
+| RLS policies que asumen role en JWT | Inconsistente con arquitectura dual-token | Usar service_role key para operaciones admin |
+
+## Impacto (CRITICAL — bloquea todos los agentes backend)
+- TODOS los agentes backend dependen implícitamente de AS-01
+- Cualquier cambio en auth middleware afecta a toda la plataforma
+- Cambios requieren: tests exhaustivos + security review + quality-gate
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/AS-02-auth-frontend.md
+++ b/.claude/agent-memory/individual/AS-02-auth-frontend.md
@@ -1,0 +1,57 @@
+# Agent Memory: AS-02 (auth-frontend)
+Last updated: 2026-03-26
+
+## Rol
+Agente frontend de autenticación: mantiene el AuthContext, las páginas de login/registro, los guards de rutas basados en roles (RequireAuth, RequireRole) y la lógica de redirección post-login.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | Para tests de AuthContext, mockear supabase y api con funciones proxy (`(...args) => mockFn(...args)`) en vi.mock factories permite reconfigurar mocks por test sin problemas de hoisting | Usar funciones proxy en vi.mock, no importar mocks directamente |
+| 2026-03-26 | signup() usa fetch directo (no apiCall) porque POST /signup no necesita X-Access-Token -- tests deben mockear globalThis.fetch para este caso | Verificar si la funcion bajo test usa fetch o apiCall antes de escribir el mock |
+| 2026-03-26 | AuthContext tiene console.log/error con guard `import.meta.env.DEV` que produce stdout en vitest (env=jsdom, DEV=true) -- no es un problema, es output esperado | No suprimir logs DEV-only a menos que contaminen la salida de un test |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/auth.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- Sincronizar tokens en localStorage con el AuthContext via `onAuthStateChange` de Supabase
+- Guards como componentes wrapper de React Router v6: RequireAuth verifica sesión, RequireRole verifica rol
+- PostLoginRouter: lógica de redirección basada en rol del usuario, nunca hardcodear rutas en componentes de página
+- SelectRolePage: mostrar solo cuando el usuario tiene múltiples roles asignados
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+- Para tests de AuthContext: usar `renderHook()` + `waitFor()` de @testing-library/react, con AuthProvider como wrapper
+- Mock de supabase: funciones proxy en vi.mock factory para permitir reconfiguracion por test (mockGetSession, mockSignInWithPassword, etc.)
+- Mock de api: mockApiCall con mockImplementation que rutea por path ('/me', '/institutions')
+- signup() usa fetch directo, no apiCall -- mockear globalThis.fetch para tests de signup
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs, puede exponer tokens o datos de sesión | Eliminar antes de commit |
+| Almacenar tokens sensibles fuera de localStorage gestionado por AuthContext | Estado inconsistente de sesión | Centralizar gestión de tokens en AuthContext |
+| Hardcodear rutas de redirección en componentes de página | Acoplamiento y dificulta mantenimiento | Centralizar lógica de redirección en PostLoginRouter |
+| Modificar archivos fuera de la zona: AuthContext, components/auth/*, RequireAuth, RequireRole | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Omitir guard RequireRole en rutas que requieren rol específico | Expone páginas de rol a usuarios sin permisos | Siempre componer RequireAuth + RequireRole en rutas protegidas |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Tests escritos | 16 | 2026-03-26 |

--- a/.claude/agent-memory/individual/AS-03-rls-auditor.md
+++ b/.claude/agent-memory/individual/AS-03-rls-auditor.md
@@ -1,0 +1,57 @@
+# Agent Memory: AS-03 (rls-auditor)
+Last updated: 2026-03-26 (session 1 — full RLS audit, 58 tables)
+
+## Audit Results (2026-03-26)
+- 58 tables audited: 38 full CRUD, 16 partial (by design), 6 service-role only
+- **2 HIGH findings**: platform_plans permissive CRUD for all auth users, ai_reading_config same
+- **4 MEDIUM findings**: rag_query_log no service_role, algorithm_config no service_role, summary_blocks scoped by created_by not institution, SECURITY DEFINER REVOKEs deferred
+- **1 LOW finding**: user_institution_ids() performance concern (acceptable)
+
+## Lecciones de esta sesión
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-26 | platform_plans tiene INSERT/UPDATE/DELETE para todos los authenticated — backend es la única protección | Siempre verificar que tablas admin tengan RLS restrictivo, no solo backend role checks |
+| 2026-03-26 | 6 SECURITY DEFINER functions sin REVOKE completado — deuda técnica documentada | Track como tech debt, requiere migración en 2 pasos |
+
+## Rol
+Audita políticas Row Level Security de PostgreSQL. Detecta tablas sin protección, políticas permisivas y misconfiguraciones.
+
+## Estado de tablas auditadas
+| Tabla | RLS Enabled | Policies (S/I/U/D) | Última auditoría | Issues |
+|-------|-------------|---------------------|-----------------|--------|
+| (ninguna aún) | — | — | — | — |
+
+> S=SELECT, I=INSERT, U=UPDATE, D=DELETE
+
+## Brechas históricas
+| Fecha | Tabla | Tipo de brecha | Severidad | Resuelto? | Cómo |
+|-------|-------|---------------|-----------|-----------|------|
+| (ninguna aún) | — | — | — | — | — |
+
+## Patrones RLS validados
+| Pattern | Notas |
+|---------|-------|
+| `auth.uid() = user_id` para SELECT propio | Patrón estándar de Supabase |
+| `auth.role() = 'service_role'` para admin | Solo backend con service key |
+| RLS enabled sin policies = bloqueado | Supabase bloquea todo por defecto |
+
+## Falsos positivos conocidos
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| (ninguno aún) | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory/individual/AS-04-security-scanner.md
+++ b/.claude/agent-memory/individual/AS-04-security-scanner.md
@@ -1,0 +1,59 @@
+# Agent Memory: AS-04 (security-scanner)
+Last updated: 2026-03-26 (session 1 — full scan)
+
+## Rol
+Escanea vulnerabilidades de seguridad (OWASP Top 10). Solo lectura — genera reportes, no modifica código.
+
+## Vulnerabilidades conocidas (tracking)
+| Fecha | Tipo (OWASP) | Archivo | Severidad | Status | Resolución |
+|-------|-------------|---------|-----------|--------|------------|
+| (ninguna aún) | — | — | — | — | — |
+
+## Falsos positivos conocidos (NO reportar)
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| DOMPurify.sanitize() + dangerouslySetInnerHTML | Sanitizado antes de render — es seguro |
+| Supabase ANON_KEY en código frontend | Es público por diseño (no es secret) |
+
+## Patrones seguros validados
+| Pattern | Verificado | Notas |
+|---------|-----------|-------|
+| DOMPurify para todo output AI | — | Decisión documentada en ai-rag.md |
+| Dual token (ANON_KEY + X-Access-Token) | — | Arquitectura definitiva de auth |
+| RLS como segunda capa de defensa | — | Complementa middleware/auth.ts |
+
+## Áreas de foco (dónde buscar primero)
+1. `components/` — buscar dangerouslySetInnerHTML sin DOMPurify
+2. `routes/` — buscar queries con concatenación de strings (SQL injection)
+3. `middleware/` — verificar CSP y CORS
+4. `lib/` — buscar secrets hardcodeados
+5. `services/` — verificar que inputs de usuario se validen
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | WhatsApp webhook uses fallback static salt when env var missing — silent degradation of crypto | Always check for hardcoded fallback values in crypto/hashing code |
+| 2026-03-26 | sanitize.ts ALLOW_DATA_ATTR: true is overly permissive | Check DOMPurify config options, not just ALLOWED_TAGS |
+| 2026-03-26 | No 401 interceptor means expired sessions show broken UI | Verify both auth flow AND session expiration handling |
+| 2026-03-26 | Scan result: 0 CRITICAL, 0 HIGH, 3 MEDIUM, 2 LOW. Codebase is generally secure. | Falsos positivos documentados: ANON_KEY, chart.tsx, CSRF absence, test tokens |
+
+## Vulnerabilidades tracking (2026-03-26 scan)
+| Severidad | Archivo | Issue | Status |
+|-----------|---------|-------|--------|
+| MEDIUM | sanitize.ts:34 | ALLOW_DATA_ATTR: true | OPEN |
+| MEDIUM | AuthContext.tsx | No 401/session expiration handling | OPEN |
+| MEDIUM | webhook.ts:167,331 | Hardcoded fallback salt | OPEN |
+| LOW | vercel.json:22 | unsafe-inline in style-src | OPEN |
+| LOW | — | No CSRF tokens (mitigated by Bearer auth design) | ACCEPTED |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory/individual/AS-05-cors-headers.md
+++ b/.claude/agent-memory/individual/AS-05-cors-headers.md
@@ -1,0 +1,53 @@
+# Agent Memory: AS-05 (cors-headers)
+Last updated: 2026-03-25
+
+## Rol
+Agente de seguridad de transporte: mantiene la configuración de CORS, Content-Security-Policy, headers HTTP de seguridad y hardening contra XSS en middleware/cors.ts, middleware/security.ts, vercel.json y lib/sanitize.ts.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca fetch directo
+- Leer CLAUDE.md + `memory/feedback_agent_isolation.md` + `agent-memory/auth.md` antes de tocar código
+- Revisar AGENT-METRICS.md (fila propia) para no repetir errores de sesiones anteriores
+- CORS: whitelist explícita de orígenes — nunca `*` en producción
+- CSP: directivas restrictivas por defecto (`default-src 'self'`), ampliar solo lo estrictamente necesario
+- HSTS: `max-age` mínimo de 1 año (31536000) + `includeSubDomains`
+- X-Frame-Options: `DENY` por defecto; `SAMEORIGIN` solo si hay iframes propios justificados
+- `X-Content-Type-Options: nosniff` siempre activo
+- DOMPurify para sanitizar HTML generado por usuarios antes de cualquier renderizado
+- vercel.json para headers de seguridad en despliegue serverless: mantener sincronizado con middleware/security.ts
+- Escalar al Arquitecto (XX-01) ante cualquier necesidad de modificar archivos fuera de la zona de ownership
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Rompe la seguridad de tipos del proyecto | Tipar correctamente o usar `unknown` con narrowing |
+| `console.log` en producción | Contamina logs | Eliminar antes de commit |
+| `Access-Control-Allow-Origin: *` en producción | Anula la protección CORS, permite peticiones desde cualquier origen | Whitelist explícita de dominios permitidos |
+| CSP permisiva con `unsafe-inline` o `unsafe-eval` | Neutraliza la protección contra XSS | Usar nonces o hashes para scripts inline si son imprescindibles |
+| Renderizar HTML de usuario sin sanitizar | Vectores de XSS almacenado | Siempre pasar por DOMPurify antes de `dangerouslySetInnerHTML` |
+| Desincronizar headers de vercel.json y middleware/security.ts | Comportamiento diferente entre entornos local y producción | Actualizar ambos archivos en el mismo commit |
+| Modificar archivos fuera de `middleware/cors.*`, `middleware/security.*`, `vercel.json`, `lib/sanitize.*` | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/BL-01-stripe-checkout.md
+++ b/.claude/agent-memory/individual/BL-01-stripe-checkout.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-01 (stripe-checkout)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración Stripe Checkout de AXON: mantiene la creación de sesiones de checkout, el portal de cliente de Stripe, y la lógica de gestión de suscripciones en el backend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flujo estándar: frontend solicita sesión → backend crea checkout session → redirect a Stripe → webhook confirma pago.
+- `lib/stripe.ts` inicializa el cliente Stripe y exporta helpers reutilizables — siempre usar estos helpers, no instanciar Stripe directamente en rutas.
+- Modo test en desarrollo: `STRIPE_SECRET_KEY` con prefijo `sk_test_` — verificar antes de ejecutar.
+- Variables de entorno: `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`.
+- Customer Portal para que el usuario gestione suscripción, método de pago y facturas sin pasar por código propio.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear API keys de Stripe | Exposición de credenciales en el repo | Variables de entorno exclusivamente |
+| Procesar confirmación de pago en esta zona | Responsabilidad de BL-02 (webhooks) | No duplicar lógica — dejar que el webhook la maneje |
+| Modificar lógica de planes (precios, features) | Zona de BL-04 | Escalar al lead |
+| Usar `any` en TypeScript | Rompe type safety | Tipar con los tipos de `@stripe/stripe-js` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/BL-02-stripe-webhooks.md
+++ b/.claude/agent-memory/individual/BL-02-stripe-webhooks.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-02 (stripe-webhooks)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en los webhook handlers de Stripe de AXON — mantiene la recepción, validación HMAC y procesamiento de eventos de pago, asegurando que los cambios de suscripción se reflejen correctamente en la base de datos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `stripe.webhooks.constructEvent()` para validar firma y parsear evento — nunca parsear manualmente.
+- El body del request debe llegar como raw buffer (no parseado por JSON middleware) para que la validación HMAC funcione.
+- Idempotencia: verificar `event.id` antes de procesar para evitar efectos dobles del mismo evento.
+- Retornar 200 rápidamente y procesar async si la operación es costosa — Stripe reintenta si no recibe 200.
+- Eventos clave: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_succeeded`, `invoice.payment_failed`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Procesar evento sin validar firma HMAC | Permite inyección de eventos falsos | Siempre usar `stripe.webhooks.constructEvent()` con `STRIPE_WEBHOOK_SECRET` |
+| Parsear body como JSON antes de validación | Rompe el cálculo HMAC | Usar raw buffer middleware antes de este handler |
+| No manejar idempotencia | El mismo evento procesado dos veces puede duplicar cobros/actualizaciones | Verificar `event.id` contra registro previo |
+| Modificar lógica de checkout | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de planes | Zona de BL-04 | Escalar al lead |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/BL-03-billing-frontend.md
+++ b/.claude/agent-memory/individual/BL-03-billing-frontend.md
@@ -1,0 +1,45 @@
+# Agent Memory: BL-03 (billing-frontend)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en la interfaz de facturación de AXON — mantiene los componentes de UI que muestran el estado de suscripción del owner, comparación de planes, e integración con el flujo de checkout de Stripe desde el frontend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- TanStack Query para server state de suscripciones — mantiene el estado sincronizado con el backend.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Flujo estándar: ver plan actual → seleccionar nuevo plan → redirect a Stripe Checkout → webhook actualiza estado.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP.
+- TypeScript strict, no `any`, no `console.log`, commits atómicos.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Llamar a la Stripe API directamente desde el frontend | Los secrets de Stripe no deben estar en el cliente | Toda llamada a Stripe pasa por el backend (BL-01) |
+| Modificar lógica de checkout backend | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de webhooks | Zona de BL-02 | Escalar al lead |
+| Modificar lógica de planes | Zona de BL-04 | Escalar al lead |
+| Usar fetch directo en vez de `apiCall()` | Rompe el patrón centralizado | Usar `apiCall()` de `lib/api.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/BL-04-billing-plans.md
+++ b/.claude/agent-memory/individual/BL-04-billing-plans.md
@@ -1,0 +1,46 @@
+# Agent Memory: BL-04 (billing-plans)
+Last updated: 2026-03-25
+
+## Rol
+Agente especializado en la gestión de planes de suscripción de AXON — mantiene el CRUD de planes, configuración por institución, planes por defecto del sistema, y la interfaz de administración de planes para owners.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `pa-plans.ts` centraliza todas las llamadas a la API de planes — no llamar a endpoints de planes desde otros archivos directamente.
+- Planes globales (default) + planes institucionales personalizados — el sistema soporta ambos niveles.
+- Cada plan define nombre, descripción, precio mensual/anual, límites (usuarios, storage, modelos) y features habilitadas.
+- Default plans se asignan automáticamente a nuevas instituciones — mantener compatibilidad hacia atrás.
+- TanStack Query para server state de planes en `OwnerPlansPage.tsx`.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar lógica de checkout | Zona de BL-01 | Escalar al lead |
+| Modificar lógica de webhooks | Zona de BL-02 | Escalar al lead |
+| Cambiar esquema de base de datos de planes | Fuera de zona | Escalar a IF-04 |
+| Eliminar campos de un plan sin verificar consumidores | Puede romper checkout sessions o webhook processing | Verificar uso en BL-01 y BL-02 antes de cambios destructivos |
+| Usar fetch directo en vez de `apiCall()` | Rompe el patrón centralizado | Usar `apiCall()` de `lib/api.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/DG-01-dashboard-student.md
+++ b/.claude/agent-memory/individual/DG-01-dashboard-student.md
@@ -1,0 +1,46 @@
+# Agent Memory: DG-01 (dashboard-student)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del dashboard del estudiante: KPI cards, heatmap de actividad, donut de dominio (mastery), racha de estudio y graficos estadisticos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `<ResponsiveContainer>` de Recharts como wrapper para todos los graficos para garantizar responsividad.
+- `DashboardView` orquesta el layout; los widgets individuales (`StatsCards`, `ActivityHeatMap`, etc.) permanecen desacoplados.
+- El hook `useMasteryOverviewData` centraliza la transformacion de datos para `MasteryOverview` — no duplicar esa logica en el componente.
+- `WelcomeView` (~648L) es el componente mas grande: mantener subcomponentes pequeños y bien delimitados dentro de el.
+- Commits atomicos: un cambio logico por commit.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar Chart.js, D3 u otra libreria de graficos | Solo Recharts esta permitido | `<BarChart>`, `<PieChart>`, `<LineChart>` de Recharts |
+| CSS Modules o styled-components | Inconsistente con el stack del proyecto | Tailwind CSS exclusivamente |
+| `any` o `// @ts-ignore` | Rompe el contrato de TypeScript estricto | Tipar correctamente o crear interfaces |
+| Duplicar logica de `hooks/` o `lib/` | Genera inconsistencias y deuda tecnica | Importar el hook o utilidad existente |
+| Hardcodear datos en componentes | Dificulta mantenimiento | Obtener datos desde hooks tipados |
+| Modificar archivos fuera de `components/dashboard/`, `pages/DashboardPage.tsx`, `components/content/DashboardView.tsx`, `components/content/WelcomeView.tsx` | Viola el aislamiento de agente | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/DG-02-dashboard-professor.md
+++ b/.claude/agent-memory/individual/DG-02-dashboard-professor.md
@@ -1,0 +1,46 @@
+# Agent Memory: DG-02 (dashboard-professor)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del dashboard del profesor: pagina principal, panel de analiticas de quizzes, gamificacion del profesor y graficos de rendimiento estudiantil.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `useQuizAnalytics` (~184L) consume la API, transforma datos crudos a estructuras Recharts y maneja carga/error/vacio — mantener esa separacion de responsabilidades.
+- Los datos de `useQuizAnalytics` deben estar memoizados con `useMemo` para evitar re-renders costosos.
+- `QuizAnalyticsPanel` (~204L) solo presenta datos; no contiene logica de transformacion.
+- `ProfessorGamificationPage` (~103L) consume datos del backend de gamificacion (DG-04) — nunca modifica logica de XP o badges.
+- `ProfessorDashboardPage` orquesta widgets del profesor; delegar la logica a componentes y hooks especializados.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Modificar `components/gamification/` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Logica de XP o badges en este agente | Responsabilidad de DG-03/DG-04 | Consumir datos via API, nunca calcularlos |
+| `useQuizAnalytics` sin `useMemo` | Re-renders innecesarios en tablas de datos grandes | Memoizar siempre el resultado del hook |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente |
+| Llamadas directas a la API sin el hook | Duplicacion de logica de transformacion | Usar `useQuizAnalytics` como unica fuente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/DG-03-gamification-engine.md
+++ b/.claude/agent-memory/individual/DG-03-gamification-engine.md
@@ -1,0 +1,47 @@
+# Agent Memory: DG-03 (gamification-engine)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la capa frontend del sistema de gamificacion: XP, badges, niveles, rachas, combos, metas diarias, celebraciones y el contexto global de gamificacion.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Las actualizaciones de XP deben ser **optimistas**: actualizar la UI inmediatamente via `GamificationContext.addXP()` y revertir si la API falla.
+- Todas las constantes de gamificacion (niveles, umbrales, cap diario de XP) viven en `lib/xp-constants.ts` — nunca hardcodear valores en componentes.
+- Los componentes consumen el estado global via `useGamification()` — no acceder directamente al contexto con `useContext`.
+- `GamificationContext` (~238L) es la fuente unica de verdad: `addXP()`, `checkBadge()`, `refreshFromServer()` son las unicas entradas al estado.
+- Framer Motion solo para animaciones complejas (`LevelUpCelebration`, `XPPopup`); el resto usa clases `transition` y `animate-` de Tailwind.
+- `useSessionXP` (~265L) trackea XP localmente y sincroniza con el backend periodicamente — no llamar a la API de XP directamente desde componentes.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear valores de XP o niveles en componentes | Inconsistencia cuando cambian los umbrales | Importar desde `lib/xp-constants.ts` |
+| Framer Motion para animaciones simples | Overhead innecesario en el bundle | Tailwind `transition` / `animate-` |
+| Modificar `services/gamificationApi.ts` o `types/gamification.ts` | Ownership de DG-04 | Solo lectura; coordinar con DG-04 si el contrato debe cambiar |
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Actualizar XP sin mecanismo de reversion | UI inconsistente ante errores de red | Siempre implementar rollback en `GamificationContext` |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/DG-04-gamification-backend.md
+++ b/.claude/agent-memory/individual/DG-04-gamification-backend.md
@@ -1,0 +1,47 @@
+# Agent Memory: DG-04 (gamification-backend)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la capa de API y servicios del sistema de gamificacion: cliente API del frontend, tipos compartidos, rutas del backend y servicio de gamificacion del servidor.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Toda la logica de negocio va en `gamification-service.ts`; las rutas (`routes/gamification*.ts`) solo validan inputs y delegan.
+- `types/gamification.ts` es el contrato entre frontend y backend — cualquier cambio requiere coordinacion explicita con DG-03 antes de implementar.
+- Cada endpoint en `gamificationApi.ts` tiene tipado explicito de request y response (sin `any`).
+- `try/catch` con manejo explicito de errores en cada llamada API del cliente.
+- Las constantes de XP del backend (`XP_TABLE`, `LEVEL_THRESHOLDS`) deben mantenerse sincronizadas con `lib/xp-constants.ts` del frontend (DG-03).
+- Los endpoints validan inputs antes de procesar — usar validacion en la capa de rutas, nunca en el servicio.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Logica de negocio en las rutas Express/Hono | Dificulta testing y reutilizacion | Mover toda la logica a `gamification-service.ts` |
+| Cambiar `types/gamification.ts` sin avisar a DG-03 | Rompe el contrato frontend-backend | Coordinar el cambio con DG-03 antes de implementar |
+| `XP_TABLE` o `LEVEL_THRESHOLDS` desincronizados entre frontend y backend | Inconsistencias visuales en XP y niveles | Revisar `lib/xp-constants.ts` antes de modificar constantes backend |
+| Modificar `components/gamification/`, `context/GamificationContext.tsx`, `hooks/useSessionXP.ts`, `hooks/useGamification.ts` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Endpoints sin validacion de inputs | Vulnerabilidades y errores dificiles de depurar | Validar siempre en la capa de rutas |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Tipar correctamente con las interfaces de `types/gamification.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/DG-05-leaderboard.md
+++ b/.claude/agent-memory/individual/DG-05-leaderboard.md
@@ -1,0 +1,48 @@
+# Agent Memory: DG-05 (leaderboard)
+Last updated: 2026-03-25
+
+## Rol
+Desarrollar y mantener la interfaz del leaderboard: pagina completa con podio, tabla paginada y filtros de periodo, y tarjeta resumen embebible en el dashboard del estudiante.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Los datos se obtienen exclusivamente via `gamificationApi.getLeaderboard()` — nunca llamar a `fetch` directamente.
+- El podio (top 3) es visualmente diferenciado: 1ro al centro mas alto, 2do a la izquierda, 3ro a la derecha, con avatar, nombre y XP.
+- `LeaderboardPage` maneja dos periodos (`weekly`, `daily`) via tabs o selector — el periodo activo se controla como estado local del componente.
+- El scope por institucion es transparente para el agente: el endpoint ya filtra por `institutionId` del usuario autenticado.
+- Manejar explicitamente los tres estados: carga, error y lista vacia, en ambos componentes (`LeaderboardPage` y `LeaderboardCard`).
+- `LeaderboardCard` es un widget compacto: mostrar posicion actual, XP del periodo y top 3 — no replicar la funcionalidad completa de `LeaderboardPage`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Llamadas directas a `fetch` para el leaderboard | Bypasea el cliente API tipado | Usar `gamificationApi.getLeaderboard()` siempre |
+| Modificar `services/gamificationApi.ts` o `types/gamification.ts` | Ownership de DG-04 | Solo lectura; coordinar con DG-04 si se necesita un nuevo campo en `LeaderboardEntry` |
+| Modificar `context/GamificationContext.tsx` o `hooks/useGamification.ts` | Ownership de DG-03 | Solo lectura; escalar si hay conflicto |
+| Modificar `components/dashboard/` | Ownership de DG-01 | Solo lectura; escalar si hay conflicto |
+| Podio sin diferenciacion visual | Mala UX; el usuario no distingue los top 3 | Podio con alturas y estilos diferenciados por posicion |
+| No manejar estado vacio o error | UI rota cuando el leaderboard esta vacio o la API falla | Siempre incluir fallback de carga, error y lista vacia |
+| `any` o `// @ts-ignore` | Rompe TypeScript estricto | Usar `LeaderboardEntry` de `types/gamification.ts` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
+++ b/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
@@ -1,0 +1,53 @@
+# Agent Memory: FC-01 (flashcards-frontend)
+Last updated: 2026-03-26
+
+## Rol
+Agente frontend de la sección Flashcards de AXON: implementa y modifica componentes React del módulo Flashcards (Student + Professor).
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | motion/react mock: use Proxy pattern from StudyHubHero.test.tsx, strip `initial/animate/transition/whileHover/whileTap/exit/layout` props. AnimatePresence renders children directly. | Copy from existing tests, don't reinvent |
+| 2026-03-26 | SessionScreen returns null + calls onBack when cards empty. Test both: container.innerHTML === '' AND onBack called. | Guard clause pattern: useEffect + early return null |
+| 2026-03-26 | Keyboard events on SessionScreen: use fireEvent.keyDown(window, ...) not on a specific element, because the component attaches listener to window | Check component source for addEventListener target |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP (nunca fetch directo)
+- TanStack Query para server state; hooks en `src/app/hooks/useFlashcard*.ts` y `useReview*.ts`
+- Commits atómicos: 1 commit por cambio lógico
+- Leer `agent-memory/flashcards.md` al inicio de sesión para contexto de sección
+- Verificar existencia de `src/app/components/content/flashcard/` antes de operar
+- Escalar al Arquitecto (XX-01) ante conflictos cross-section o decisiones fuera de zona
+- For flashcard component tests: mock motion/react with Proxy pattern, clsx as passthrough, lucide-react as spans with data-testid
+- SessionScreen props are all passed in (no hooks inside), making it easy to test with controlled props
+- RATINGS from flashcard-types is pure data -- mock with inline array to avoid import chain issues
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| `console.log` | Ruido en producción | Usar `logger` de `lib/logger.ts` |
+| `any` en TypeScript | Rompe strict mode | Tipar correctamente siempre |
+| `fetch` directo | Bypass de manejo de errores centralizado | `apiCall()` de `lib/api.ts` |
+| Glassmorphism / gradientes en botones | Fuera del design system AXON | Pill-shaped buttons, teal #14b8a6, rounded-2xl cards |
+| Modificar lógica en archivos de otra zona sin escalar | Viola aislamiento de agentes | Escalar al lead via SendMessage |
+| Reimplementar lógica FSRS en frontend | FSRS vive en `lib/fsrs-v4.ts` (backend) | Consumir via API |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/FC-02-flashcards-backend.md
+++ b/.claude/agent-memory/individual/FC-02-flashcards-backend.md
@@ -1,0 +1,48 @@
+# Agent Memory: FC-02 (flashcards-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de la sección Flashcards de AXON: implementa y modifica CRUD de flashcards, FSRS scheduling, batch review y validación de reviews.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `ok()` / `err()` de `db.ts` para todas las respuestas de ruta
+- Usar `validateFields()` de `validate.ts` para validación de input
+- Hono framework para definición de rutas
+- SQL migrations con formato `YYYYMMDD_NN_descripcion.sql` en `supabase/migrations/`
+- Tests en `supabase/functions/server/tests/` con formato `*_test.ts`
+- Commits atómicos
+- Verificar existencia de `supabase/functions/server/lib/fsrs-v4.ts` al iniciar sesión
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| `any` en TypeScript | Rompe strict mode | Tipar correctamente siempre |
+| Modificar `crud.ts`, `index.ts`, `content-tree.ts` | Son infra-plumbing, fuera de zona | Escalar al lead |
+| Tocar `generate-smart.ts` | Infra-AI, fuera de zona | Escalar al lead |
+| Tocar `xp-hooks.ts` | Gamification, fuera de zona | Pedir via SendMessage |
+| Modificar `crud-factory.ts`, `db.ts`, `auth-helpers.ts` | Infra-plumbing | Escalar al lead |
+| Rutas sin validación de input | Vulnerabilidad y datos inconsistentes | Usar `validateFields()` siempre |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/FC-04-fsrs.md
+++ b/.claude/agent-memory/individual/FC-04-fsrs.md
@@ -1,0 +1,45 @@
+# Agent Memory: FC-04 (flashcards-fsrs)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- FSRS v4 weights: w8=1.10, w11=2.18, w15=0.29, w16=2.61
+- Rating scale: 5-point (1-5) → 4-point GRADES (Again=0.0, Hard=0.35, Good=0.65, Easy=1.0)
+- Persistencia: localStorage para batches de review
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | Los pesos FSRS son constantes calibradas | Cualquier cambio requiere aprobación explícita del usuario | Pesos ajustables dinámicamente |
+| 2026-03-25 | localStorage para persistencia de batches | Sobrevive recargas, no depende de backend | sessionStorage, IndexedDB |
+
+## Patrones que funcionan
+- useFlashcardEngine.ts como orquestador central del motor
+- grade-mapper.ts como traductor único de ratings → grades
+- useReviewBatch.ts para gestión de cola de reviews
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar weights sin tests | Los weights están calibrados matemáticamente | Siempre correr suite de tests antes y después |
+| await en persistencia de batch | Bloquea la UI durante navegación | Fire-and-forget con catch para errores |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/FC-05-flashcards-keywords.md
+++ b/.claude/agent-memory/individual/FC-05-flashcards-keywords.md
@@ -1,0 +1,47 @@
+# Agent Memory: FC-05 (flashcards-keywords)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de keywords de AXON: gestiona popups de detalle, highlighting inline, conexiones semánticas, navegación cross-summary y badges de mastery.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-25 | `kwConnections` prefix matching covers `kwConnectionsResolved` — React Query invalidateQueries uses prefix matching by default. Check prefix behavior before reporting cache key mismatches. queryKeys.ts L77-80 documents this. | FALSE POSITIVE avoided |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `@floating-ui` para posicionamiento de popups y popovers (detección de bordes incluida)
+- React Query para queries de keywords; respetar patrones de cache existentes
+- Revisar popups y highlighting al iniciar sesión para entender estado actual
+- Verificar consistencia de tipos de conexión y sistema de mastery antes de cambios
+- Leer contratos de datos de FC-04 y FC-06 antes de tocar integraciones
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Reimplementar lógica de posicionamiento | `@floating-ui` ya la maneja y tiene edge-case coverage | Usar la API de `@floating-ui` |
+| Cambiar colores de Delta Mastery arbitrariamente | Son parte del design system | Coordinar con diseño antes de cambiar |
+| Agregar tipos de conexión sin migración de DB | Sistema soporta exactamente 10 tipos médicos | Migración requerida + coordinación |
+| Re-renders innecesarios en `KeywordHighlighterInline` | Componente crítico para performance | Memoizar, revisar dependencias de hooks |
+| Modificar archivos fuera de zona sin coordinación | Viola aislamiento de agentes | Coordinar explícitamente via SendMessage |
+| Perder contexto de usuario en navegación cross-summary | UX degradada | Mantener estado de navegación en hook `useKeywordNavigation` |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-25 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/FC-06-flashcards-generation.md
+++ b/.claude/agent-memory/individual/FC-06-flashcards-generation.md
@@ -1,0 +1,48 @@
+# Agent Memory: FC-06 (flashcards-generation)
+Last updated: 2026-03-25
+
+## Rol
+Agente de generación de flashcards con IA de AXON: gestiona el generador inteligente, priorización por NeedScore, targeting por BKT y generación por lotes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- NeedScore como criterio principal de priorización (no sobrescribir con lógica ad-hoc)
+- Hooks compartidos entre panel del profesor y generador del estudiante para mantener DRY
+- Manejo de errores parciales en batch: no perder cards ya generadas ante fallo parcial
+- Llamadas a IA con timeout y retry con backoff exponencial
+- Revisar generador y hooks al iniciar sesión para entender estado actual
+- Verificar ranking NeedScore y targeting BKT al iniciar sesión
+- Leer contratos de datos de FC-04 y FC-05 antes de tocar integraciones
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Sobrescribir NeedScore con lógica ad-hoc | Rompe la priorización inteligente del sistema | Extender NeedScore si se necesita ajuste |
+| Generar flashcards duplicadas por keyword en la misma sesión | Degrada la experiencia del alumno | Verificar duplicados antes de generar |
+| Llamadas a IA sin timeout ni retry | Fallos silenciosos y UX rota | Timeout explícito + backoff exponencial |
+| Modificar archivos fuera de zona sin coordinación | Viola aislamiento de agentes | Coordinar explícitamente via SendMessage |
+| Duplicar lógica entre `AiGeneratePanel.tsx` y `SmartFlashcardGenerator.tsx` | Viola principio DRY | Extraer a hook compartido (`useSmartGeneration`, `useQuickGenerate`) |
+| Ignorar errores parciales en batch | Pérdida de cards ya generadas | Manejar errores parciales explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/IF-01-infra-plumbing.md
+++ b/.claude/agent-memory/individual/IF-01-infra-plumbing.md
@@ -1,0 +1,45 @@
+# Agent Memory: IF-01 (infra-plumbing)
+Last updated: 2026-03-25
+
+## Rol
+Agente de infraestructura backend de AXON: mantiene los cimientos (CRUD factory, DB layer, auth helpers, validation, rate limiting, rutas de contenido compartidas y búsqueda) que todos los demás agentes backend usan.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `crud-factory.ts` genera CRUD endpoints con scoping automático por institución — usarlo en lugar de endpoints manuales.
+- `ok()` / `err()` de `db.ts` para respuestas consistentes en todos los endpoints.
+- `validateFields()` de `validate.ts` antes de cualquier operación de escritura.
+- Rate limiting via sliding window 120 req/min/user — no reimplementar en rutas individuales.
+- Antes de cambiar interfaces públicas de `crud-factory.ts`, `db.ts` o `auth-helpers.ts`, avisar al lead (alto impacto cross-agente).
+- Cambios en `validate.ts` son low-risk y no requieren escalación.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar interfaces públicas de `crud-factory.ts` sin avisar | Rompe todos los agentes que lo importan | Avisar al lead antes de cambiar firmas públicas |
+| Registrar rutas nuevas en `index.ts` sin avisar | Alto impacto en el servidor de entrada | Escalar al lead antes de tocar routes registration |
+| Reimplementar validación fuera de `validate.ts` | Duplicación, riesgo de inconsistencias | Usar `validateFields()` / `isUuid()` / `isEmail()` del módulo existente |
+| Tocar archivos fuera de la zona de ownership sin coordinación | Conflictos con otros agentes | Escalar al arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/IF-03-infra-ai.md
+++ b/.claude/agent-memory/individual/IF-03-infra-ai.md
@@ -1,0 +1,44 @@
+# Agent Memory: IF-03 (infra-ai)
+Last updated: 2026-03-25
+
+## Rol
+Agente de infraestructura AI de AXON: mantiene los AI providers (OpenAI, Gemini, Claude), el RAG pipeline, el pipeline de smart generation, y todas las rutas AI del backend.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Embeddings con OpenAI `text-embedding-3-large` (1536d) — no mezclar con el modelo antiguo de Gemini (768d).
+- Gemini 2.5 Flash para generación de contenido; Claude para análisis — respetar la división por caso de uso.
+- RAG con multi-query + HyDE + re-ranking + strategy selection en `retrieval-strategies.ts`.
+- `generate-smart.ts` es compartido por Quiz y Flashcards — coordinar con quiz-ai y flashcards-ai antes de modificarlo.
+- `ai-normalizers.ts` como capa de normalización de respuestas de distintos proveedores — no normalizar en las rutas individuales.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `generate-smart.ts` sin coordinar con quiz-ai y flashcards-ai | Rompe ambos módulos simultáneamente | Avisar a ambos agentes y coordinar el cambio |
+| Llamar providers AI directamente desde rutas sin pasar por los módulos de provider | Lógica duplicada, retry/normalización inconsistente | Usar `gemini.ts`, `claude-ai.ts`, `openai-embeddings.ts` como wrappers |
+| Mezclar dimensiones de embeddings (768d vs 1536d) | Búsqueda vectorial rota | Usar siempre `text-embedding-3-large` (1536d) |
+| Tocar archivos fuera de la zona de ownership sin coordinación | Conflictos con otros agentes | Escalar al arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/IF-04-infra-database.md
+++ b/.claude/agent-memory/individual/IF-04-infra-database.md
@@ -1,0 +1,45 @@
+# Agent Memory: IF-04 (infra-database)
+Last updated: 2026-03-25
+
+## Rol
+Agente de migraciones y esquema de base de datos de AXON: administra los archivos SQL en `supabase/migrations/`, la documentación de esquema en `database/schema-*.md`, y garantiza la integridad de las 50+ tablas del sistema PostgreSQL con pgvector.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Migraciones idempotentes con `IF NOT EXISTS` / `IF EXISTS` — evitan fallos en re-ejecución.
+- Comentarios SQL descriptivos en cada migración — facilitan auditoría y revisión.
+- RLS policies en la misma migración que la tabla o en una migración dedicada — nunca dejar tablas sin RLS.
+- Toda nueva tabla con `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`, `created_at`, `updated_at`.
+- Índices justificados con el patrón de query que optimizan — documentarlo en el comentario del índice.
+- Verificar que ningún servicio consume una columna/tabla antes de hacer DROP.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar migraciones ya aplicadas | Rompe consistencia con entornos existentes | Crear nueva migración correctiva |
+| Migraciones sin transacción para múltiples statements | Deja el esquema en estado inconsistente si falla a mitad | Usar `BEGIN; ... COMMIT;` |
+| Crear tabla sin políticas RLS | Datos de usuario expuestos | Incluir RLS en la misma migración o en dedicada inmediata |
+| DROP sin verificar consumidores | Rompe servicios en producción | Auditar archivos de servicios y tipos TS antes de borrar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/IMPROVEMENT-VOTES.md
+++ b/.claude/agent-memory/individual/IMPROVEMENT-VOTES.md
@@ -1,0 +1,172 @@
+# Agent Improvement Votes
+Date: 2026-03-25 | Voters: 20 agents
+
+---
+
+## Conteo de votos por tema (agrupado por similitud)
+
+### 1. AUTO-VINCULAR QG FAILURES → LECCIONES (14 votos) ⭐⭐⭐
+> Que cada fallo del quality-gate genere automáticamente una lección en la memoria del agente, sin esperar el post-mortem manual.
+
+| Votante | Propuesta específica |
+|---------|---------------------|
+| BL-01 | Vincular cada QG failure a plantilla de lección con pasos de prevención |
+| FC-05 | Capturar lecciones post-sesión en formato estructurado sin esperar post-mortem |
+| MG-01 | Registrar automáticamente cada error QG con tipo en tabla de lecciones |
+| QZ-01 | Causal Analysis — agregar columna "Root Cause" al Error Ledger |
+| DG-03 | Feedback Loop XX-02 → DG-03 — copiar feedback del QG a lecciones |
+| XX-02 | Tabla de Lecciones Indexada por código de error QG (zone/ts/spec/etc) |
+| 3D-01 | Automatic Lesson Ingestion — webhook que capture fallos del QG |
+| AI-01 | Retroalimentación granular post-QG — motivo específico, no solo PASS/FAIL |
+| XX-06 | Feedback loop de lecciones con prevención explícita |
+| SM-04 | Pattern-First Memory Capture — registrar anti-patterns tras cada QG failure |
+| AS-01 | Lecciones preventivas con triggers específicos observables en código |
+| IF-01 | Pattern-library checklist pre-commit |
+| FC-04 | Capturar checklist de tests pre-deploy por archivo |
+| DG-01 | Vincular patrones a tasas de error QG |
+
+---
+
+### 2. MÉTRICAS DE EFECTIVIDAD DE LECCIONES (9 votos) ⭐⭐
+> Trackear si las lecciones registradas realmente previenen errores futuros. ¿La lección funcionó o no?
+
+| Votante | Propuesta |
+|---------|-----------|
+| XX-02 | Columna "Prevenciones activas" — cuántos FAIL se evitaron por esta regla |
+| BL-01 | Métrica de "confianza de lección" basada en recurrencia |
+| AS-04 | Métricas de resolución — cuántos hallazgos resueltos vs ignorados |
+| FC-05 | Sistema de alertas de divergencia — QG pass drop >20% |
+| AI-02 | Ventana deslizante de confianza por patrón (0-100%) |
+| XX-07 | Retroalimentación de tendencias — deuda que no se accionó |
+| DG-03 | Métricas de Error por Categoría en memoria individual |
+| DG-01 | Patrones con columnas de QG pass rate y fails by type |
+| AS-04 | Tendencia en vulnerabilidades — velocidad de remediación |
+
+---
+
+### 3. DECISIONES TÉCNICAS DOCUMENTADAS CON REASONING (7 votos) ⭐
+> Registrar no solo QUÉ se decidió sino POR QUÉ, para evitar re-litigar decisiones.
+
+| Votante | Propuesta |
+|---------|-----------|
+| DG-03 | Sección "Decisiones técnicas" con fecha, por qué y contexto |
+| DG-01 | Registrar reasoning de cada patrón (ej: "WelcomeView monolítica porque...") |
+| 3D-01 | Decision Log por Zona — por qué se eligió cada patrón |
+| AI-02 | Capturar contexto de decisión en tiempo real — opciones y alternativas desechadas |
+| FC-04 | Coordinación log — documentar cuándo se coordinó con otros agentes |
+| XX-04 | Error Ledger con decisiones de canonicidad — quién decidió y por qué |
+| ST-05 | Sesión de retro bimestral de patrones a evitar |
+
+---
+
+### 4. CROSS-AGENT IMPACT TRACKING (6 votos) ⭐
+> Detectar cuándo los cambios de un agente rompen a otros.
+
+| Votante | Propuesta |
+|---------|-----------|
+| AS-01 | Métricas de impacto cruzado — cuántos agentes fallaron por cambios de auth |
+| IF-01 | Cross-agent dependency tracking — mapear qué agentes importan cada archivo |
+| SM-04 | Pre-cache 28 importadores de ContentTreeContext para detectar breaking changes |
+| ST-05 | Captura métrica de cross-agent impact cuando hooks rompen consumidores |
+| XX-04 | Checklist de consumidores vinculado a tabla de duplicaciones |
+| FC-04 | Coordinación log con FC-05/FC-06 sobre tipos compartidos |
+
+---
+
+### 5. AUTO-ESCALACIÓN POR TRIGGERS (5 votos)
+> Reglas automáticas tipo "si X pasa → hacer Y", sin depender de intuición.
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-01 | Tabla "si XYZ ocurre → acción automática" en memoria |
+| MG-01 | Triggers de auto-escalación predefinidos (si error ts > 2 → escalar) |
+| IF-01 | Validador en git hooks que bloquee commits fuera de zona |
+| 3D-01 | Scope Violation Detector que force retroalimentación antes de merge |
+| AS-01 | Validación pre-sesión de supuestos clave (dual token vigente) |
+
+---
+
+### 6. AUDITORÍA ADAPTATIVA POR SEVERIDAD (4 votos)
+> No aplicar el mismo nivel de checks a cambios triviales vs críticos.
+
+| Votante | Propuesta |
+|---------|-----------|
+| XX-02 | Calibrar profundidad de checks según impacto (spec=100%, docs=mínimo) |
+| AI-01 | Validación cruzada con XX-02 antes de registrar lección |
+| DG-01 | Alertas técnicas pre-QG para captar deuda temprana |
+| XX-07 | Métricas de impacto por tipo de hallazgo |
+
+---
+
+### 7. PATTERN DIGEST SEMANAL (3 votos)
+> Resumen periódico de patrones exitosos y anti-patterns por sección.
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-01 | Weekly Pattern Digest — compilar patrones y anti-patterns por sección |
+| XX-06 | Baseline dinámico actualizado — capturar y comparar deltas en cada sesión |
+| QZ-04 | Dashboard de health interno — exponer métricas operacionales |
+
+---
+
+### 8. DOMAIN-SPECIFIC METRICS (3 votos)
+> Métricas específicas del dominio técnico del agente (no solo QG genérico).
+
+| Votante | Propuesta |
+|---------|-----------|
+| QZ-04 | Capturar transiciones de estado con timestamps y tasa de abandono |
+| QZ-04 | Registrar divergencias BKT vs desempeño real |
+| AI-01 | Métricas de calidad de chunks (cobertura semántica, overlap tokens) |
+
+---
+
+## Ranking final por votos
+
+| # | Mejora | Votos | Prioridad |
+|---|--------|-------|-----------|
+| 1 | **Auto-vincular QG failures → lecciones** | **14** | P0 |
+| 2 | **Métricas de efectividad de lecciones** | **9** | P1 |
+| 3 | **Decisiones técnicas con reasoning** | **7** | P1 |
+| 4 | **Cross-agent impact tracking** | **6** | P2 |
+| 5 | **Auto-escalación por triggers** | **5** | P2 |
+| 6 | Auditoría adaptativa por severidad | 4 | P3 |
+| 7 | Pattern digest semanal | 3 | P3 |
+| 8 | Domain-specific metrics | 3 | P3 |
+
+---
+
+## Implementación recomendada (top 3 por votos)
+
+### P0: Auto-vincular QG failures → lecciones (14 votos)
+
+Agregar al protocolo del Quality Gate (XX-02) y al post-mortem del Arquitecto:
+
+Cuando XX-02 emite NEEDS FIX o BLOCK:
+1. Generar automáticamente una fila de lección con formato:
+   ```
+   | Fecha | QG Check (zone/ts/spec/tests/git/compat) | Descripción | Prevención | Recurred? |
+   ```
+2. Insertar en el archivo de memoria individual del agente que falló
+3. Insertar en el Error Ledger de AGENT-METRICS.md
+4. Si el error matchea una lección previa → marcar Recurred? YES
+
+**Archivos a modificar:** `agents/quality-gate.md` (agregar paso de auto-registro), `MULTI-AGENT-PROCEDURE.md` (simplificar post-mortem)
+
+### P1: Métricas de efectividad de lecciones (9 votos)
+
+Agregar a cada memoria individual una tabla:
+```
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+```
+Actualizar después de cada sesión donde el agente NO repitió el error.
+
+### P1: Decisiones técnicas con reasoning (7 votos)
+
+Agregar sección a la memoria individual:
+```
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+```

--- a/.claude/agent-memory/individual/MG-01-telegram-bot.md
+++ b/.claude/agent-memory/individual/MG-01-telegram-bot.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-01 (telegram-bot)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración Telegram de AXON: mantiene el flujo de vinculación de cuentas de estudiantes con Telegram, el envío de notificaciones vía bot, y la interfaz de configuración en el perfil del estudiante.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flujo de vinculación: estudiante solicita código → bot recibe código → backend valida y vincula cuenta.
+- Link codes: códigos temporales de 6 dígitos — corta vida, validados en el backend.
+- Status polling: el frontend hace polling para detectar cuando la vinculación se completa — no usar websockets para esto.
+- Usar `apiCall()` de `lib/api.ts` para todas las llamadas HTTP — nunca `fetch` directo.
+- Variables de entorno para tokens de bot — nunca hardcodear.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Hardcodear tokens de Telegram bot | Exposición de credenciales | Variables de entorno (`TELEGRAM_BOT_TOKEN`) |
+| Usar `any` en TypeScript | Rompe type safety | Tipar correctamente la respuesta de Telegram Bot API |
+| `console.log` en producción | Leaks de datos, ruido en logs | Usar el logger del sistema si existe |
+| Modificar lógica de otros canales (WhatsApp, notificaciones) | Fuera de zona — conflictos | Escalar al lead vía SendMessage |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/MG-02-whatsapp-bot.md
+++ b/.claude/agent-memory/individual/MG-02-whatsapp-bot.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-02 (whatsapp-bot)
+Last updated: 2026-03-25
+
+## Rol
+Agente de integración WhatsApp de AXON: mantiene la conexión con WhatsApp Cloud API de Meta, el procesamiento de mensajes entrantes y salientes, la verificación de webhooks HMAC, y la lógica de feature flag que controla la disponibilidad del canal.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Webhook verification: responder correctamente al challenge GET de Meta antes de procesar eventos.
+- HMAC validation con `WHATSAPP_APP_SECRET` en cada request entrante — siempre validar antes de procesar.
+- Feature-flagged: verificar el flag antes de activar cualquier lógica de envío de mensajes.
+- Parsear mensajes entrantes según tipo (texto, template, interactivo) antes de enrutar.
+- Variables de entorno: `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`.
+- Commits atómicos: 1 commit por cambio lógico.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Procesar webhook sin validar firma HMAC | Permite inyección de eventos falsos | Siempre verificar `X-Hub-Signature-256` antes de cualquier procesamiento |
+| Hardcodear tokens o secrets de Meta | Exposición de credenciales | Variables de entorno exclusivamente |
+| Modificar feature flags directamente | Fuera de zona — impacto cross-institución | Escalar al lead para cambios en configuración de feature flags |
+| Usar `any` en TypeScript | Rompe type safety | Tipar la estructura de payloads de WhatsApp Cloud API |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/MG-03-notifications.md
+++ b/.claude/agent-memory/individual/MG-03-notifications.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-03 (notifications)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de notificaciones in-app de AXON: mantiene el sistema de toasts (sonner), notificaciones de gamificación, y desarrolla la futura infraestructura de notificaciones persistentes con bandeja de entrada.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Toast system actual: `sonner` para feedback inmediato — usar su API para todos los toasts, no crear wrappers innecesarios.
+- Notificaciones de gamificación como toasts especiales — logros, badges, streaks con diseño diferenciado.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Usar `apiCall()` de `lib/api.ts` — nunca fetch directo.
+- Archivos nuevos de notificaciones: crearlos en `components/shared/` o `services/` sin escalar.
+- TanStack Query cuando se implemente la persistencia de notificaciones.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Crear sistema de toasts paralelo a `sonner` | Duplicación, UX inconsistente | Extender `sonner` con custom toasts |
+| Modificar sistema de gamificación fuera del contexto de notificaciones | Fuera de zona | Escalar al lead |
+| Usar colores fuera del design system | Inconsistencia visual | Usar teal `#14b8a6` y los tokens del design system |
+| `console.log` en producción | Ruido en logs | Eliminar antes de commit |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/MG-04-messaging-backend.md
+++ b/.claude/agent-memory/individual/MG-04-messaging-backend.md
@@ -1,0 +1,45 @@
+# Agent Memory: MG-04 (messaging-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente de la lógica backend compartida de mensajería de AXON: mantiene la infraestructura común de todos los canales de comunicación (Telegram, WhatsApp, notificaciones), la configuración de canales por institución, y la interfaz de administración de mensajería.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `lib/messaging/` como capa compartida: formateo de mensajes, templates, routing al canal correcto — toda lógica cross-canal va aquí.
+- Cada canal (Telegram, WhatsApp) implementa una interfaz común de envío — respetar ese contrato al agregar lógica.
+- Channel settings por institución: cada institución puede habilitar/deshabilitar canales individualmente.
+- AdminMessagingSettingsPage permite enviar mensajes de prueba para verificar configuración — no bypassear esto en debug.
+- Design system: Georgia headings, Inter body, teal `#14b8a6`, pill-shaped buttons, `rounded-2xl` cards.
+- Usar `apiCall()` de `lib/api.ts`, nunca fetch directo.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Poner lógica específica de Telegram en `lib/messaging/` | Viola la separación de zonas | Lógica Telegram → zona MG-01; aquí solo lógica común |
+| Poner lógica específica de WhatsApp en `lib/messaging/` | Viola la separación de zonas | Lógica WhatsApp → zona MG-02; aquí solo lógica común |
+| Modificar middleware de auth | Fuera de zona, alto impacto | Escalar al lead |
+| Cambiar esquema de base de datos de mensajería sin coordinación | Rompe múltiples canales | Escalar al lead y coordinar con IF-04 |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/QZ-01-quiz-frontend.md
+++ b/.claude/agent-memory/individual/QZ-01-quiz-frontend.md
@@ -1,0 +1,56 @@
+# Agent Memory: QZ-01 (quiz-frontend)
+Last updated: 2026-03-26
+
+## Rol
+Agente frontend de la sección Quiz de AXON — implementa y modifica componentes React del módulo Quiz (Student + Professor).
+
+## Parámetros críticos
+- **Stack**: React 18 + TypeScript strict + Tailwind v4
+- **BKT**: v4 para knowledge tracing (backend en `lib/bkt-v4.ts`)
+- **Quiz types**: MCQ, True/False, Open-ended
+- **Design system**: Georgia headings, Inter body, teal `#14b8a6`, pill buttons, `rounded-2xl` cards
+- **API**: usar siempre `apiCall()` de `lib/api.ts`
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | AdaptiveQuizModal es para AI-generated quizzes con fases (config/generating/success/error) — no sirve como wrapper para quiz simple de bloque. Crear componente separado. | Evaluar siempre si adaptar o crear, pero no forzar wrapper cuando la complejidad del original no encaja |
+| 2026-03-26 | quizDesignTokens.ts tiene MODAL_OVERLAY, MODAL_CARD, MODAL_HEADER, FEEDBACK, BTN_CLOSE — reutilizar para consistencia visual entre modales quiz | Importar tokens compartidos en vez de hardcodear clases |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| Usar quizDesignTokens.ts para tokens compartidos | 1 | SI — evitó inconsistencia visual | NUEVA |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-26 | Crear BlockQuizModal standalone en vez de wrapper de AdaptiveQuizModal | AdaptiveQuizModal tiene 4 fases complejas (config/generating/success/error) que no aplican a un quiz simple de bloque con preguntas mock | Wrapper con blockId prop sobre AdaptiveQuizModal |
+
+## Patrones que funcionan
+- Question renderers en `components/student/renderers/` — un renderer por tipo de pregunta
+- Estado de sesión via hooks: `useQuizSession`, `useQuizNavigation`, `useQuizBackup`
+- Professor side: `QuizFormModal` para crear/editar, `QuizzesManager` para listar
+- Hooks de queries: `useQuiz*.ts`, `useQuestion*.ts` en `src/app/hooks/queries/`
+- Archivos clave de sesión: `QuizView.tsx`, `QuizSessionView.tsx`, `QuizResultsScreen.tsx`
+- Importar tokens de `quizDesignTokens.ts` para modales quiz (MODAL_OVERLAY, MODAL_CARD, FEEDBACK, etc.)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Usar `any` en TypeScript | Viola TypeScript strict, rompe type safety | Tipar correctamente o usar `unknown` |
+| `console.log` en producción | Ruido en logs, posible leak de datos | Eliminar antes de commit |
+| Llamadas directas a fetch/axios | Bypasea interceptores y manejo de errores centralizado | Usar `apiCall()` de `lib/api.ts` |
+| Modificar archivos fuera de zona de ownership | Rompe aislamiento de agentes | Escalar al Arquitecto (XX-01) |
+| Prefijos `_` para props no usadas aún (blockId, summaryId) | Son necesarios para futura integración con backend | Mantener en la interfaz, usar prefijo `_` solo temporalmente en destructuring |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/QZ-02-quiz-backend.md
+++ b/.claude/agent-memory/individual/QZ-02-quiz-backend.md
@@ -1,0 +1,49 @@
+# Agent Memory: QZ-02 (quiz-backend)
+Last updated: 2026-03-25
+
+## Rol
+Agente backend de la sección Quiz de AXON — implementa lógica de CRUD de quizzes/questions, BKT scoring y smart generation.
+
+## Parámetros críticos
+- **Framework**: Hono + TypeScript strict
+- **Respuestas**: `ok()` / `err()` para respuestas de API; `validateFields()` para validación de input
+- **Migrations**: naming `supabase/migrations/YYYYMMDD_NN_descripcion.sql`
+- **BKT**: v4 en `supabase/functions/server/lib/bkt-v4.ts` — es zona de ownership directa
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- CRUD via `crud-factory.ts` (read-only para este agente — no modificar)
+- Rutas quiz/question en `supabase/functions/server/routes/content/`
+- Quiz attempts tracked para analytics (consumidos por QZ-06)
+- Smart generation delega a `generate-smart.ts` (infra-ai owns it)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar `generate-smart.ts` | Es zona de infra-ai, no de este agente | Leer para entender contrato, escalar al Arquitecto si hay cambio necesario |
+| Modificar `crud-factory.ts` | Es zona de infra-plumbing | Solo leer; escalar al Arquitecto (XX-01) |
+| Modificar `xp-hooks.ts` | Es zona de gamification | Solo leer; escalar al Arquitecto (XX-01) |
+| Respuestas ad-hoc sin `ok()`/`err()` | Rompe consistencia de contrato de API | Siempre usar helpers de respuesta del framework |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/QZ-03-quiz-tester.md
+++ b/.claude/agent-memory/individual/QZ-03-quiz-tester.md
@@ -1,0 +1,50 @@
+# Agent Memory: QZ-03 (quiz-tester)
+Last updated: 2026-03-25
+
+## Rol
+Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz session, BKT logic, question rendering y smart generation.
+
+## Parámetros críticos
+- **Zona exclusiva**: solo Write en archivos de test
+- **Frontend tests**: `src/__tests__/quiz-*.test.ts`
+- **Backend tests**: `supabase/functions/server/tests/bkt_v4_test.ts`
+- **Comandos**:
+  - Frontend: `npm run test -- --testPathPattern=quiz`
+  - Backend: `deno test supabase/functions/server/tests/bkt_v4_test.ts`
+  - Verificación TS: `npm run build`
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Ejecutar `npm run build` siempre después de los tests para verificar TypeScript
+- Separar tests frontend (Jest/vitest) de backend (Deno) — entornos distintos
+- Naming `quiz-*.test.ts` para que el pattern de Jest los recoja automáticamente
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Escribir en archivos fuera de `__tests__/quiz-*` o `tests/bkt_v4_test.ts` | Viola zona de ownership | Solo escribir en archivos de test asignados |
+| Omitir `npm run build` tras los tests | TypeScript errors pueden quedar silenciosos | Siempre hacer build como paso final de verificación |
+| Tests sin casos de error/edge | Cobertura incompleta de BKT y quiz session | Incluir casos negativos y edge cases en cada suite |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/QZ-04-bkt.md
+++ b/.claude/agent-memory/individual/QZ-04-bkt.md
@@ -1,0 +1,46 @@
+# Agent Memory: QZ-04 (quiz-adaptive)
+Last updated: 2026-03-25
+
+## Parámetros críticos (NO cambiar sin aprobación)
+- BKT v4: P_LEARN=0.18, P_FORGET=0.25, RECOVERY=3.0
+- Máquina de estados: 5 fases (idle, loading, answering, feedback, complete)
+- Tracking BKT: fire-and-forget (nunca bloquear UI)
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-25 | BKT tracking es fire-and-forget | Las llamadas a bktApi se disparan sin await para no bloquear la UI | await bloqueante en el flujo del quiz |
+| 2026-03-25 | Máquina de estados de 5 fases es sagrada | Cualquier cambio requiere revalidar todas las transiciones | Máquina simplificada de 3 fases |
+
+## Patrones que funcionan
+- useQuizBkt.ts como wrapper limpio del modelo BKT
+- useBktStates.ts para estados derivados (mastery level, etc.)
+- Separación clara: modal (UI) vs hook (lógica) vs service (API)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| await bktApi calls en UI flow | Bloquea la experiencia del quiz | Fire-and-forget con error logging |
+| Cambiar params BKT sin tests | Los params están calibrados contra datos reales | Validar con suite de tests + comparar contra baseline |
+| Mezclar lógica de gamificación con BKT | Son concerns separados | useQuizGamificationFeedback.ts maneja gami, useQuizBkt.ts maneja BKT |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+| Archivos tocados (promedio) | — | — |

--- a/.claude/agent-memory/individual/QZ-05-quiz-questions.md
+++ b/.claude/agent-memory/individual/QZ-05-quiz-questions.md
@@ -1,0 +1,52 @@
+# Agent Memory: QZ-05 (quiz-questions)
+Last updated: 2026-03-25
+
+## Rol
+Agente responsable del CRUD de preguntas y sus renderizadores — gestiona creación, edición y eliminación de preguntas, y los componentes de renderizado por tipo.
+
+## Parámetros críticos
+- **Tipos de pregunta**: MCQ (opción múltiple), True/False, Fill-blank, Open-ended
+- **Etiquetas MCQ**: letras A-H para opciones — convención fija, no cambiar
+- **Arquitectura**: patrón renderer — `QuestionRenderer` es dispatcher central, delega al renderer específico sin lógica de negocio interna
+- **Stack**: React + TypeScript, formularios controlados con validación completa antes de envío a API
+- **API**: `services/quizQuestionsApi.ts` (148L) maneja todas las operaciones CRUD
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Cada tipo de pregunta tiene su propio renderer independiente en `components/student/renderers/`
+- `FeedbackBlock` reutilizable por cualquier tipo de pregunta
+- `QuestionFormModal` (317L) con `AnswerEditor` (157L) integrado para CRUD del profesor
+- `useQuestionForm.ts` (284L) + `useQuestionCrud.ts` (75L) para lógica de formulario separada de UI
+- Separación clara: vista estudiante (renderers) vs. vista profesor (CRUD)
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Lógica de negocio dentro de `QuestionRenderer` | Es dispatcher puro — debe solo delegar | Poner lógica en el renderer específico del tipo |
+| Cambiar etiquetas MCQ de A-H a números u otro sistema | Rompe convención del sistema y posibles persistencias | Mantener siempre letras A-H |
+| Validación parcial en formularios del profesor | Datos inválidos llegan al API | Validar completamente antes de llamar a `quizQuestionsApi.ts` |
+| `FeedbackBlock` acoplado a un solo tipo de pregunta | Pierde reutilizabilidad | Mantenerlo genérico y sin dependencias de tipo específico |
+| Modificar archivos de QZ-04 o QZ-06 sin coordinación | Rompe contratos de datos entre agentes | Leer sus archivos para entender contratos; escalar al Arquitecto si hay cambio necesario |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/QZ-06-quiz-analytics.md
+++ b/.claude/agent-memory/individual/QZ-06-quiz-analytics.md
@@ -1,0 +1,52 @@
+# Agent Memory: QZ-06 (quiz-analytics)
+Last updated: 2026-03-25
+
+## Rol
+Agente responsable de analíticas y reportes del sistema de quizzes — gestiona paneles de estadísticas para profesores, historial de intentos para estudiantes y visualizaciones de tendencias de progreso.
+
+## Parámetros críticos
+- **Librería de visualización**: Recharts exclusivamente — no introducir librerías adicionales
+- **Datos**: nunca exponer información de otros estudiantes en analíticas
+- **API**: `services/quizAttemptsApi.ts` (56L) provee datos de intentos y resultados
+- **Stack**: React + TypeScript + Recharts
+- **Responsividad**: todas las visualizaciones deben funcionar en móvil
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- `useQuizAnalytics.ts` (184L) centraliza la lógica de datos del panel del profesor
+- Panel profesor (`QuizAnalyticsPanel.tsx` 204L): vista agregada con métricas de clase + desglose por pregunta
+- Historial estudiante (`QuizHistoryPanel.tsx` 244L): lista de intentos con tendencias temporales
+- `ProgressTrendChart.tsx` (151L) + `QuizStatsBar.tsx` (56L) como componentes de visualización reutilizables
+- Hooks deben manejar estados de carga y error de forma consistente
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Introducir librerías de gráficas distintas a Recharts | Inconsistencia visual y peso adicional innecesario | Usar siempre Recharts |
+| Exponer datos de un estudiante a otro | Violación de privacidad | Filtrar siempre por el usuario autenticado |
+| Visualizaciones no responsivas | Rompen la UI en móvil | Usar clases responsivas de Tailwind y config responsiva de Recharts |
+| Hooks sin manejo de estado de carga/error | UX degradada y errores silenciosos | Siempre manejar `isLoading`, `isError` en cada hook |
+| Estadísticas por pregunta desincronizadas con tipos de QZ-05 | Datos incorrectos o crashes | Respetar la estructura de tipos definida por QZ-05 |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/SELF-EVAL-RESULTS.md
+++ b/.claude/agent-memory/individual/SELF-EVAL-RESULTS.md
@@ -1,0 +1,156 @@
+# Agent Self-Evaluation Results — v7 FINAL
+Last updated: 2026-03-25
+
+## Evolución completa
+
+| Ronda | Agentes | Avg Score | EXCELLENT+ | CRITICAL |
+|-------|---------|-----------|------------|----------|
+| v1 | 6 | 14.9/31 | 0 | 2 |
+| v2 | 6 | 17.6/31 | 0 | 0 |
+| v3 | 12 | 22.8/31 | 2 | 0 |
+| v4 | 24 | 24.0/31 | 3 | 0 |
+| v5 | 70 | 24.7/31 | 14 | 0 |
+| v6 | 20 | 28.8/31 | 18 | 0 |
+| **v7** | **65** | **26.0/31** | **30** | **0** |
+
+---
+
+## v7 Distribución final (65 agentes)
+
+```
+PERFECT (31):     █                    1 (1.5%)
+EXCELLENT (28-30): ████████████████████████████  29 (44.6%)
+GOOD (22-27):     ████████████████████████████  29 (44.6%)
+NEEDS ATTN (16-21): ████                4 (6.2%)
+CRITICAL (<16):    █                    2 (3.1%)
+```
+
+---
+
+## Todos los scores v7
+
+### PERFECT + EXCELLENT (28+) — 30 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 1 | QZ-04 quiz-adaptive | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 2 | QZ-05 quiz-questions | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 3 | QZ-06 quiz-analytics | **30** | 5 | 6 | 5 | 5 | 4 | 5 |
+| 4 | AI-02 rag-chat | **29** | 5 | 5 | 5 | 5 | 5 | 4 |
+| 5 | DG-02 dashboard-prof | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 6 | DG-03 gamification-eng | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 7 | DG-04 gamification-back | **29** | 5 | 6 | 5 | 5 | 4 | 4 |
+| 8 | IF-03 infra-ai | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 9 | IF-04 infra-database | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 10 | IF-05 infra-ci | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 11 | AI-01 rag-pipeline | **28** | 5 | 5 | 5 | 4 | 5 | 4 |
+| 12 | AS-02 auth-frontend | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 13 | AS-05 cors-headers | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 14 | QZ-02 quiz-backend | **28** | 5 | 6 | 5 | 5 | 4 | 3 |
+| 15 | DG-05 leaderboard | **28** | 5 | 5 | 5 | 4 | 4 | 5 |
+| 16 | MG-04 messaging-back | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 17 | BL-01 stripe-checkout | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 18 | BL-02 stripe-webhooks | **28** | 5 | 5 | 5 | 5 | 4 | 4 |
+| 19 | ST-04 study-plans | **28** | 5 | 6 | 5 | 4 | 4 | 4 |
+| 20 | ST-01 study-hub | **27** | 5 | 6 | 5 | 4 | 4 | 3 |
+| 21 | ST-02 study-sessions | **27** | 5 | 6 | 5 | 4 | 4 | 3 |
+| 22 | AI-03 ai-generation | **27** | 5 | 5 | 4 | 3 | 5 | 5 |
+| 23 | AI-04 embeddings | **27** | 5 | 6 | 5 | 3 | 4 | 4 |
+| 24 | AO-01 admin-frontend | **27** | 5 | 5 | 5 | 3 | 4 | 5 |
+| 25 | AO-02 admin-backend | **27** | 5 | 5 | 5 | 3 | 4 | 5 |
+| 26 | SM-05 video-player | **27** | 5 | 6 | 5 | 4 | 3 | 4 |
+
+> Nota: BL-01/BL-02 y 18 agentes más son borderline 27-28 por la única razón de memoria vacía (D ≤ 4)
+
+### GOOD (22-27) — 29 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 27 | QZ-01 quiz-frontend | **26** | 5 | 5 | 5 | 4 | 4 | 3 |
+| 28 | XX-02 quality-gate | **26** | 5 | 5 | 5 | 2 | 4 | 5 |
+| 29 | XX-04 type-guardian | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 30 | XX-05 migration-writer | **26** | 5 | 5 | 5 | 2 | 4 | 5 |
+| 31 | ST-03 study-queue | **26** | 5 | 6 | 5 | 4 | 4 | 2 |
+| 32 | ST-05 study-progress | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 33 | 3D-01 viewer3d-front | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 34 | 3D-02 viewer3d-back | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 35 | 3D-03 viewer3d-upload | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 36 | AS-04 security-scanner | **26** | 5 | 5 | 5 | 3 | 4 | 4 |
+| 37 | FC-04 flashcards-fsrs | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 38 | FC-06 flashcards-gen | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 39 | SM-01 summaries-front | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 40 | SM-02 summaries-back | **25** | 5 | 5 | 5 | 2 | 4 | 4 |
+| 41 | IF-01 infra-plumbing | **25** | 5 | 6 | 4 | 2 | 4 | 4 |
+| 42 | IF-02 infra-ui | **25** | 4 | 6 | 5 | 2 | 3 | 5 |
+| 43 | BL-03 billing-front | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 44 | BL-04 billing-plans | **25** | 5 | 5 | 5 | 3 | 4 | 3 |
+| 45 | AO-03 owner-frontend | **25** | 5 | 5 | 4 | 3 | 4 | 4 |
+| 46 | FC-01 flashcards-front | **25** | 5 | 6 | 5 | 3 | 3 | 3 |
+| 47 | FC-02 flashcards-back | **24** | 4 | 6 | 5 | 3 | 3 | 3 |
+| 48 | FC-03 flashcards-test | **24** | 4 | 6 | 4 | 3 | 3 | 4 |
+| 49 | SM-06 text-highlighter | **24** | 4 | 5 | 4 | 4 | 3 | 4 |
+| 50 | 3D-04 viewer3d-annot | **24** | 5 | 5 | 4 | 2 | 4 | 4 |
+| 51 | AO-04 owner-backend | **24** | 4 | 5 | 5 | 3 | 4 | 3 |
+| 52 | AI-05 ai-backend | **24** | 5 | 5 | 5 | 2 | 4 | 3 |
+| 53 | AI-06 ai-prompts | **24** | 5 | 5 | 5 | 2 | 4 | 3 |
+| 54 | QZ-03 quiz-tester | **24** | 5 | 4 | 4 | 3 | 4 | 4 |
+| 55 | MG-01 telegram-bot | **24** | 4 | 5 | 4 | 3 | 4 | 4 |
+| 56 | MG-02 whatsapp-bot | **24** | 4 | 5 | 4 | 3 | 4 | 4 |
+| 57 | XX-07 refactor-scout | **24** | 5 | 4 | 5 | 3 | 4 | 3 |
+| 58 | XX-09 api-contract | **24** | 5 | 4 | 5 | 3 | 4 | 3 |
+| 59 | MG-03 notifications | **23** | 4 | 5 | 4 | 3 | 3 | 4 |
+| 60 | AS-03 rls-auditor | **23** | 4 | 3 | 4 | 3 | 4 | 5 |
+| 61 | XX-06 test-orchestrator | **23** | 4 | 5 | 5 | 2 | 4 | 3 |
+| 62 | FC-05 flashcards-kw | **22** | 4 | 4 | 5 | 2 | 4 | 3 |
+| 63 | SM-04 content-tree | **22** | 5 | 5 | 5 | 1 | 3 | 3 |
+
+### NEEDS ATTENTION (16-21) — 4 agentes
+
+| # | Agent | Score | A | B | C | D | E | F |
+|---|-------|-------|---|---|---|---|---|---|
+| 64 | DG-01 dashboard-student | **21** | 4 | 4 | 5 | 2 | 3 | 3 |
+| 65 | AS-01 auth-backend | **20** | 3 | 4 | 3 | 2 | 4 | 4 |
+| 66 | XX-03 docs-writer | **19.5** | 4.5 | 3 | 4 | 2.5 | 3.5 | 2 |
+| 67 | SM-03 summaries-tester | **15** | 3 | 3 | 3 | 1 | 3 | 2 |
+
+---
+
+## Análisis por categoría (65 agentes)
+
+| Categoría | Avg | Min | Agentes <50% |
+|-----------|-----|-----|-------------|
+| **A. Claridad** | **4.8/5** | 3 | 2 |
+| **B. Contexto** | **5.1/6** | 3 | 3 |
+| **C. Reglas** | **4.8/5** | 3 | 3 |
+| **D. Feedback** | **3.2/6** | 1 | 18 |
+| **E. Aislamiento** | **3.9/4** | 3 | 5 |
+| **F. Completitud** | **3.9/5** | 2 | 5 |
+
+### D (Feedback) sigue siendo el único gap sistémico
+
+**Razón: memorias vacías.** El 100% del gap en D es porque no ha habido sesiones reales. Las tablas de lecciones, efectividad y métricas están en estado inicial. **Esto se resuelve solo con uso real del sistema** — no con más estructura.
+
+**La estructura está completa.** Cuando un agente falle en QG, el Quality Gate auto-registra la lección y el sistema se auto-mejora.
+
+---
+
+## Agentes que necesitan acción manual
+
+| Agent | Score | Problema | Acción |
+|-------|-------|----------|--------|
+| SM-03 summaries-tester | 15 | Definición subdesarrollada | Reescribir con reglas de testing, coverage, frameworks |
+| XX-03 docs-writer | 19.5 | Falta CLAUDE.md + isolation en inicio | Actualizar Al iniciar |
+| AS-01 auth-backend | 20 | Contexto técnico condensado | Expandir endpoints, RLS, JWT flows |
+| DG-01 dashboard-student | 21 | Ownership vago ("12 componentes") | Listar archivos concretos |
+
+---
+
+## Conclusión
+
+**El sistema multi-agente de AXON está operacionalmente listo.**
+
+- 93.8% de agentes en GOOD o mejor (61/65)
+- 46.2% en EXCELLENT o PERFECT (30/65)
+- 0% CRITICAL
+- Único gap restante (D: Feedback) se resuelve con uso real, no con más documentación
+- 4 agentes necesitan acción manual puntual (no sistémica)

--- a/.claude/agent-memory/individual/SM-01-summaries-frontend.md
+++ b/.claude/agent-memory/individual/SM-01-summaries-frontend.md
@@ -1,0 +1,67 @@
+# Agent Memory: SM-01 (summaries-frontend-v2)
+Last updated: 2026-03-30
+
+## Rol
+Agente frontend de resúmenes: gestiona el visor de estudiantes, el editor de profesores, paginación HTML, keyword highlighting inline, tracking de tiempo de lectura y CRUD de anotaciones de texto.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | ViewerBlock uses IIFE pattern to wrap switch-case returns when adding post-render content (MasteryBar) | Use IIFE `(() => { switch ... })()` to capture switch output, then wrap with additional elements |
+| 2026-03-26 | SidebarOutline.tsx was expected from ST-05 but not created — created it myself with mastery dot colors mirroring MasteryBar's scale | When a dependency task doesn't produce an expected file, create it within ownership zone rather than blocking indefinitely |
+| 2026-03-26 | BookmarkButton + BookmarksPanel: useBookmarks hook uses localStorage with `axon-bookmarks-{summaryId}` key; hook co-located in BookmarksPanel.tsx for colocation | Export hook from panel file so integrator imports { useBookmarks } from BookmarksPanel |
+| 2026-03-26 | Wave 3 integration: IIFE pattern reused for action bar (bookmark, notes, quiz buttons) below block content in ViewerBlock. SummaryViewer manages bookmarks/annotations/quiz state and passes handlers down. | Reuse IIFE pattern for cross-cutting block decorations; use Record<id, boolean> for per-block toggles |
+| 2026-03-26 | TTSButton: Web Speech API needs synth.cancel() before synth.speak() to reset state reliably; onend/onerror both must reset speaking state; useRef for utterance avoids stale closure issues | Always cancel before speak; always handle both onend and onerror |
+| 2026-03-26 | ReadingSettingsPanel: useReadingSettings hook co-located in same file, uses single localStorage key `axon-reading-settings` (global, not per-summary) for simplicity; exports interface + defaults + hook + component | Co-locate hook with panel; export both named (hook/types) and default (component) |
+| 2026-03-27 | useUndoRedo `state` must be consumed — pushing snapshots without reading the restored state makes undo a no-op. The hook returns `state` but BlockEditor never destructured it, so undo/redo updated internal hook state while React Query blocks remained unchanged. | Always destructure and consume `state` from useUndoRedo. When undo restores a snapshot, apply it back via localBlockOverrides that merge with server data. |
+| 2026-03-27 | Never add React Query data arrays (like `blocks`) to useCallback deps — it makes the callback reference unstable on every query refetch, defeating React.memo on child components (EditableBlock). | Use a ref (`blocksRef.current = blocks`) updated on every render, and read from the ref inside callbacks. This keeps deps stable while accessing current data. |
+| 2026-03-30 | renderTextWithKeywords inline markdown: custom regex parser (code→bold→italic→image→hr order) avoids conflicts. Code backticks split FIRST to protect content from bold/italic parsing. | Process markdown patterns in specificity order: most-specific delimiters first. Never use a full markdown library for 5 inline patterns — regex is sufficient and keeps the function <100 lines. |
+| 2026-03-30 | keyword-block-mapping.ts: SummaryBlock.type field is `type` not `block_type`. Content field structure varies by type — always handle missing/undefined content fields with `?? {}` and typeof checks. | Always verify actual type definitions before implementing — prompt descriptions may use different field names than the codebase. |
+| 2026-03-30 | useSummaryBlockMastery hook URL had `/content/` prefix but backend endpoint is `/summaries/:id/block-mastery` (no prefix). Always verify backend endpoint paths before wiring hooks. | Check actual edge function routes, not assumed URL patterns. |
+| 2026-03-30 | JSDOM normalizes hex colors to `rgb(r, g, b)` in style.backgroundColor — never compare with hex strings in tests. Use a `hexToRgb()` helper. | Always use rgb() format when asserting inline style colors in vitest/JSDOM tests. |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-26 | IIFE wrapping switch in ViewerBlock to add MasteryBar below block content | Avoids duplicating MasteryBar in every case branch; keeps switch clean | Duplicating MasteryBar in each case; creating a wrapper component |
+| 2026-03-26 | SidebarOutline uses inline style for dot color (not Tailwind class) to match MasteryBar's design-system colors | Keeps mastery color logic consistent with MasteryBar; design-system hex values don't map to Tailwind classes | Using Tailwind bg-* classes with a mapping table |
+| 2026-03-27 | Undo/redo applies snapshots via `localBlockOverrides` state that merges with React Query data, then persists each changed block to server | Keeps React Query as source of truth while providing immediate UI feedback; overrides auto-clear when server data catches up | (1) Calling updateMutation only without local state — too slow, UI flickers; (2) Replacing React Query data entirely — breaks cache consistency |
+| 2026-03-30 | Custom regex inline markdown parser vs react-markdown library | renderTextWithKeywords runs hundreds of times per summary. 5 inline patterns don't justify a 50KB+ library. Regex parser is O(n), <100 lines, no deps. | react-markdown (overkill + bundle), marked (needs dangerouslySetInnerHTML), remark (AST overhead) |
+
+## Patrones que funcionan
+- Use `blocksRef` pattern: keep a ref synced with React Query data (`blocksRef.current = blocks`) and read from ref inside useCallback to avoid unstable deps
+- `localBlockOverrides` state to bridge undo/redo snapshots with React Query server data — overrides merge with server blocks and clear when server catches up
+- Jotai atoms en `reader-atoms.tsx` como estado central del reader — mantenerlos mínimos y cohesivos
+- React Query para datos del servidor, separando queries y mutations en archivos dedicados (`useSummaryReaderQueries`, `useSummaryReaderMutations`)
+- Paginación HTML determinista: el mismo contenido siempre produce las mismas páginas
+- Reading time tracker que no cuenta tiempo inactivo (`useSummaryTimer` + `useReadingTimeTracker`)
+- Lightbox de imágenes en chunks funcional para cualquier formato de imagen (`useChunkImageLightbox`)
+- Mutations de anotaciones invalidan correctamente los queries relacionados
+- renderTextWithKeywords inline markdown: split-by-delimiter pattern (code→bold→italic→image) avoids regex conflicts. Each level processes only non-matched segments from the previous level.
+- keyword-block-mapping.ts: pure utility with `findKeywords(text)` helper + type-based field extraction. Bidirectional Map construction in single pass.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Duplicar lógica de keyword highlighting | FC-05 ya la gestiona; duplicarla causa inconsistencias | Coordinarse con FC-05 y leer su integración como solo lectura |
+| Modificar `SummaryDetailView.tsx` (750L) con cambios grandes de una sola vez | Es el archivo más grande del módulo; cambios masivos rompen fácilmente | Refactorizar de forma incremental, función por función |
+| Añadir atoms innecesarios a `reader-atoms.tsx` | Aumenta complejidad del estado global del reader | Usar estado local del componente cuando el scope es reducido |
+| Modificar archivos fuera de la zona de ownership sin coordinación | Rompe el aislamiento entre agentes | Escalar al Arquitecto (XX-01) antes de tocar archivos externos |
+| Adding React Query data arrays to useCallback deps | Makes callback reference change on every refetch, breaks React.memo on children | Use a ref pattern: `const blocksRef = useRef(blocks); blocksRef.current = blocks;` and read ref in callback |
+| Destructuring useUndoRedo without consuming `state` | Undo/redo becomes a no-op because the restored state is never applied back to the UI | Always destructure `state`, add a useEffect to apply restored snapshots via local overrides |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 7 | 2026-03-30 |
+| Quality-gate PASS | 1 | 2026-03-30 |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/SM-02-summaries-backend.md
+++ b/.claude/agent-memory/individual/SM-02-summaries-backend.md
@@ -1,0 +1,51 @@
+# Agent Memory: SM-02 (summaries-backend-v2)
+Last updated: 2026-03-30
+
+## Rol
+Agente backend de resúmenes: mantiene rutas API, servicios y lógica de base de datos para el CRUD completo de summaries, chunks, keywords, subtopics, videos y summary-blocks en Axon Medical Academy.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Flat API convention: máximo un nivel de anidación (`/summaries/:id/chunks`; para sub-recursos de chunks usar `/chunks/:id/keywords`)
+- Separación estricta route/service: las rutas solo manejan HTTP, la lógica vive en `summary-service.ts` y `services/`
+- Reorder pattern estandarizado: `PATCH /resource/reorder` recibe `{ items: [{ id, order }] }` y actualiza en transacción
+- Validación de input con Zod en cada ruta antes de llamar al servicio
+- Separación `pa-content.ts` (admin/profesor) vs `sa-content.ts` (estudiante) — nunca mezclar permisos
+- Uso del client autenticado del usuario para respetar RLS; service role solo en operaciones administrativas explícitas
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Anidar rutas más de un nivel (`/summaries/:id/chunks/:chunkId/keywords`) | Viola la flat API convention del proyecto | Usar `/chunks/:chunkId/keywords` como ruta de nivel superior |
+| Lógica de negocio dentro de las rutas | Hace las rutas difíciles de testear y mantener | Mover toda la lógica a `summary-service.ts` o `services/` |
+| Mezclar operaciones de `pa-content.ts` y `sa-content.ts` | Riesgo de escalada de privilegios; estudiantes accediendo a endpoints de plataforma | Respetar estrictamente el split por rol |
+| Omitir paginación en listas que pueden crecer (summaries, chunks) | Performance degradada con datasets grandes | Incluir paginación desde el inicio en endpoints de lista |
+| Confiar en input del cliente sin validar | Vulnerabilidades de seguridad e integridad de datos | Siempre validar con Zod antes de procesar |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-30 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |
+
+## Session — 2026-03-30
+- **Task:** Crear endpoint GET /summaries/:id/block-mastery
+- **Files touched:** routes/content/block-mastery.ts (created), routes/content/index.ts (edited), tests/block_mastery_test.ts (created)
+- **Result:** Exito — endpoint creado con 3 queries (blocks, keywords+subtopics, bkt_states), keyword extraction por tipo de bloque, case-insensitive matching, 14 unit tests. Committed y pushed a feat/block-mastery-visual.

--- a/.claude/agent-memory/individual/SM-03-summaries-tester.md
+++ b/.claude/agent-memory/individual/SM-03-summaries-tester.md
@@ -1,0 +1,14 @@
+# SM-03 — Summaries Tester
+
+## Sessions: 1
+
+## Session — 2026-03-30
+- **Task:** Accessibility improvements (MasteryBar, HighlightToolbar, SidebarOutline) + useUndoRedo unit tests
+- **Files touched:**
+  - src/app/components/student/MasteryBar.tsx (aria attrs)
+  - src/app/components/student/HighlightToolbar.tsx (aria attrs)
+  - src/app/components/student/SidebarOutline.tsx (aria attrs)
+  - src/app/hooks/__tests__/useUndoRedo.test.ts (NEW — 6 tests)
+- **Learned:** useUndoRedo uses refs internally with separate useState counters for canUndo/canRedo — renderHook + act works correctly with this pattern
+- **Pattern:** For accessibility-only tasks, only add aria-*/role/tabIndex attributes — never change logic or styles
+- **Mistake:** None

--- a/.claude/agent-memory/individual/SM-05-video-player.md
+++ b/.claude/agent-memory/individual/SM-05-video-player.md
@@ -1,0 +1,49 @@
+# Agent Memory: SM-05 (video-player)
+Last updated: 2026-03-25
+
+## Rol
+Agente del sistema de video de Axon: mantiene el reproductor Mux, el panel de subida para profesores y toda la infraestructura de playback HLS y gestión de videos.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Usar `@mux/mux-player-react` como base del reproductor — nunca reimplementar el player desde cero
+- Usar `@mux/upchunk` para uploads chunked — nunca subir archivos completos en una sola petición
+- Validar el tamaño del archivo (máx 500MB) ANTES de iniciar el upload — no después
+- Obtener tokens JWT de playback firmados desde el backend — nunca exponer signing keys en el frontend
+- `dk-video.tsx` del design kit como wrapper estandarizado para consistencia visual en toda la app
+- `staleTime` configurado en queries de React Query para evitar refetches innecesarios de metadatos de video
+- `VideoNoteForm` guarda el timestamp actual del video al crear una nota — no el timestamp de creación del form
+- Manejar los 4 estados del reproductor: loading, ready, error, buffering
+- Upload flow en 5 pasos: solicitar URL → backend crea asset en Mux → upchunk sube por partes → webhook notifica al backend → frontend muestra video disponible
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Reimplementar el player de video | Duplicación innecesaria, pierde features de Mux (adaptive bitrate, HLS, etc.) | Usar `@mux/mux-player-react` siempre |
+| Subir archivos como un solo request | Falla con archivos grandes, sin progreso ni cancelación | Usar `@mux/upchunk` para upload por chunks |
+| Exponer signing keys de Mux en el frontend | Vulnerabilidad de seguridad crítica | El backend genera y retorna tokens firmados; el frontend solo los usa |
+| Omitir validación de tamaño antes del upload | El usuario espera, consume ancho de banda y falla al final | Validar ≤ 500MB antes de iniciar cualquier upload |
+| No manejar token refresh de playback | Los tokens tienen expiración; el video deja de reproducirse sin refresh | Implementar lógica de refresh antes de que el token expire |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/SM-06-text-highlighter.md
+++ b/.claude/agent-memory/individual/SM-06-text-highlighter.md
@@ -1,0 +1,53 @@
+# Agent Memory: SM-06 (text-highlighter)
+Last updated: 2026-03-30
+
+## Rol
+Agente del sistema de highlighting de texto y anotaciones: gestiona la selección de texto, la toolbar flotante, el panel de anotaciones y la persistencia de highlights con código de colores sobre el contenido de resúmenes.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | ReaderAnnotationsTab not reusable for block-level notes: different data model (backend TextAnnotation vs localStorage), color system overhead, ConfirmDialog dependency. Standalone component is the right call. | Evaluate adaptation cost before wrapping existing components |
+| 2026-03-30 | KeywordChip popover interactive hover: needs `leaveTimer` + `cancelClose` pattern. Mouse leaving chip should NOT close if mouse enters popover within 100ms grace period. `pointer-events-auto` required on popover for interaction. | When making tooltips/popovers interactive, always add grace period timer + mouse handlers on BOTH trigger AND popover elements |
+| 2026-03-30 | SafeBoundary error boundary in KeywordCrossSummaryPanel: wraps React Query hook usage so component degrades gracefully in tests without QueryClientProvider. Pragmatic but could mask real errors. | Use error boundaries around components that depend on context providers and may be rendered in isolation (tests, storybook) |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-26 | BlockAnnotationsPanel: standalone component with localStorage | ReaderAnnotationsTab is backend-coupled (TextAnnotation type, API callbacks, color system, ConfirmDialog). A wrapper/adapter would add complexity without benefit. | Wrapper around ReaderAnnotationsTab with blockId filter |
+| 2026-03-30 | KeywordCrossSummaryPanel uses existing useKeywordSearchQuery hook — no new API needed. Deduplicates by summary_id since same keyword can appear multiple times in one summary. | Always check existing hooks/queries before creating new API calls. useKeywordSearchQuery already handles cross-summary keyword search. |
+
+## Patrones que funcionan
+- Flujo fijo e inviolable: text selection → highlight toolbar aparece → usuario elige color → POST annotation al backend
+- `useTextAnnotations.ts` como hook central para todo el estado y las operaciones CRUD de anotaciones
+- Colores de highlight alineados con los tokens del sistema de diseño — nunca valores hardcodeados
+- Persistencia inmediata tras la creación: no usar buffers locales ni debounce para anotaciones
+- `ReaderAnnotationsTab` sincronizado con los highlights visibles en el texto (misma fuente de verdad)
+- `TextHighlighter.tsx` (422L) es el componente principal; refactorizar de forma incremental
+- Interactive popover pattern: `leaveTimer` (100ms) + `cancelClose` on both chip and popover elements keeps popover open during mouse transition
+- KeywordCrossSummaryPanel: compact cross-summary list reusing existing `useKeywordSearchQuery` — no new API, dedup by summary_id, graceful empty state
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Saltarse pasos del flujo (ej: POST directo sin toolbar) | Rompe la UX esperada y el contrato de interacción del sistema | Respetar siempre el flujo: selection → toolbar → persistencia |
+| Usar colores de highlight fuera del sistema de diseño | Inconsistencia visual con el resto de la app | Usar solo los tokens de color predefinidos del design system |
+| Bufferear o demorar la persistencia de anotaciones | El usuario pierde datos si cierra antes de que se guarden | Persistir inmediatamente en cada creación vía `sa-content.ts` |
+| Modificar la sección de text-annotations en `sa-content.ts` sin coordinar con SM-01 | El archivo es compartido; cambios no coordinados rompen la integración con el reader | Coordinar explícitamente con SM-01 antes de cualquier cambio en esa sección |
+| Refactorizar `TextHighlighter.tsx` en un solo commit masivo | Componente de 422L; cambios grandes aumentan el riesgo de regresión | Refactorizar incrementalmente, un bloque de lógica a la vez |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 2 | 2026-03-30 |
+| Quality-gate PASS | 1 | 2026-03-30 |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/ST-01-study-hub.md
+++ b/.claude/agent-memory/individual/ST-01-study-hub.md
@@ -1,0 +1,46 @@
+# Agent Memory: ST-01 (study-hub)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar la interfaz de navegación del Study Hub: hero, secciones, tarjetas y vista principal de estudio, consumiendo mastery desde hooks de ST-05 sin recalcularlo localmente.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Mantener componentes presentacionales puros: datos y lógica en hooks/servicios, no en componentes.
+- Consumir mastery exclusivamente desde `useTopicMastery`, `useCourseMastery` y `useStudyHubProgress` (owner ST-05); nunca recalcular localmente.
+- Usar `studyhub-helpers.ts` para transformaciones de datos; no duplicar lógica en los componentes.
+- Respetar la jerarquía de contenido: Course > Topic > Keyword > Card en toda navegación y renderizado.
+- Aplicar lazy loading y virtualización en `StudyHubSectionCards.tsx` para performance con grandes listas.
+- Aplicar los colores de la Delta Mastery Scale (gray/red/yellow/green/blue) de forma consistente en tarjetas y secciones.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Calcular mastery localmente en componentes | Duplica lógica, genera inconsistencias con BKT/FSRS real | Consumir `useTopicMastery` / `useCourseMastery` (ST-05) |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente con interfaces del dominio |
+| Modificar hooks o servicios de ST-05 directamente | Viola aislamiento de agentes | Escalar al Arquitecto (XX-01) para coordinar |
+| Duplicar lógica de transformación fuera de `studyhub-helpers.ts` | Genera drift entre componentes | Centralizar en `studyhub-helpers.ts` |
+| Usar componentes de clase | Incompatible con el stack de hooks | React funcional con hooks siempre |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/ST-02-study-sessions.md
+++ b/.claude/agent-memory/individual/ST-02-study-sessions.md
@@ -1,0 +1,51 @@
+# Agent Memory: ST-02 (study-sessions)
+Last updated: 2026-03-26
+
+## Rol
+Mantener y evolucionar el flujo completo de sesiones de estudio: creación de sesión, envío de batches de revisión FSRS y registro de analítica de actividad.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | studentApi.ts es un barrel re-exporter; las implementaciones reales viven en student-api/sa-*.ts sub-files. Tests deben importar desde barrel pero entender las sub-files para verificar contratos. | Siempre leer los sub-files antes de escribir tests |
+| 2026-03-26 | saveReviews tiene un flujo de 3 pasos: (1) POST /study-sessions, (2) POST /reviews por cada review, (3) PUT /study-sessions/:id para finalizar. correct_reviews se calcula con rating >= 3. | Verificar los 3 pasos en contract tests |
+| 2026-03-26 | Funciones stub (getReviews, getReviewsByCourse, getAllSummaries, etc.) retornan valores vacios sin llamar apiCall. Los tests deben verificar que NO se llama mockApiCall. | No mockear apiCall para stubs |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Mantener separación clara entre tres capas: lógica de sesión (`studySessionApi.ts`), lógica de batch (`useReviewBatch.ts`) y analítica (`sessionAnalytics.ts`).
+- Implementar idempotencia en todo envío de batch: los reintentos por error de red no deben duplicar datos.
+- Tratar los estados FSRS (New, Learning, Review, Relearning) como enum estricto; nunca strings literales.
+- `session-stats.ts` debe ser función pura sin side effects; los side effects de tracking van en `sessionAnalytics.ts`.
+- Aplicar retry con exponential backoff en todas las llamadas a API.
+- Flujo estándar: crear sesión → obtener batch → estudiante responde → enviar batch → actualizar FSRS → registrar analytics → cerrar sesión.
+- Para contract tests: mock `apiCall` con `vi.fn()` ANTES de los imports, usar `mockApiCall.mock.calls[N]` para inspeccionar URL/method/body. Resetear caches de infra en `beforeEach`.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Envíos de batch no idempotentes | Un retry duplica registros en el servidor | Diseñar con idempotency key o deduplicación en API |
+| Strings literales para estados FSRS | Errores silenciosos por typos | Enum estricto de TypeScript |
+| Side effects en `session-stats.ts` | Rompe la pureza y dificulta testing | Mover side effects a `sessionAnalytics.ts` |
+| Mezclar lógica de sesión y analítica en el mismo módulo | Acoplamiento alto, difícil de testear | Mantener separación de responsabilidades por archivo |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+| Modificar `studyQueueApi.ts` o `bktApi.ts` directamente | Viola ownership de ST-03 y ST-05 | Escalar al Arquitecto (XX-01) |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 1 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/ST-03-study-queue.md
+++ b/.claude/agent-memory/individual/ST-03-study-queue.md
@@ -1,0 +1,47 @@
+# Agent Memory: ST-03 (study-queue)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar la cola de estudio: algoritmo NeedScore de priorización, caché TTL y actualizaciones optimistas para mantener la UI responsive.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Respetar la fórmula NeedScore como contrato sagrado: `overdue(40%) + mastery(30%) + fragility(20%) + novelty(10%)`. Cambios de pesos requieren aprobación explícita.
+- Invalidar el TTL cache siempre que se complete una sesión de estudio o se actualice mastery.
+- Implementar rollback automático en actualizaciones optimistas si la API falla.
+- Memoizar el cálculo de NeedScore en `StudyQueueWidget.tsx` para evitar recálculos en cada render.
+- Garantizar que toda tarjeta en la cola tenga un NeedScore calculado antes de mostrarse.
+- Consumir mastery desde `useTopicMastery` y `useKeywordMastery` (ST-05); nunca calcularlo localmente.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Alterar los pesos de NeedScore sin aprobación | Cambia el comportamiento de priorización para todos los estudiantes | Escalar al Arquitecto (XX-01) con justificación |
+| Mostrar tarjetas sin NeedScore calculado | UI inconsistente, posible crash | Garantizar score antes de renderizar |
+| No invalidar cache tras sesión completada | Datos stale en la cola, tarjetas ya revisadas reaparecen | Suscribirse a eventos de sesión completa para invalidar TTL |
+| Actualizaciones optimistas sin rollback | Si la API falla, UI queda en estado incorrecto | Implementar rollback al estado previo en caso de error |
+| Recalcular NeedScore en cada render del widget | Performance degradada en el dashboard | Usar `useMemo` con dependencias precisas |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/ST-04-study-plans.md
+++ b/.claude/agent-memory/individual/ST-04-study-plans.md
@@ -1,0 +1,47 @@
+# Agent Memory: ST-04 (study-plans)
+Last updated: 2026-03-25
+
+## Rol
+Mantener y evolucionar el sistema completo de planes de estudio: wizard de 6 pasos, dashboard, vistas de calendario, agente de scheduling con IA y motor de reprogramación.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Refactorizar `StudyOrganizerWizard.tsx` (~1268L) de forma incremental, nunca romper la navegación entre los 6 pasos.
+- Mantener `rescheduleEngine.ts` como función pura: sin side effects, sin llamadas a API; recibe plan, devuelve plan reprogramado.
+- Tratar `types/study-plan.ts` como contrato compartido: cualquier cambio requiere verificar todos los consumidores antes de aplicar.
+- Implementar fail graceful en `useScheduleAI.ts`: si la IA no responde, ofrecer scheduling manual como fallback.
+- Las estimaciones de tiempo en `useStudyTimeEstimates.ts` deben considerar mastery actual y dificultad del contenido.
+- Consumir mastery y progreso exclusivamente desde hooks de ST-05 (read-only); nunca modificarlos.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Refactores grandes y monolíticos en `StudyOrganizerWizard.tsx` | Alto riesgo de romper la navegación entre pasos | Cambios incrementales, un paso a la vez |
+| Side effects o llamadas a API en `rescheduleEngine.ts` | Rompe la pureza, dificulta testing | Mantener puro; side effects en el hook que lo llama |
+| Cambiar `types/study-plan.ts` sin auditar consumidores | Rompe contrato compartido con ST-01, ST-02, ST-03, ST-05 | Buscar todos los consumidores antes de modificar |
+| Dependencia dura de la respuesta IA en `useScheduleAI.ts` | Si la IA falla, el usuario queda bloqueado | Siempre proveer path de scheduling manual |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente con tipos del dominio |
+| Modificar archivos de ST-05 para obtener mastery | Viola ownership | Consumir hooks de ST-05 en modo solo lectura |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/ST-05-study-progress.md
+++ b/.claude/agent-memory/individual/ST-05-study-progress.md
@@ -1,0 +1,55 @@
+# Agent Memory: ST-05 (study-progress)
+Last updated: 2026-03-26
+
+## Rol
+Mantener y evolucionar el sistema de tracking de progreso y mastery: hooks BKT/FSRS, contextos compartidos, helpers de cálculo, APIs de mastery y servicios de progreso que alimentan a todos los demás agentes de Study.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-03-26 | Task spec had different mastery thresholds than Delta Mastery Scale in agent definition (task: 0.5/0.85/1.0/1.0+ vs agent def: 0.3/0.6/0.85). Used task spec thresholds since they were explicitly requested for this block-level component. | Always check if task spec overrides standard scale thresholds |
+| 2026-03-26 | `STUDENT_BKT_STALE` (5 min) exists in staleTimes.ts — reuse it instead of hardcoding staleTime values | Import from `staleTimes.ts` always |
+| 2026-03-26 | StudyTimer: useRef for interval ID instead of just clearInterval in cleanup — prevents stale closure issues when toggling running state rapidly | Use useRef for interval IDs in timer components |
+| 2026-03-26 | StudyTimer: separate useEffect for auto-switch (seconds===0) from tick logic — avoids race condition where mode switch and interval clear compete | Keep timer tick and mode-switch effects decoupled |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+| 2026-03-26 | MasteryBar uses inline style for color + transition instead of Tailwind color classes | Mastery colors are dynamic from design tokens (hex values), can't use Tailwind classes; transition is color-only per spec (no size/position) | Tailwind arbitrary values `bg-[${color}]` (doesn't work with dynamic values at runtime) |
+| 2026-03-26 | useSummaryBlockMastery uses try/catch fallback to {} instead of React Query error state | Spec requires graceful 404 fallback — endpoint may not exist yet for all summaries | Let React Query propagate the error (would require error handling in every consumer) |
+
+## Patrones que funcionan
+- Respetar la Delta Mastery Scale como estándar inmutable: Gray (<sin datos>) / Red (p_know < 0.3) / Yellow (0.3–0.6) / Green (0.6–0.85) / Blue (>= 0.85). Cambios requieren aprobación.
+- Mantener `mastery-helpers.ts` y `grade-mapper.ts` como funciones puras sin side effects.
+- Usar React Query con `staleTime` apropiado en todos los hooks de mastery para evitar refetches innecesarios.
+- Memoizar contextos (`TopicMasteryContext`, `StudyTimeEstimatesContext`) para minimizar re-renders.
+- Mantener separación clara en `keywordMasteryApi.ts` (~529L): CRUD, agregación y caché en secciones distintas.
+- La agregación de `p_know` a nivel de tema es promedio ponderado de keywords; a nivel de curso, agregación desde temas.
+- Este agente es proveedor de mastery para ST-01, ST-03 y ST-04: cambios en interfaces de hooks tienen impacto cross-agent.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Alterar la Delta Mastery Scale sin aprobación | Rompe la consistencia visual en toda la plataforma | Escalar al Arquitecto (XX-01) |
+| Side effects en `mastery-helpers.ts` o `grade-mapper.ts` | Rompe la pureza y dificulta testing | Mantener puros; side effects en hooks o servicios |
+| Modificar estados FSRS directamente | Responsabilidad exclusiva de ST-02 | Solo consumir FSRS para métricas de progreso |
+| Cambiar interfaces públicas de hooks sin coordinar | ST-01, ST-03, ST-04 dependen de estas interfaces | Auditar consumidores antes de cambiar firmas |
+| Re-renders excesivos en contextos de mastery | Degrada performance en toda la app | `useMemo` / `useCallback` con dependencias precisas |
+| Mezclar CRUD, agregación y caché en `keywordMasteryApi.ts` | Hace el archivo inmanejable (~529L) | Mantener secciones bien delimitadas |
+| Usar `any` en TypeScript | Rompe la seguridad de tipos | Tipar explícitamente |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 2 | 2026-03-26 |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/XX-01-architect.md
+++ b/.claude/agent-memory/individual/XX-01-architect.md
@@ -1,0 +1,79 @@
+# XX-01 Architect — Individual Memory
+
+Created: 2026-03-25
+Last updated: 2026-03-25
+Sessions executed: 1
+
+---
+
+## 1. Session Log
+
+| # | Date | Type | Agents | Outcome | Lessons |
+|---|------|------|--------|---------|---------|
+| 1 | 2026-03-25 | Recon Batch 1 | 20 (QZ×6, FC×6, SM×6, ST×2) | All completed. Avg confidence 8.3/10 | 4 critical bugs, 3 registry gaps, multiple dead code. See below. |
+
+---
+
+## 2. Architectural Decisions
+
+| ID | Date | Decision | Why | Alternatives discarded |
+|----|------|----------|-----|----------------------|
+| D1 | 2026-03-25 | Recon before fix — agents study first, fix after | Agents need domain knowledge before touching code. Blind fixes cause regressions. | Fix-first (risky without context) |
+| D2 | 2026-03-25 | Sonnet for recon, Opus for fixes | Recon is read-only exploration — sonnet sufficient. Fixes need precision — opus required. | All opus (hits API 529 with 20 agents) |
+| D3 | 2026-03-25 | Each agent fixes its own findings | Agent already has deep context from recon. Handing off to another agent loses context. | Central fix agent (loses section expertise) |
+| D4 | 2026-03-25 | Classify fixes: safe/investigate/risky before launching | Prevents agents from "fixing" intentional design decisions. BKT v3.1 vs v4 might be intentional dual-system. | Fix everything (risky) |
+
+---
+
+## 3. Patterns That Work
+
+- **Batch recon of 20 agents**: all completed successfully, no API 529 with sonnet model
+- **Structured report format**: inventory + patterns + dependencies + confidence score gives excellent signal
+- **Agents self-identify registry gaps**: QZ-02 and SM-02 both caught that their listed files don't exist
+- **Cross-agent corroboration**: QZ-03, QZ-04, and ST-02 all independently confirmed BKT v3.1 vs v4 discrepancy — high confidence finding
+
+## 4. Patterns to Avoid
+
+- **Don't launch 20 opus agents simultaneously** — API 529 guaranteed. Use sonnet for read-only tasks.
+- **Don't fix BKT parameter discrepancy without understanding intent** — v3.1 frontend is heuristic-only (visual), v4 backend is authoritative. May be intentional architecture.
+- **Don't trust registry file paths blindly** — 3/20 agents found their listed files don't exist. Always verify.
+- **NEVER use specialized subagent types for code fixes** — `study-hub`, `video-player`, `text-highlighter`, `docs-writer` etc. lack effective Bash/Edit permissions even with `bypassPermissions`. ALWAYS use `general-purpose` + `model: "opus"` + `mode: "bypassPermissions"` for any agent that needs to write code, run git, or edit files.
+- **Don't forget `mode: "bypassPermissions"`** — without it, agents ask for confirmation and block. For autonomous operation, always include it.
+
+## 5. Registry Corrections Needed
+
+| Agent | Issue | Fix |
+|-------|-------|-----|
+| QZ-02 | Lists `routes/quiz*.ts`, `quiz-service.ts` — don't exist | Update to `routes-student.ts` (CRUD factory), `routes/study/reviews.ts`, `lib/bkt-v4.ts`, `lib/types.ts` |
+| SM-02 | Lists `summary-service.ts` — doesn't exist | Update to `crud-factory.ts`, `summary-hook.ts`, `block-hook.ts`, `block-flatten.ts`, `auto-ingest.ts`, `publish-summary.ts` |
+| SM-06 | `useTextAnnotations.ts` dead code, TextHighlighter possibly not integrated | Verify integration point before removing |
+
+## 6. Bug Triage from Batch 1 Recon
+
+### SAFE TO FIX (clear solution, low risk)
+| Bug | Agent | Fix | Risk |
+|-----|-------|-----|------|
+| `watchTimeRef` never increments | SM-05 | Accumulate time in `onTimeUpdate` when `!el.paused` | Low — telemetry only |
+| `StudyHubSections.tsx` orphaned | ST-01 | Remove file (confirmed not imported anywhere) | Low — dead code |
+| `useTextAnnotations.ts` dead code | SM-06 | Remove file + old `textAnnotationsApi.ts` | Low — dead code |
+| `saveReviews` legacy path | ST-02 | Document as deprecated, add TODO comment | Low — documentation |
+| Cache key mismatch `kwConnections` vs `kwConnectionsResolved` | FC-05 | Align invalidation key | Medium — could affect cache |
+
+### NEEDS INVESTIGATION (might be intentional)
+| Bug | Agent | Question |
+|-----|-------|----------|
+| BKT v3.1 vs v4 params | QZ-04 | Is the frontend heuristic intentionally different from backend? (Likely YES — frontend is visual-only) |
+| `useQuizNavigation` duplicated in QuizTaker | QZ-01 | Was extraction intentional but incomplete? Or is it the planned migration path? |
+
+### RISKY (could break production)
+| Bug | Agent | Why risky |
+|-----|-------|-----------|
+| `getKeywordsNeedingCards` stub | FC-06 | Implementing real logic requires understanding NeedScore from backend — not just unstubbing |
+| `KeywordCollection` type collision | FC-06 | Two modules use same name with different shapes — refactoring requires coordinated rename |
+
+## 7. Self-Improvement Notes
+
+- Next recon batch: ask agents to also report "files in my zone that are NOT in the registry" (reverse gap)
+- Consider adding a "verify registry accuracy" step to every recon prompt
+- The confidence score (1-10) is a useful health metric — track trends per agent across sessions
+- 20 agents in background works well — no issues with completion notifications

--- a/.claude/agent-memory/individual/XX-02-quality-gate.md
+++ b/.claude/agent-memory/individual/XX-02-quality-gate.md
@@ -1,0 +1,61 @@
+# Agent Memory: XX-02 (quality-gate)
+Last updated: 2026-03-30
+
+## Parámetros de verificación (spec v4.2)
+- BKT: P_LEARN=0.18, P_FORGET=0.25, RECOVERY=3.0
+- FSRS: w8=1.10, w11=2.18, w15=0.29, w16=2.61
+- Colors: delta mode (Δ = displayMastery / threshold)
+- Grades: Again=0.0, Hard=0.35, Good=0.65, Easy=1.0
+
+## Lecciones aprendidas por este agente
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado — sin errores registrados aún | — |
+| 2026-03-30 | Pre-existing test failures (StudentSummaryReader.tsx size regression 29KB>28KB) should not block APPROVE — verify they exist on main before attributing to the branch. | Always run `git stash && npm test` on main to confirm pre-existing failures before flagging them as regressions. |
+| 2026-03-30 | SafeBoundary error boundaries can mask real errors in production — flag as warning, not blocker. They're pragmatic for test resilience but should be reviewed periodically. | Flag error boundaries that swallow errors silently as "suggestion" level, not "critical". |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Falsos positivos conocidos (NO reportar)
+| Pattern | Por qué es falso positivo |
+|---------|--------------------------|
+| (ninguno aún) | — |
+| StudentSummaryReader.tsx size regression (29KB > 28KB) | Pre-existing on main — not caused by agents in this session |
+
+## Falsos negativos históricos (cosas que se escaparon)
+| Fecha | Qué se escapó | Regla agregada |
+|-------|---------------|----------------|
+| (ninguno aún) | — | — |
+
+## Decisiones de criterio
+| Fecha | Decisión | Contexto |
+|-------|----------|----------|
+| 2026-03-25 | BLOCK si se modifican archivos fuera de zona | Scope creep es el error más frecuente (3x) |
+| 2026-03-25 | NEEDS FIX si faltan tests para happy path | Tests son obligatorios, no opcionales |
+
+## Métricas de auditoría
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Total auditorías ejecutadas | 2 | 2026-03-30 |
+| Veredictos APPROVE | 2 | 2026-03-30 |
+| Veredictos NEEDS FIX | 0 | — |
+| Veredictos BLOCK | 0 | — |
+| Falsos positivos reportados | 0 | — |
+| Falsos negativos descubiertos | 0 | — |
+
+## Session Log: 2026-03-30 (Audit #2) — feat/block-mastery-visual
+| Agent | Veredicto | Issues |
+|-------|-----------|--------|
+| SM-02 (Backend) | APPROVE | 0 critical, 0 warning, 1 suggestion |
+| SM-01 (Frontend) | APPROVE | 0 critical, 0 warning, 0 suggestions |
+- Backend: 3 files touched, all in-zone. Auth uses getUserClient (RLS). 3 queries max. Case-insensitive matching. Tests pass (deno not available on this machine but logic tests are unit-pure).
+- Frontend: 4 files touched, all in-zone. Hook URL matches backend route. MasteryLegend imports MASTERY_LIGHT from MasteryBar (same colors). TypeScript clean (only pre-existing tsconfig deprecation warnings). Vitest 6/6 pass.

--- a/.claude/agent-memory/individual/XX-04-type-guardian.md
+++ b/.claude/agent-memory/individual/XX-04-type-guardian.md
@@ -1,0 +1,51 @@
+# Agent Memory: XX-04 (type-guardian)
+Last updated: 2026-03-25
+
+## Rol
+Guardián del sistema de tipos TypeScript. Consolida duplicados, mantiene coherencia. PUEDE modificar archivos de tipos.
+
+## Duplicaciones conocidas (CRITICO — resolver)
+| Tipo | Definido en | Canónico | Status |
+|------|------------|----------|--------|
+| Course | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Semester | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Section | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| Topic | content.ts, legacy-stubs.ts, platform.ts | content.ts (propuesto) | PENDIENTE |
+| MasteryLevel | (2 ubicaciones con VALORES DIFERENTES) | POR DECIDIR | BLOQUEADO |
+
+## Plan de consolidación
+1. Identificar todos los consumidores de cada definición duplicada
+2. Elegir canónico (content.ts para contenido, platform.ts para plataforma)
+3. Actualizar todas las importaciones
+4. Eliminar definiciones duplicadas
+5. Eliminar legacy-stubs.ts completamente
+
+## Progreso de limpieza
+| Archivo | Líneas | Estado | Notas |
+|---------|--------|--------|-------|
+| types/legacy-stubs.ts | 128 | MARCADO PARA ELIMINACIÓN | No agregar tipos nuevos aquí |
+| types/content.ts | 113 | ACTIVO | Candidato a canónico para tipos de contenido |
+| types/platform.ts | 255 | ACTIVO | Candidato a canónico para tipos de plataforma |
+
+## Reglas de tipos (NO violar)
+- Cada tipo: UNA SOLA definición canónica
+- `export type` para tipos, `export interface` para interfaces con métodos
+- Nunca `any` → usar `unknown`
+- `import type { ... }` siempre
+- Archivos de tipos: sin lógica de runtime
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory/individual/XX-05-migration-writer.md
+++ b/.claude/agent-memory/individual/XX-05-migration-writer.md
@@ -1,0 +1,49 @@
+# Agent Memory: XX-05 (migration-writer)
+Last updated: 2026-03-25
+
+## Rol
+Generador de migraciones SQL de AXON — crea, revisa y mantiene las migraciones de base de datos que evolucionan el esquema PostgreSQL/Supabase de forma versionada y consistente.
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Patrones que funcionan
+- Nombre de archivo con timestamp UTC real: `YYYYMMDDHHMMSS_descripcion_breve.sql` — garantiza orden secuencial.
+- Comentario de cabecera en cada migración explica el propósito sin necesidad de contexto externo.
+- `BEGIN; ... COMMIT;` envuelve migraciones con múltiples statements para atomicidad.
+- Idempotencia con `IF NOT EXISTS` / `IF EXISTS` permite re-ejecución segura en ambientes de desarrollo.
+- Toda tabla nueva sigue el estándar: `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`, `created_at TIMESTAMPTZ DEFAULT now()`, `updated_at TIMESTAMPTZ DEFAULT now()`.
+- Foreign keys con `ON DELETE` behavior explícito — nunca implícito.
+- Índices con comentario que justifica el patrón de query que optimizan.
+- Migraciones destructivas marcadas claramente con `-- DESTRUCTIVE`.
+- RLS habilitado en todas las tablas con datos de usuario.
+
+## Patrones a evitar
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Modificar una migración ya aplicada | Rompe la secuencia y genera conflictos irrecuperables | Crear nueva migración correctiva |
+| DROP sin verificar consumidores | Puede romper servicios en producción silenciosamente | Buscar usos en servicios, tipos TypeScript y código antes de ejecutar |
+| Migraciones sin `BEGIN/COMMIT` con múltiples statements | Si falla a mitad queda el schema en estado inconsistente | Siempre envolver en transacción |
+| Usar timestamps inventados (no UTC real) en el nombre | Rompe el orden secuencial de aplicación | Usar timestamp UTC del momento real de creación |
+| Tablas sin RLS en datos de usuario | Expone datos sin control de acceso | Agregar políticas RLS en la misma migración |
+
+## Métricas
+| Métrica | Valor | Última sesión |
+|---------|-------|---------------|
+| Sesiones ejecutadas | 0 | — |
+| Quality-gate PASS | 0 | — |
+| Quality-gate FAIL | 0 | — |
+| Scope creep incidents | 0 | — |

--- a/.claude/agent-memory/individual/XX-06-test-orchestrator.md
+++ b/.claude/agent-memory/individual/XX-06-test-orchestrator.md
@@ -1,0 +1,47 @@
+# Agent Memory: XX-06 (test-orchestrator)
+Last updated: 2026-03-25
+
+## Rol
+Ejecuta todas las suites de tests, reporta fallos y verifica cobertura. NO modifica código.
+
+## Tests flaky conocidos (max 15)
+| Fecha | Test | Archivo | Razón | Status |
+|-------|------|---------|-------|--------|
+| (ninguno aún) | — | — | — | — |
+
+## Módulos problemáticos (top error producers)
+| Módulo | Tests fallidos (acumulado) | Última vez | Tendencia |
+|--------|---------------------------|------------|-----------|
+| (ninguno aún) | — | — | — |
+
+## Baseline de ejecución
+| Métrica | Valor | Última actualización |
+|---------|-------|---------------------|
+| Frontend tests (total) | — | — |
+| Backend tests (total) | — | — |
+| Tiempo típico frontend | — | — |
+| Tiempo típico backend | — | — |
+| Tests con .only | — | — |
+| Tests con .skip | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|
+
+## Decisiones
+| Fecha | Decisión | Contexto |
+|-------|----------|----------|
+| 2026-03-25 | Tests >5s se reportan como candidatos a optimización | Umbral definido en la spec del agente |
+| 2026-03-25 | Agrupar fallos por módulo/feature | Facilita triaje por el Arquitecto |

--- a/.claude/agent-memory/individual/XX-07-refactor-scout.md
+++ b/.claude/agent-memory/individual/XX-07-refactor-scout.md
@@ -1,0 +1,42 @@
+# Agent Memory: XX-07 (refactor-scout)
+Last updated: 2026-03-25
+
+## Rol
+Identifica código muerto, duplicaciones y deuda técnica. Solo lectura — reporta, no modifica.
+
+## Deuda técnica conocida (tracking)
+| Fecha | Tipo | Archivo | Severidad | Accionado? | Notas |
+|-------|------|---------|-----------|-----------|-------|
+| 2026-03-25 | Tipos duplicados | types/legacy-stubs.ts | CRITICO | NO | 128L marcado para eliminación — XX-04 es responsable |
+| 2026-03-25 | Tipos duplicados | Course, Semester, Section, Topic (3x) | CRITICO | NO | Definidos en content.ts, legacy-stubs.ts, platform.ts |
+| 2026-03-25 | Tipos inconsistentes | MasteryLevel (2x con valores diferentes) | CRITICO | NO | Requiere decisión de cuál es canónico |
+
+## Archivos >500 líneas (candidatos a split)
+| Archivo | Líneas | Sugerencia | Accionado? |
+|---------|--------|-----------|-----------|
+| components/ai/AxonAIAssistant.tsx | 1106 | Refactor incremental — AI-02 es dueño | NO |
+| hooks/useFlashcardNavigation.ts | 567 | FC-04 es dueño — requiere tests exhaustivos | NO |
+
+## Tendencias entre escaneos
+| Métrica | Escaneo anterior | Último escaneo | Trend |
+|---------|-----------------|---------------|-------|
+| Total `any` types | — | — | — |
+| Total console.log | — | — | — |
+| Archivos >500L | — | — | — |
+| Exports no usados | — | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory/individual/XX-08-design-system.md
+++ b/.claude/agent-memory/individual/XX-08-design-system.md
@@ -1,0 +1,11 @@
+# XX-08 — Design System
+
+## Sessions: 1
+
+## Session — 2026-03-30
+- **Task:** Create severity tokens (mild/moderate/critical) for quiz and mastery indicators
+- **Files touched:**
+  - src/app/design-system/severity.ts (NEW)
+  - src/app/design-system/index.ts (added section 12 re-export)
+- **Learned:** design-system/index.ts barrel has numbered sections (1-11 before this session); new modules go at the end with next number
+- **Pattern:** Severity tokens use standard Tailwind classes (bg-amber-50, text-amber-700, etc.) — no arbitrary values

--- a/.claude/agent-memory/individual/XX-09-api-contract.md
+++ b/.claude/agent-memory/individual/XX-09-api-contract.md
@@ -1,0 +1,47 @@
+# Agent Memory: XX-09 (api-contract)
+Last updated: 2026-03-25
+
+## Rol
+Valida consistencia de contratos API entre frontend (services/) y backend (routes/). Solo lectura.
+
+## Convenciones de contrato (NO violar)
+- Envelope lista: `{ data: { items: [...], total: N } }`
+- Envelope item: `{ data: { ... } }`
+- Envelope error: `{ error: { message, code } }`
+- URLs: flat REST, kebab-case, max 2 niveles de recurso
+- Métodos: GET=lectura, POST=creación, PUT/PATCH=actualización, DELETE=eliminación
+- Campos JSON: camelCase
+
+## Mismatches conocidos (tracking)
+| Fecha | Frontend | Backend | Tipo | Severidad | Resuelto? |
+|-------|----------|---------|------|-----------|-----------|
+| (ninguno aún) | — | — | — | — | — |
+
+## Endpoints orphan (backend sin consumidor frontend)
+| Endpoint | Método | Desde cuándo | Acción sugerida |
+|----------|--------|-------------|-----------------|
+| (ninguno aún) | — | — | — |
+
+## Tendencias entre auditorías
+| Métrica | Auditoría anterior | Última auditoría | Trend |
+|---------|-------------------|-----------------|-------|
+| Total endpoints | — | — | — |
+| Mismatches | — | — | — |
+| Envelope violations | — | — | — |
+| Orphan endpoints | — | — | — |
+
+## Lecciones aprendidas
+| Fecha | Lección | Prevención |
+|-------|---------|------------|
+| 2026-03-25 | (inicial) Archivo creado | — |
+
+## Efectividad de lecciones
+| Lección | Veces aplicada | Previno error? | Confianza |
+|---------|---------------|----------------|-----------|
+| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+
+> Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
+
+## Decisiones técnicas (NO re-litigar)
+| Fecha | Decisión | Por qué | Alternativas descartadas |
+|-------|----------|---------|--------------------------|

--- a/.claude/agent-memory/infra.md
+++ b/.claude/agent-memory/infra.md
@@ -1,0 +1,45 @@
+# Memory: infra
+Last updated: 2026-03-18
+
+## Plumbing
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+
+## AI
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+
+## UI
+
+### Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-20 | Recharts v2.15.2 insertBefore crash (SVG DOM desync) | All chart files | ChartErrorBoundary wrapping + ProgressTrendChart null→div fix |
+
+### Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+### Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory/messaging.md
+++ b/.claude/agent-memory/messaging.md
@@ -1,0 +1,17 @@
+# Messaging Memory
+
+## Estado actual
+- Telegram bot linking working (link code, status, unlink)
+- WhatsApp feature-flagged
+- Admin messaging settings page exists
+
+## Decisiones tomadas (NO re-litigar)
+- Feature flags for WhatsApp
+
+## Archivos clave
+- services/student-api/sa-telegram.ts — Telegram link/unlink/status
+- services/platform-api/pa-messaging.ts — messaging settings API
+- AdminMessagingSettingsPage.tsx (521L) — admin messaging config UI
+
+## Bugs conocidos
+- None open

--- a/.claude/agent-memory/quiz.md
+++ b/.claude/agent-memory/quiz.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory/study.md
+++ b/.claude/agent-memory/study.md
@@ -1,0 +1,14 @@
+# Memory: ${section}
+Last updated: 2026-03-18
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|

--- a/.claude/agent-memory/summaries.md
+++ b/.claude/agent-memory/summaries.md
@@ -1,0 +1,32 @@
+# Memory: Summaries
+Last updated: 2026-03-25
+
+## Errores conocidos (max 20)
+| Fecha | Error | Archivo | Resolución |
+|-------|-------|---------|------------|
+| 2026-03-24 | handleFieldChange escribía a ref sin re-render → input lag 2s+ | BlockEditor.tsx | Agregar setTick(t=>t+1) para forzar re-render |
+| 2026-03-24 | flushPending era fire-and-forget → publish podía racear saves | BlockEditor.tsx | Cambiar a mutateAsync + await en handlePublish |
+| 2026-03-24 | Severity forms usaban español (leve/moderado/grave) pero renderers esperan inglés | StagesForm, ListDetailForm | StagesForm: mild/moderate/critical. ListDetailForm: high/medium/low |
+| 2026-03-24 | Callout con título vacío → contenido desaparecía en ViewerBlock | ViewerBlock.tsx | Remover `&& c.title` de la condición de routing edu callout |
+| 2026-03-24 | Publish endpoint tenía path incorrecto /content/summaries/ | BlockEditor.tsx | Cambiar a /summaries/${id}/publish |
+| 2026-03-24 | ReorderTable type no incluía summary_blocks → unsafe cast | summariesApi.ts | Agregar 'summary_blocks' al union type |
+| 2026-03-25 | Auditoría visual recomendó GridBlock horizontal pero prototipo es centered | GridBlock.tsx | Siempre verificar contra prototipo ORIGINAL, no confiar en auditoría sola |
+| 2026-03-25 | apiCall fuerza Content-Type JSON, rompe FormData uploads | ImageReferenceForm, ProseForm | Usar raw fetch para uploads multipart |
+
+## Patterns a evitar (max 10)
+| Pattern | Por qué | Alternativa |
+|---------|---------|-------------|
+| Controlled inputs con onChange que solo escribe a ref | Input lag — React no re-renderiza | Agregar setTick o usar local state |
+| `as ReorderTable` type casts | Oculta errores reales de tipo | Expandir el union type en summariesApi.ts |
+| Severity values en español en forms | Renderers usan inglés → colores nunca aplican | Siempre usar valores que matchean SEVERITY_COLORS del renderer |
+| Confiar en una sola auditoría visual | Puede recomendar cambios incorrectos | Siempre cruzar con el código fuente del prototipo |
+| apiCall para FormData uploads | Fuerza Content-Type: application/json | Usar raw fetch con headers manuales |
+
+## Decisiones (max 10)
+| Fecha | Decisión | Contexto |
+|-------|---------|----------|
+| 2026-03-24 | Block editor usa auto-save 2s debounce en vez de undo/redo | Server-first architecture, más robusto que local state |
+| 2026-03-24 | Professor accent = violet, no teal | Consistente con otras pages del profesor |
+| 2026-03-24 | Prototype design tokens: darkTeal=#1B3B36, tealAccent=#2a8c7a | Definidos en theme.css como CSS variables |
+| 2026-03-25 | Image upload usa POST /storage/upload (backend route) no direct Supabase | Centraliza logging, validación, path generation |
+| 2026-03-25 | KeywordChip usa hover popover con 150ms delay | Mejor UX que tooltip nativo, evita flicker |

--- a/.claude/agents/admin-backend.md
+++ b/.claude/agents/admin-backend.md
@@ -36,9 +36,9 @@ Eres AO-02, el agente backend del rol administrador. Mantenés las rutas API de 
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/admin.md` (contexto de seccion admin)
-4. Lee `docs/claude-config/agent-memory/individual/AO-02-admin-backend.md` (TU memoria personal — lecciones, patrones, metricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/admin.md` (contexto de seccion admin)
+4. Lee `.claude/agent-memory/individual/AO-02-admin-backend.md` (TU memoria personal — lecciones, patrones, metricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, Hono framework — sin `any`, sin `console.log`, sin `// @ts-ignore`
@@ -62,7 +62,7 @@ Eres AO-02, el agente backend del rol administrador. Mantenés las rutas API de 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/admin-dev.md
+++ b/.claude/agents/admin-dev.md
@@ -36,7 +36,7 @@ Sos el agente fullstack de Dashboard + Owner + Admin + Professor admin de AXON.
 - Layout/Sidebar (Lead owns)
 - Design system (DO NOT MODIFY)
 
-## Al iniciar: leer `docs/claude-config/agent-memory/admin.md`
+## Al iniciar: leer `.claude/agent-memory/admin.md`
 
 ## Contexto técnico
 - Owner: gestión de institución, miembros, planes, suscripciones, reportes

--- a/.claude/agents/admin-frontend.md
+++ b/.claude/agents/admin-frontend.md
@@ -37,9 +37,9 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/admin.md`
-4. Lee `docs/claude-config/agent-memory/individual/AO-01-admin-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Leer `.claude/agent-memory/admin.md`
+4. Lee `.claude/agent-memory/individual/AO-01-admin-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 6. Revisa el estado de las paginas placeholder para saber cuales ya estan cableadas y cuales aun son stub
 
 ## Reglas de codigo
@@ -95,7 +95,7 @@ El guard de rol (`requireRole('admin')`) esta en `AdminLayout`, no en cada pagin
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/ai-backend.md
+++ b/.claude/agents/ai-backend.md
@@ -41,10 +41,10 @@ Eres el agente AI-05 responsable de los route handlers del backend AI en Axon. T
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` para obtener contexto actualizado sobre el estado del backend AI y decisiones previas.
-4. Lee `docs/claude-config/agent-memory/individual/AI-05-ai-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` para obtener contexto actualizado sobre el estado del backend AI y decisiones previas.
+4. Lee `.claude/agent-memory/individual/AI-05-ai-backend.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -54,7 +54,7 @@ Eres el agente AI-05 responsable de los route handlers del backend AI en Axon. T
 - `as-realtime.ts` (297L) maneja WebSocket con OpenAI Realtime API; la reconexion automatica es obligatoria.
 - `useRealtimeVoice.ts` (309L) gestiona audio bidireccional; mantener latencia por debajo de 200ms.
 - Los 17 archivos de rutas AI deben seguir una estructura consistente: validacion, procesamiento, respuesta.
-- Todo cambio en rutas o servicios de tiempo real debe documentarse en `docs/claude-config/agent-memory/ai-rag.md`.
+- Todo cambio en rutas o servicios de tiempo real debe documentarse en `.claude/agent-memory/ai-rag.md`.
 
 ## Contexto tecnico
 
@@ -66,7 +66,7 @@ Eres el agente AI-05 responsable de los route handlers del backend AI en Axon. T
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/ai-generation.md
+++ b/.claude/agents/ai-generation.md
@@ -46,10 +46,10 @@ Eres el agente AI-03 responsable de la generacion de contenido educativo con IA 
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` para obtener contexto actualizado sobre decisiones de generacion y estado del sistema AI.
-4. Lee `docs/claude-config/agent-memory/individual/AI-03-ai-generation.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` para obtener contexto actualizado sobre decisiones de generacion y estado del sistema AI.
+4. Lee `.claude/agent-memory/individual/AI-03-ai-generation.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -58,7 +58,7 @@ Eres el agente AI-03 responsable de la generacion de contenido educativo con IA 
 - El modelo BKT (Bayesian Knowledge Tracing) define el targeting; nunca generar contenido para conceptos ya dominados (P(L) > 0.95).
 - `aiApi.ts` (263L) es la interfaz central de comunicacion con servicios AI; cambios aqui afectan a multiples flujos.
 - `useSmartGeneration.ts` (279L) coordina la logica frontend de generacion inteligente; mantener separacion clara entre logica de UI y logica de negocio.
-- Todo cambio en algoritmos de ranking o targeting debe documentarse en `docs/claude-config/agent-memory/ai-rag.md`.
+- Todo cambio en algoritmos de ranking o targeting debe documentarse en `.claude/agent-memory/ai-rag.md`.
 
 ## Contexto tecnico
 
@@ -70,7 +70,7 @@ Eres el agente AI-03 responsable de la generacion de contenido educativo con IA 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/ai-prompts.md
+++ b/.claude/agents/ai-prompts.md
@@ -37,10 +37,10 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` para obtener contexto actualizado sobre decisiones de prompts y estado del sistema AI.
-4. Lee `docs/claude-config/agent-memory/individual/AI-06-ai-prompts.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` para obtener contexto actualizado sobre decisiones de prompts y estado del sistema AI.
+4. Lee `.claude/agent-memory/individual/AI-06-ai-prompts.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -50,7 +50,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 - Los reportes de calidad (`aiReportApi.ts`, 205L) deben evaluar: relevancia, precision, completitud y adecuacion pedagogica.
 - `useAiReports.ts` (244L) maneja la visualizacion de reportes; mantener separacion entre logica de datos y presentacion.
 - Nunca hardcodear prompts directamente en servicios; siempre usar plantillas centralizadas en `as-types.ts`.
-- Todo cambio en prompt templates debe documentarse en `docs/claude-config/agent-memory/ai-rag.md` con justificacion y resultados de evaluacion.
+- Todo cambio en prompt templates debe documentarse en `.claude/agent-memory/ai-rag.md` con justificacion y resultados de evaluacion.
 
 ## Contexto tecnico
 
@@ -62,7 +62,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/api-contract.md
+++ b/.claude/agents/api-contract.md
@@ -15,7 +15,7 @@ Ninguna — eres un agente de solo lectura que audita contratos API.
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 - `routes/**` — rutas del backend
 - `services/**` — servicios del frontend que consumen las APIs
 
@@ -26,13 +26,13 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo que estás auditando
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` (contexto compartido)
-4. Lee `docs/claude-config/agent-memory/individual/XX-09-api-contract.md` (TU memoria personal — mismatches conocidos, convenciones, endpoints orphan)
+3. Lee `.claude/agent-memory/cross-cutting.md` (contexto compartido)
+4. Lee `.claude/agent-memory/individual/XX-09-api-contract.md` (TU memoria personal — mismatches conocidos, convenciones, endpoints orphan)
 5. Escanea `routes/**` para mapear todos los endpoints disponibles
 6. Escanea `services/**` para mapear todas las llamadas API del frontend
 7. Cruza ambos mapas para detectar discrepancias
 8. Genera un reporte de inconsistencias
-9. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+9. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -90,7 +90,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
+- **Resultados:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si encontrás un hallazgo crítico que requiere acción inmediata
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -14,8 +14,8 @@ Sos el Arquitecto de AXON. Tu trabajo es analizar cada pedido del usuario y orqu
 1. Leer `.claude/AGENT-REGISTRY.md` (el índice maestro)
 2. Leer `.claude/memory/project_current_state.md` (estado actual)
 3. Leer `.claude/memory/feedback_agent_isolation.md` (reglas de aislamiento)
-4. Leer `docs/claude-config/agent-memory/individual/SELF-EVAL-RESULTS.md` (scores de agentes — saber cuáles están en NEEDS ATTN antes de seleccionarlos)
-5. Leer `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → System Pulse + Section Health (estado general del sistema)
+4. Leer `.claude/agent-memory/individual/SELF-EVAL-RESULTS.md` (scores de agentes — saber cuáles están en NEEDS ATTN antes de seleccionarlos)
+5. Leer `.claude/agent-memory/individual/AGENT-METRICS.md` → System Pulse + Section Health (estado general del sistema)
 
 ## Procedimiento de selección
 
@@ -151,8 +151,8 @@ Al terminar una sesión multi-agente (2+ agentes), ejecutar:
 
 ### Fase 2: Registrar lecciones
 4. **Lecciones globales** → `memory/feedback_agent_isolation.md` tabla HISTORICAL ERRORS
-5. **Lecciones de sección** → `docs/claude-config/agent-memory/<section>.md` tabla "Errores conocidos"
-6. **Lecciones individuales** → `docs/claude-config/agent-memory/individual/<AGENT-ID>.md` tabla "Lecciones aprendidas" (si existe)
+5. **Lecciones de sección** → `.claude/agent-memory/<section>.md` tabla "Errores conocidos"
+6. **Lecciones individuales** → `.claude/agent-memory/individual/<AGENT-ID>.md` tabla "Lecciones aprendidas" (si existe)
 
 ### Fase 3: Actualizar métricas (seguir Update Protocol de AGENT-METRICS.md)
 7. **Paso 1 — Error Ledger:** Por cada QG failure, agregar fila al Error Ledger (Sección 4). Verificar si matchea lección previa del mismo agente → `Recurred? YES(#N)`.
@@ -172,7 +172,7 @@ Al terminar una sesión multi-agente (2+ agentes), ejecutar:
     - Agregar warning a "Patrones a evitar" si es scope creep
 11. **Si quality-gate detectó un tipo de error nuevo no cubierto:**
     - Agregar check a `agents/quality-gate.md` sección "Qué verificar"
-    - Agregar a `docs/claude-config/agent-memory/individual/XX-02-quality-gate.md` tabla "Falsos negativos"
+    - Agregar a `.claude/agent-memory/individual/XX-02-quality-gate.md` tabla "Falsos negativos"
 
 ### Fase 5: Reportar
 12. **Reportar al usuario:** Resumen con:
@@ -206,7 +206,7 @@ Luego lee AGENT-SELF-EVAL.md y completá el checklist de auto-evaluación.
 Reportá con el formato especificado. NO modifiques nada — solo reportá.
 ```
 
-4. Recopilar resultados en `docs/claude-config/agent-memory/individual/SELF-EVAL-RESULTS.md`
+4. Recopilar resultados en `.claude/agent-memory/individual/SELF-EVAL-RESULTS.md`
 5. Identificar patrones sistémicos (misma categoría baja en múltiples agentes)
 6. Priorizar mejoras: primero CRITICO, luego NEEDS ATTENTION
 

--- a/.claude/agents/auth-backend.md
+++ b/.claude/agents/auth-backend.md
@@ -26,9 +26,9 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 ## Al iniciar cada sesion (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/auth.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/AS-01-auth-backend.md` (TU memoria personal — lecciones, decisiones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/auth.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/AS-01-auth-backend.md` (TU memoria personal — lecciones, decisiones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -74,7 +74,7 @@ Ambos tokens coexisten en requests autenticados; el middleware valida el USER_JW
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/auth-frontend.md
+++ b/.claude/agents/auth-frontend.md
@@ -28,9 +28,9 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/auth.md`
-4. Lee `docs/claude-config/agent-memory/individual/AS-02-auth-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Leer `.claude/agent-memory/auth.md`
+4. Lee `.claude/agent-memory/individual/AS-02-auth-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -45,7 +45,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/billing-frontend.md
+++ b/.claude/agents/billing-frontend.md
@@ -31,10 +31,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/billing.md`
-4. Lee `docs/claude-config/agent-memory/individual/BL-03-billing-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/billing.md`
+4. Lee `.claude/agent-memory/individual/BL-03-billing-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `OwnerSubscriptionsPage.tsx` existe
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -53,7 +53,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/billing-plans.md
+++ b/.claude/agents/billing-plans.md
@@ -32,10 +32,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/billing.md`
-4. Lee `docs/claude-config/agent-memory/individual/BL-04-billing-plans.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/billing.md`
+4. Lee `.claude/agent-memory/individual/BL-04-billing-plans.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `pa-plans.ts` y `OwnerPlansPage.tsx` existen
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -59,7 +59,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/content-tree.md
+++ b/.claude/agents/content-tree.md
@@ -21,7 +21,7 @@ Eres SM-04, el agente del arbol de contenido de Axon. Tu responsabilidad es mant
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/summaries.md` — memoria compartida de sección
+- `.claude/agent-memory/summaries.md` — memoria compartida de sección
 - `types/content.ts` — tipos canónicos de contenido. Si necesitan cambios, escalar a XX-01 (Arquitecto)
 
 ## Depends On / Produces for
@@ -32,8 +32,8 @@ Eres SM-04, el agente del arbol de contenido de Axon. Tu responsabilidad es mant
 ## Al iniciar cada sesión (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` (memoria de sección)
-4. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → sección Agent Detail para SM-04 (tu historial QG)
+3. Lee `.claude/agent-memory/summaries.md` (memoria de sección)
+4. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → sección Agent Detail para SM-04 (tu historial QG)
 5. Revisa `ContentTreeContext.tsx` para entender el estado actual
 6. Revisa `ContentTree.tsx` para validar la estructura del componente
 7. Verifica tipos en `types/content.ts` (SOLO LECTURA — si necesitan cambios, escalar a XX-01)
@@ -66,7 +66,7 @@ Eres SM-04, el agente del arbol de contenido de Axon. Tu responsabilidad es mant
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/cors-headers.md
+++ b/.claude/agents/cors-headers.md
@@ -25,9 +25,9 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/auth.md`
-4. Lee `docs/claude-config/agent-memory/individual/AS-05-cors-headers.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Leer `.claude/agent-memory/auth.md`
+4. Lee `.claude/agent-memory/individual/AS-05-cors-headers.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -44,7 +44,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/dashboard-professor.md
+++ b/.claude/agents/dashboard-professor.md
@@ -46,9 +46,9 @@ Puedes leer pero **nunca modificar**:
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/dashboard.md` (contexto de seccion dashboard — estado, decisiones, tareas pendientes)
-4. Lee `docs/claude-config/agent-memory/individual/DG-02-dashboard-professor.md` (TU memoria personal — lecciones, patrones, metricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/dashboard.md` (contexto de seccion dashboard — estado, decisiones, tareas pendientes)
+4. Lee `.claude/agent-memory/individual/DG-02-dashboard-professor.md` (TU memoria personal — lecciones, patrones, metricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -79,7 +79,7 @@ Puedes leer pero **nunca modificar**:
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/dashboard-student.md
+++ b/.claude/agents/dashboard-student.md
@@ -44,11 +44,11 @@ Puedes leer pero **nunca modificar**:
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
+3. Lee `.claude/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
 4. Si el archivo no existe, notifica al usuario y continua sin el.
-5. Lee `docs/claude-config/agent-memory/individual/DG-01-dashboard-student.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/DG-01-dashboard-student.md` (TU memoria personal — lecciones, patrones, métricas)
 6. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 7. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
 
 ## Reglas de codigo
@@ -75,7 +75,7 @@ Puedes leer pero **nunca modificar**:
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/design-system-agent.md
+++ b/.claude/agents/design-system-agent.md
@@ -15,7 +15,7 @@ Ninguna — eres un agente de solo lectura que audita componentes.
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 - `components/**` — todos los componentes de UI
 - `design-system/` — tokens y definiciones del sistema de diseno
 
@@ -26,15 +26,15 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` para obtener contexto actualizado.
+3. Lee `.claude/agent-memory/cross-cutting.md` para obtener contexto actualizado.
 4. Lee los tokens definidos en `design-system/` para tener la referencia actualizada.
 5. Escanea `components/**` aplicando todas las verificaciones.
 6. Genera un reporte de violaciones agrupado por severidad.
-4. Lee `docs/claude-config/agent-memory/individual/XX-08-design-system-agent.md` (TU memoria personal — violaciones recurrentes, tokens actualizados, componentes auditados)
+4. Lee `.claude/agent-memory/individual/XX-08-design-system-agent.md` (TU memoria personal — violaciones recurrentes, tokens actualizados, componentes auditados)
 5. Lee los tokens definidos en `design-system/` para tener la referencia actualizada.
 6. Escanea `components/**` aplicando todas las verificaciones.
 7. Genera un reporte de violaciones agrupado por severidad.
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -93,7 +93,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/design-tokens.md
+++ b/.claude/agents/design-tokens.md
@@ -41,7 +41,7 @@ Estos archivos son tu responsabilidad directa. Puedes leerlos, editarlos y crear
 
 Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coordinación explícita con el agente responsable:
 
-- `docs/claude-config/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para contexto de infraestructura.
+- `.claude/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para contexto de infraestructura.
 - `components/layout/*.tsx` — Para ver cómo se consumen los tokens en layouts reales.
 - `tailwind.config.ts` o configuración de CSS — Para verificar que los tokens estén sincronizados.
 
@@ -52,10 +52,10 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` para sincronizarte con el estado actual de la infraestructura.
+3. Lee `.claude/agent-memory/infra.md` para sincronizarte con el estado actual de la infraestructura.
 4. Verifica que no haya tokens duplicados o inconsistencias entre archivos del design-system.
 5. Confirma que los componentes del design-kit importen tokens desde `design-system/`, nunca valores hardcodeados.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -80,7 +80,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -21,9 +21,9 @@ Sos el agente de documentación de AXON. Manejás todo el repo axon-docs/.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar — si no existe, notificá al usuario y continuá sin él
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento) — si no existe, notificá al usuario
-3. Lee `docs/claude-config/agent-memory/docs.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/XX-03-docs-writer.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/docs.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/XX-03-docs-writer.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Depends On
 Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
@@ -45,7 +45,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/embeddings.md
+++ b/.claude/agents/embeddings.md
@@ -34,10 +34,10 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/AI-04-embeddings.md` (TU memoria personal — lecciones, decisiones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/AI-04-embeddings.md` (TU memoria personal — lecciones, decisiones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -46,7 +46,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 - `useRagAnalytics.ts` (142L) debe mantener un cache local de estadisticas para evitar llamadas excesivas al backend.
 - Nunca eliminar embeddings sin confirmar que no estan referenciados por conversaciones activas.
 - Los embeddings tienen dimension fija de 1536; validar dimension antes de insertar.
-- Todo cambio en indices o estrategias de busqueda debe documentarse en `docs/claude-config/agent-memory/ai-rag.md`.
+- Todo cambio en indices o estrategias de busqueda debe documentarse en `.claude/agent-memory/ai-rag.md`.
 
 ## Contexto tecnico
 
@@ -58,7 +58,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-backend.md
+++ b/.claude/agents/flashcards-backend.md
@@ -30,13 +30,13 @@ Podés LEER cualquier archivo pero NO modificar fuera de tu zona.
 ## Al iniciar cada sesión
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
 4. Verificar que `supabase/functions/server/lib/fsrs-v4.ts` existe
-5. Lee `docs/claude-config/agent-memory/individual/FC-02-flashcards-backend.md` (TU memoria personal — lecciones, patrones, métricas)
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+5. Lee `.claude/agent-memory/individual/FC-02-flashcards-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Al encontrar un error o tomar una decisión
-Registrar en `docs/claude-config/agent-memory/flashcards.md`
+Registrar en `.claude/agent-memory/flashcards.md`
 
 ## Reglas de código
 - TypeScript strict, no `any`
@@ -56,7 +56,7 @@ Registrar en `docs/claude-config/agent-memory/flashcards.md`
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-frontend.md
+++ b/.claude/agents/flashcards-frontend.md
@@ -46,13 +46,13 @@ Podés LEER cualquier archivo del proyecto pero NO modificar archivos fuera de t
 ## Al iniciar cada sesión
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
 4. Verificar que `src/app/components/content/flashcard/` existe
-5. Lee `docs/claude-config/agent-memory/individual/FC-01-flashcards-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+5. Lee `.claude/agent-memory/individual/FC-01-flashcards-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Al encontrar un error o tomar una decisión
-Registrar en `docs/claude-config/agent-memory/flashcards.md` si:
+Registrar en `.claude/agent-memory/flashcards.md` si:
 - El error costó más de 1 intento resolverlo
 - El lead te pide registrar una decisión
 
@@ -74,7 +74,7 @@ Registrar en `docs/claude-config/agent-memory/flashcards.md` si:
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-fsrs.md
+++ b/.claude/agents/flashcards-fsrs.md
@@ -21,7 +21,7 @@ Eres FC-04, el agente responsable del motor de repetición espaciada FSRS v4. Ge
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/flashcards.md`
+- `.claude/agent-memory/flashcards.md`
 - Archivos de otros agentes de flashcards (FC-05, FC-06) para entender contratos de datos
 - Tipos compartidos y servicios globales
 
@@ -34,11 +34,11 @@ Eres FC-04, el agente responsable del motor de repetición espaciada FSRS v4. Ge
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/FC-04-fsrs.md` (TU memoria personal — lecciones, decisiones, métricas)
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/FC-04-fsrs.md` (TU memoria personal — lecciones, decisiones, métricas)
 5. Revisa los hooks del engine y la sesión adaptativa para entender el estado actual
 6. Verifica que los pesos FSRS y el mapeo de grades estén correctos
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -61,7 +61,7 @@ Eres FC-04, el agente responsable del motor de repetición espaciada FSRS v4. Ge
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-generation.md
+++ b/.claude/agents/flashcards-generation.md
@@ -20,7 +20,7 @@ Eres FC-06, el agente responsable de la generación de flashcards con IA. Gestio
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/flashcards.md`
+- `.claude/agent-memory/flashcards.md`
 - Archivos de otros agentes de flashcards (FC-04, FC-05) para entender contratos de datos
 - Servicios BKT del módulo de quizzes para entender el modelo de conocimiento
 - Tipos compartidos y servicios globales
@@ -33,11 +33,11 @@ Eres FC-06, el agente responsable de la generación de flashcards con IA. Gestio
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
 4. Revisa el generador y los hooks de generación para entender el estado actual.
 5. Verifica que el ranking NeedScore y el targeting BKT estén funcionando correctamente.
-6. Lee `docs/claude-config/agent-memory/individual/FC-06-flashcards-generation.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/FC-06-flashcards-generation.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -60,7 +60,7 @@ Eres FC-06, el agente responsable de la generación de flashcards con IA. Gestio
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-keywords.md
+++ b/.claude/agents/flashcards-keywords.md
@@ -35,7 +35,7 @@ Eres FC-05, el agente responsable del sistema de keywords. Gestionas los popups 
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/flashcards.md`
+- `.claude/agent-memory/flashcards.md`
 - Archivos de otros agentes de flashcards (FC-04, FC-06) para entender contratos de datos
 - Archivos del módulo de summaries para entender la integración de highlighting
 - Tipos compartidos y servicios globales
@@ -47,11 +47,11 @@ Eres FC-05, el agente responsable del sistema de keywords. Gestionas los popups 
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
 4. Revisa los componentes de popup y highlighting para entender el estado actual.
 5. Verifica que los tipos de conexión y el sistema de mastery estén consistentes.
-6. Lee `docs/claude-config/agent-memory/individual/FC-05-flashcards-keywords.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/FC-05-flashcards-keywords.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -75,7 +75,7 @@ Eres FC-05, el agente responsable del sistema de keywords. Gestionas los popups 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/flashcards-tester.md
+++ b/.claude/agents/flashcards-tester.md
@@ -39,19 +39,19 @@ Después de tests, correr `npm run build` para verificar TypeScript.
 ## Al iniciar cada sesión
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/flashcards.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/FC-03-flashcards-tester.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/flashcards.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/FC-03-flashcards-tester.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas
 - Tests deben ser determinísticos (no depender de estado externo)
 - Mockear Supabase client cuando sea necesario
 - Testear edge cases (null, empty, invalid input)
-- Registrar errores encontrados en `docs/claude-config/agent-memory/flashcards.md`
+- Registrar errores encontrados en `.claude/agent-memory/flashcards.md`
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/gamification-backend.md
+++ b/.claude/agents/gamification-backend.md
@@ -38,9 +38,9 @@ Puedes leer pero **nunca modificar**:
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/gamification.md` para obtener el estado actual del dominio de gamificacion, decisiones recientes y tareas pendientes. Si el archivo no existe, notifica al usuario y continua sin el.
-4. Lee `docs/claude-config/agent-memory/individual/DG-04-gamification-backend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/gamification.md` para obtener el estado actual del dominio de gamificacion, decisiones recientes y tareas pendientes. Si el archivo no existe, notifica al usuario y continua sin el.
+4. Lee `.claude/agent-memory/individual/DG-04-gamification-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 6. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
 
 ## Reglas de codigo
@@ -99,7 +99,7 @@ Los triggers de XP se disparan desde los modulos correspondientes via `POST /gam
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/gamification-engine.md
+++ b/.claude/agents/gamification-engine.md
@@ -52,11 +52,11 @@ Puedes leer pero **nunca modificar**:
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
+3. Lee `.claude/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
 4. Si el archivo no existe, notifica al usuario y continua sin el.
-5. Lee `docs/claude-config/agent-memory/individual/DG-03-gamification-engine.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/DG-03-gamification-engine.md` (TU memoria personal — lecciones, patrones, métricas)
 6. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 7. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
 
 ## Reglas de codigo
@@ -83,7 +83,7 @@ Puedes leer pero **nunca modificar**:
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/infra-ai.md
+++ b/.claude/agents/infra-ai.md
@@ -52,9 +52,9 @@ Sos IF-03, el agente de infraestructura AI de AXON. Manejás todos los AI provid
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` sección "## AI"
-4. Lee `docs/claude-config/agent-memory/individual/IF-03-infra-ai.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/infra.md` sección "## AI"
+4. Lee `.claude/agent-memory/individual/IF-03-infra-ai.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -84,7 +84,7 @@ Sos IF-03, el agente de infraestructura AI de AXON. Manejás todos los AI provid
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/infra-ci.md
+++ b/.claude/agents/infra-ci.md
@@ -23,7 +23,7 @@ Estos archivos son tu responsabilidad directa. Puedes leerlos, editarlos y crear
 
 Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coordinación explícita con el agente responsable:
 
-- `docs/claude-config/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para obtener contexto actualizado de infraestructura.
+- `.claude/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para obtener contexto actualizado de infraestructura.
 - `package.json` — Para entender dependencias y scripts disponibles.
 - Cualquier archivo fuente `.ts`/`.tsx` — Solo para entender imports o dependencias de build.
 
@@ -34,11 +34,11 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` para sincronizarte con el estado actual de la infraestructura.
-4. Lee `docs/claude-config/agent-memory/individual/IF-05-infra-ci.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/infra.md` para sincronizarte con el estado actual de la infraestructura.
+4. Lee `.claude/agent-memory/individual/IF-05-infra-ci.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Revisa si hay workflows fallidos recientes o cambios pendientes en los archivos de tu zona de ownership.
 6. Confirma la versión de Node, el runtime de Vercel y cualquier variable de entorno relevante documentada.
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -60,7 +60,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/infra-database.md
+++ b/.claude/agents/infra-database.md
@@ -16,7 +16,7 @@ Eres IF-04, el agente responsable de las migraciones de base de datos y la gesti
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/infra.md`
+- `.claude/agent-memory/infra.md`
 - Archivos de servicios API para entender cómo se consumen las tablas
 - Archivos de tipos TypeScript que reflejan el esquema de DB
 - Políticas RLS existentes
@@ -28,11 +28,11 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` para cargar el contexto actual de la infraestructura.
-4. Lee `docs/claude-config/agent-memory/individual/IF-04-infra-database.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/infra.md` para cargar el contexto actual de la infraestructura.
+4. Lee `.claude/agent-memory/individual/IF-04-infra-database.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Revisa las migraciones recientes para entender los últimos cambios al esquema.
 6. Verifica la consistencia entre la documentación del esquema y las migraciones aplicadas.
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -58,7 +58,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/infra-plumbing.md
+++ b/.claude/agents/infra-plumbing.md
@@ -35,9 +35,9 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` sección "## Plumbing"
-4. Lee `docs/claude-config/agent-memory/individual/IF-01-infra-plumbing.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/infra.md` sección "## Plumbing"
+4. Lee `.claude/agent-memory/individual/IF-01-infra-plumbing.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Contexto técnico
 - crud-factory: genera CRUD endpoints para cualquier tabla con scoping por institution
@@ -49,7 +49,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/infra-ui.md
+++ b/.claude/agents/infra-ui.md
@@ -49,9 +49,9 @@ Sos IF-02, el agente de infraestructura UI de AXON. Manejás todo lo compartido 
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` sección "## UI"
-4. Lee `docs/claude-config/agent-memory/individual/IF-02-infra-ui.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/infra.md` sección "## UI"
+4. Lee `.claude/agent-memory/individual/IF-02-infra-ui.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 - TypeScript strict — sin `any`, sin `// @ts-ignore`, sin `console.log`
@@ -78,7 +78,7 @@ Sos IF-02, el agente de infraestructura UI de AXON. Manejás todo lo compartido 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/layout-system.md
+++ b/.claude/agents/layout-system.md
@@ -29,7 +29,7 @@ Estos archivos son tu responsabilidad directa. Puedes leerlos, editarlos y crear
 
 Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coordinación explícita con el agente responsable:
 
-- `docs/claude-config/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para obtener contexto de infraestructura y convenciones globales.
+- `.claude/agent-memory/infra.md` — Lee este archivo al inicio de cada sesión para obtener contexto de infraestructura y convenciones globales.
 - `design-system/*.ts` — Tokens de diseño (colores, tipografía, spacing). Respétalos pero no los edites.
 - `components/design-kit/*.tsx` — Componentes del design kit. Úsalos pero no los modifiques.
 - Archivos de rutas (`routes/` o configuración de React Router) — Para entender la estructura de navegación.
@@ -41,10 +41,10 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/infra.md` para sincronizarte con convenciones globales y estado de la infraestructura.
+3. Lee `.claude/agent-memory/infra.md` para sincronizarte con convenciones globales y estado de la infraestructura.
 4. Identifica qué roles están activos y si hay layouts nuevos pendientes de implementar.
 5. Verifica el estado de los breakpoints responsive y si hay issues reportados de navegación mobile.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -69,7 +69,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/leaderboard.md
+++ b/.claude/agents/leaderboard.md
@@ -34,11 +34,11 @@ Puedes leer pero **nunca modificar**:
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
+3. Lee `.claude/agent-memory/dashboard.md` para obtener el estado actual del proyecto, decisiones recientes y tareas pendientes.
 4. Si el archivo no existe, notifica al usuario y continua sin el.
-5. Lee `docs/claude-config/agent-memory/individual/DG-05-leaderboard.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/DG-05-leaderboard.md` (TU memoria personal — lecciones, patrones, métricas)
 6. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 7. Resume brevemente lo que encontraste antes de comenzar cualquier tarea.
 
 ## Reglas de codigo
@@ -66,7 +66,7 @@ Puedes leer pero **nunca modificar**:
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/messaging-backend.md
+++ b/.claude/agents/messaging-backend.md
@@ -33,10 +33,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/messaging.md`
-4. Lee `docs/claude-config/agent-memory/individual/MG-04-messaging-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/messaging.md`
+4. Lee `.claude/agent-memory/individual/MG-04-messaging-backend.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `lib/messaging/` existe en el backend
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -55,7 +55,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/migration-writer.md
+++ b/.claude/agents/migration-writer.md
@@ -16,7 +16,7 @@ Eres XX-05, el generador de migraciones SQL de Axon. Tu responsabilidad es crear
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 
 ## Depends On
 - **IF-04** (infra-database) — las migraciones se basan en el esquema existente gestionado por IF-04
@@ -25,12 +25,12 @@ Eres XX-05, el generador de migraciones SQL de Axon. Tu responsabilidad es crear
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` para obtener contexto actualizado.
-4. Lee `docs/claude-config/agent-memory/individual/XX-05-migration-writer.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Lee `.claude/agent-memory/cross-cutting.md` para obtener contexto actualizado.
+4. Lee `.claude/agent-memory/individual/XX-05-migration-writer.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Lista las migraciones existentes en `supabase/migrations/` para conocer el estado actual.
 6. Revisa los archivos `database/schema-*.md` para entender el esquema documentado.
 7. Identifica si hay migraciones pendientes o conflictos de orden.
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -59,7 +59,7 @@ Eres XX-05, el generador de migraciones SQL de Axon. Tu responsabilidad es crear
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/notifications.md
+++ b/.claude/agents/notifications.md
@@ -32,10 +32,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/messaging.md`
-4. Lee `docs/claude-config/agent-memory/individual/MG-03-notifications.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/messaging.md`
+4. Lee `.claude/agent-memory/individual/MG-03-notifications.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar el estado actual del sistema de toasts
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -54,7 +54,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/owner-backend.md
+++ b/.claude/agents/owner-backend.md
@@ -24,9 +24,9 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/owner.md` para contexto acumulado del dominio owner
-4. Lee `docs/claude-config/agent-memory/individual/AO-04-owner-backend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/owner.md` para contexto acumulado del dominio owner
+4. Lee `.claude/agent-memory/individual/AO-04-owner-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 6. Resume brevemente lo que encontraste antes de comenzar cualquier tarea
 
 ## Reglas de codigo
@@ -102,7 +102,7 @@ El router owner se monta con `app.use('/api/owner', requireRole('owner'), ownerR
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/owner-frontend.md
+++ b/.claude/agents/owner-frontend.md
@@ -42,9 +42,9 @@ Eres AO-03, el agente frontend del rol owner. Mantenés todas las páginas del o
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/owner.md` (contexto de seccion owner — estado, decisiones, tareas pendientes)
-4. Lee `docs/claude-config/agent-memory/individual/AO-03-owner-frontend.md` (TU memoria personal — lecciones, patrones, metricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/owner.md` (contexto de seccion owner — estado, decisiones, tareas pendientes)
+4. Lee `.claude/agent-memory/individual/AO-03-owner-frontend.md` (TU memoria personal — lecciones, patrones, metricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, sin `any`, sin `console.log`, sin `// @ts-ignore`
@@ -79,7 +79,7 @@ Eres AO-03, el agente frontend del rol owner. Mantenés todas las páginas del o
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quality-gate.md
+++ b/.claude/agents/quality-gate.md
@@ -9,15 +9,15 @@ model: opus
 
 1. Lee el CLAUDE.md del repo que estás auditando
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/individual/XX-02-quality-gate.md` (TU memoria personal — falsos positivos, falsos negativos, métricas)
-4. Lee el `docs/claude-config/agent-memory/<section>.md` de la sección del agente que estás auditando
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/individual/XX-02-quality-gate.md` (TU memoria personal — falsos positivos, falsos negativos, métricas)
+4. Lee el `.claude/agent-memory/<section>.md` de la sección del agente que estás auditando
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Depends On / Produces for
 - **Depende de:** El output de cualquier agente implementador. Se invoca DESPUÉS de que otro agente termina.
 - **Input requerido al ser invocado:** (a) nombre del agente auditado, (b) branch/commit a revisar, (c) contexto de tarea
 - **Produce para:** XX-01 (Arquitecto) — el post-mortem consume los veredictos QG
-- **Escribe en:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (Error Ledger), `XX-02-quality-gate.md` (métricas propias)
+- **Escribe en:** `.claude/agent-memory/individual/AGENT-METRICS.md` (Error Ledger), `XX-02-quality-gate.md` (métricas propias)
 
 ## Rol
 Sos el agente Quality Gate de AXON. Tu trabajo es auditar TODO lo que otros agentes producen INMEDIATAMENTE después de que terminan.
@@ -56,8 +56,8 @@ Sos el agente Quality Gate de AXON. Tu trabajo es auditar TODO lo que otros agen
 - ¿Hay imports rotos?
 
 ### 7. Agent memory update
-- ¿El agente actualizó su archivo de memoria individual (`docs/claude-config/agent-memory/individual/<AGENT-ID>.md`)?
-- Verificar con: `git diff main --name-only | grep docs/claude-config/agent-memory/individual/<AGENT-ID>`
+- ¿El agente actualizó su archivo de memoria individual (`.claude/agent-memory/individual/<AGENT-ID>.md`)?
+- Verificar con: `git diff main --name-only | grep .claude/agent-memory/individual/<AGENT-ID>`
 - **Mínimo obligatorio:** `Last updated:` con fecha de hoy + contador de sesiones incrementado
 - **Lecciones:** Solo verificar que SI el agente descubrió patrones, errores evitados o decisiones técnicas, los haya registrado. NO es obligatorio tener lecciones nuevas en cada sesión — una sesión sin aprendizajes es válida.
 - **Si no hay NINGÚN cambio en el archivo de memoria (ni fecha ni métricas) → NEEDS FIX**
@@ -111,12 +111,12 @@ Cuando tu veredicto es NEEDS FIX o BLOCK, ANTES de reportar al usuario:
    Donde QG_CHECK es uno de: `zone`, `ts`, `spec`, `tests`, `git`, `compat`
 
 2. **Insertar en la memoria individual del agente auditado:**
-   - Abrir `docs/claude-config/agent-memory/individual/<AGENT-ID>.md`
+   - Abrir `.claude/agent-memory/individual/<AGENT-ID>.md`
    - Agregar fila a la tabla "Lecciones aprendidas"
    - Si el error matchea una lección previa del mismo agente → marcar como recurrencia
 
 3. **Insertar en el Error Ledger:**
-   - Abrir `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Sección 4 (Error Ledger)
+   - Abrir `.claude/agent-memory/individual/AGENT-METRICS.md` → Sección 4 (Error Ledger)
    - Agregar fila con: #, Date, Agent, QG Check, Description, Lesson?=YES, Where=<archivo de memoria>, Recurred?
 
 4. **Si el error recurrió (misma categoría QG + mismo agente + lección previa existía):**
@@ -128,8 +128,8 @@ Cuando tu veredicto es NEEDS FIX o BLOCK, ANTES de reportar al usuario:
 ## Revisión y escalación
 
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados QG se registran en:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger (Sección 4) y Agent Detail (Sección 3)
-- **Tus métricas propias:** `docs/claude-config/agent-memory/individual/XX-02-quality-gate.md` → tabla "Métricas de auditoría"
+- **Resultados QG se registran en:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger (Sección 4) y Agent Detail (Sección 3)
+- **Tus métricas propias:** `.claude/agent-memory/individual/XX-02-quality-gate.md` → tabla "Métricas de auditoría"
 - **Cuándo escalar al Arquitecto:**
   - Si un BLOCK afecta a múltiples secciones
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/quiz-adaptive.md
+++ b/.claude/agents/quiz-adaptive.md
@@ -21,7 +21,7 @@ Eres QZ-04, el agente responsable del motor de quizzes adaptativos. Gestionas la
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/quiz.md`
+- `.claude/agent-memory/quiz.md`
 - Archivos de otros agentes de quiz (QZ-05, QZ-06) para entender contratos de datos
 - Servicios compartidos y tipos globales
 
@@ -34,11 +34,11 @@ Eres QZ-04, el agente responsable del motor de quizzes adaptativos. Gestionas la
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/QZ-04-bkt.md` (TU memoria personal — lecciones, decisiones, métricas)
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/QZ-04-bkt.md` (TU memoria personal — lecciones, decisiones, métricas)
 5. Revisa los archivos de tu zona de ownership para entender el estado actual del código
 6. Identifica cualquier cambio reciente en los contratos BKT o la máquina de estados
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -59,7 +59,7 @@ Eres QZ-04, el agente responsable del motor de quizzes adaptativos. Gestionas la
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quiz-analytics.md
+++ b/.claude/agents/quiz-analytics.md
@@ -20,7 +20,7 @@ Eres QZ-06, el agente responsable de las analíticas y reportes del sistema de q
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/quiz.md`
+- `.claude/agent-memory/quiz.md`
 - Archivos de otros agentes de quiz (QZ-04, QZ-05) para entender estructuras de datos
 - Tipos compartidos y servicios globales
 
@@ -32,11 +32,11 @@ Eres QZ-06, el agente responsable de las analíticas y reportes del sistema de q
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
 4. Revisa los paneles de analíticas y hooks para entender las métricas actuales.
 5. Verifica que las visualizaciones estén sincronizadas con los datos disponibles del API.
-6. Lee `docs/claude-config/agent-memory/individual/QZ-06-quiz-analytics.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/QZ-06-quiz-analytics.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -59,7 +59,7 @@ Eres QZ-06, el agente responsable de las analíticas y reportes del sistema de q
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quiz-backend.md
+++ b/.claude/agents/quiz-backend.md
@@ -27,9 +27,9 @@ Sos el agente QZ-02, responsable del backend del modulo Quiz de AXON. Mantenes e
 ## Al iniciar cada sesión
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/QZ-02-quiz-backend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/QZ-02-quiz-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 - TypeScript strict: no `any`, no `// @ts-ignore`, no `console.log` — usar `logger.error({ route, userId, quizId, error })` antes de retornar respuesta de error
@@ -120,7 +120,7 @@ Todos los intentos se persisten en la tabla `quiz_attempts`. Las queries de anal
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quiz-frontend.md
+++ b/.claude/agents/quiz-frontend.md
@@ -32,9 +32,9 @@ Todo fuera de tu zona. Escalar al lead para modificar lógica de otra zona.
 ## Al iniciar cada sesión
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/QZ-01-quiz-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/QZ-01-quiz-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 - TypeScript strict, no `any`, no console.log
@@ -51,7 +51,7 @@ Todo fuera de tu zona. Escalar al lead para modificar lógica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quiz-questions.md
+++ b/.claude/agents/quiz-questions.md
@@ -25,7 +25,7 @@ Eres QZ-05, el agente responsable del CRUD de preguntas y sus renderizadores. Ge
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/quiz.md`
+- `.claude/agent-memory/quiz.md`
 - Archivos de otros agentes de quiz (QZ-04, QZ-06) para entender contratos de datos
 - Tipos compartidos y servicios globales
 
@@ -37,11 +37,11 @@ Eres QZ-05, el agente responsable del CRUD de preguntas y sus renderizadores. Ge
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
 4. Revisa los renderizadores y el formulario de preguntas para entender el estado actual.
 5. Verifica que los tipos de pregunta soportados coincidan con los renderizadores existentes.
-6. Lee `docs/claude-config/agent-memory/individual/QZ-05-quiz-questions.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/QZ-05-quiz-questions.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -64,7 +64,7 @@ Eres QZ-05, el agente responsable del CRUD de preguntas y sus renderizadores. Ge
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/quiz-tester.md
+++ b/.claude/agents/quiz-tester.md
@@ -29,13 +29,13 @@ Después: `npm run build` para verificar TypeScript.
 ## Al iniciar cada sesión (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/quiz.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/QZ-03-quiz-tester.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/quiz.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/QZ-03-quiz-tester.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/rag-chat.md
+++ b/.claude/agents/rag-chat.md
@@ -38,10 +38,10 @@ Eres el agente AI-02 responsable de la interfaz de chat RAG en Axon. Tu dominio 
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/AI-02-rag-chat.md` (TU memoria personal — lecciones, decisiones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/AI-02-rag-chat.md` (TU memoria personal — lecciones, decisiones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → sección Agent Detail y Error Ledger para ver tu historial de QG y no repetir errores previos
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → sección Agent Detail y Error Ledger para ver tu historial de QG y no repetir errores previos
 
 ## Reglas de codigo
 
@@ -50,7 +50,7 @@ Eres el agente AI-02 responsable de la interfaz de chat RAG en Axon. Tu dominio 
 - El contexto multi-turno debe limitar la ventana de historial para no exceder los limites de tokens del modelo.
 - Nunca enviar datos sensibles del usuario en el prompt sin sanitizacion previa.
 - Las respuestas en streaming deben renderizarse de forma incremental, no esperar al mensaje completo.
-- Todo cambio en la logica de chat debe documentarse en `docs/claude-config/agent-memory/ai-rag.md`.
+- Todo cambio en la logica de chat debe documentarse en `.claude/agent-memory/ai-rag.md`.
 - [APRENDIDO BUG-035] El streaming requiere enviar BOTH ?stream=1 (query param) Y body.stream (body field). Enviar solo uno produce fallo silencioso — el backend verifica ambos.
 - [APRENDIDO] Todo output del LLM renderizado en el DOM debe pasar por DOMPurify.sanitize() sin excepción. El modelo puede generar HTML malicioso vía prompt injection.
 
@@ -64,7 +64,7 @@ Eres el agente AI-02 responsable de la interfaz de chat RAG en Axon. Tu dominio 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/rag-pipeline.md
+++ b/.claude/agents/rag-pipeline.md
@@ -34,10 +34,10 @@ Eres el agente AI-01 responsable del pipeline de ingesta RAG en Axon. Tu dominio
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/ai-rag.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/AI-01-rag-pipeline.md` (TU memoria personal — lecciones, decisiones, métricas)
+3. Lee `.claude/agent-memory/ai-rag.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/AI-01-rag-pipeline.md` (TU memoria personal — lecciones, decisiones, métricas)
 5. Revisa los archivos de tu zona de ownership para confirmar el estado actual del codigo
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -45,7 +45,7 @@ Eres el agente AI-01 responsable del pipeline de ingesta RAG en Axon. Tu dominio
 - Los chunks deben respetar limites semanticos (parrafos, secciones) antes que limites de tokens arbitrarios.
 - Nunca almacenar el texto completo del PDF en memoria; procesar en streaming o por paginas.
 - Los embeddings se generan con el modelo `text-embedding-3-large` de OpenAI con dimension 1536.
-- Todo cambio en la logica de chunking debe documentarse en `docs/claude-config/agent-memory/ai-rag.md`.
+- Todo cambio en la logica de chunking debe documentarse en `.claude/agent-memory/ai-rag.md`.
 - Mantener logs estructurados para cada etapa del pipeline: extraccion, chunking, embedding, almacenamiento.
 
 ## Contexto tecnico
@@ -58,7 +58,7 @@ Eres el agente AI-01 responsable del pipeline de ingesta RAG en Axon. Tu dominio
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/refactor-scout.md
+++ b/.claude/agents/refactor-scout.md
@@ -15,7 +15,7 @@ Ninguna — eres un agente de solo lectura que escanea todo el proyecto.
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 - **Todos los archivos del proyecto** — acceso de lectura completo
 
 ## Depends On
@@ -25,12 +25,12 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo que estás escaneando
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` (contexto compartido)
-4. Lee `docs/claude-config/agent-memory/individual/XX-07-refactor-scout.md` (TU memoria personal — deuda conocida, tendencias, archivos >500L)
+3. Lee `.claude/agent-memory/cross-cutting.md` (contexto compartido)
+4. Lee `.claude/agent-memory/individual/XX-07-refactor-scout.md` (TU memoria personal — deuda conocida, tendencias, archivos >500L)
 5. Ejecuta los escaneos definidos en la seccion de reglas
 6. Genera un reporte priorizado de hallazgos (critico, alto, medio, bajo)
 7. Compara con datos de tu memoria individual para identificar tendencias
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -87,7 +87,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
+- **Resultados:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si encontrás un hallazgo crítico que requiere acción inmediata
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/rls-auditor.md
+++ b/.claude/agents/rls-auditor.md
@@ -24,9 +24,9 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 ## Al iniciar cada sesion (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo que estás auditando
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/auth.md` (contexto de auth)
-4. Lee `docs/claude-config/agent-memory/individual/AS-03-rls-auditor.md` (TU memoria personal — tablas auditadas, brechas históricas, patrones validados)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/auth.md` (contexto de auth)
+4. Lee `.claude/agent-memory/individual/AS-03-rls-auditor.md` (TU memoria personal — tablas auditadas, brechas históricas, patrones validados)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -42,7 +42,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
+- **Resultados:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si encontrás un hallazgo crítico que requiere acción inmediata
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -27,13 +27,13 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 ## Al iniciar cada sesion (OBLIGATORIO)
 1. Lee el CLAUDE.md del repo que estás escaneando
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/auth.md` (contexto de auth y security)
-4. Lee `docs/claude-config/agent-memory/individual/AS-04-security-scanner.md` (TU memoria personal — vulnerabilidades conocidas, falsos positivos, patrones seguros)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/auth.md` (contexto de auth y security)
+4. Lee `.claude/agent-memory/individual/AS-04-security-scanner.md` (TU memoria personal — vulnerabilidades conocidas, falsos positivos, patrones seguros)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de escaneo
 - Cada hallazgo DEBE reportarse con: Tipo | Categoría OWASP (A01-A10) | Archivo:línea | Severidad (CRITICAL/HIGH/MEDIUM/LOW) | Remediación sugerida
-- Antes de reportar, verificar tabla "Falsos positivos conocidos" en `docs/claude-config/agent-memory/individual/AS-04-security-scanner.md`
+- Antes de reportar, verificar tabla "Falsos positivos conocidos" en `.claude/agent-memory/individual/AS-04-security-scanner.md`
 - localStorage para tokens: es decisión de arquitectura documentada en auth.md — NO reportar como vulnerabilidad sin escalar al Arquitecto con justificación
 - Supabase ANON_KEY en frontend: es público por diseño — NO reportar como secret expuesto
 - DOMPurify.sanitize() + dangerouslySetInnerHTML: es el patrón seguro aprobado — NO reportar como XSS
@@ -50,7 +50,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
+- **Resultados:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si encontrás un hallazgo crítico que requiere acción inmediata
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/stripe-checkout.md
+++ b/.claude/agents/stripe-checkout.md
@@ -32,10 +32,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/billing.md`
-4. Lee `docs/claude-config/agent-memory/individual/BL-01-stripe-checkout.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/billing.md`
+4. Lee `.claude/agent-memory/individual/BL-01-stripe-checkout.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `lib/stripe.ts` existe en el backend
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -54,7 +54,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/stripe-webhooks.md
+++ b/.claude/agents/stripe-webhooks.md
@@ -31,10 +31,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/billing.md`
-4. Lee `docs/claude-config/agent-memory/individual/BL-02-stripe-webhooks.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/billing.md`
+4. Lee `.claude/agent-memory/individual/BL-02-stripe-webhooks.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `routes/webhooks/stripe*.ts` existe en el backend
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -54,7 +54,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/study-dev.md
+++ b/.claude/agents/study-dev.md
@@ -36,7 +36,7 @@ Sos el agente fullstack de la sección Estudio/Cronograma de AXON. Manejás tant
 - `fsrs-v4.ts` (flashcards) — importas pero no modificás
 - `crud-factory.ts`, `db.ts` (infra-plumbing)
 
-## Al iniciar: leer `docs/claude-config/agent-memory/study.md`
+## Al iniciar: leer `.claude/agent-memory/study.md`
 
 ## Contexto técnico
 - Study Queue: resolver algorítmico que decide qué estudiar next

--- a/.claude/agents/study-hub.md
+++ b/.claude/agents/study-hub.md
@@ -43,12 +43,12 @@ Eres **ST-01 — Study Hub Browsing UI Agent**. Tu responsabilidad es mantener y
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/study.md` para contexto acumulado del dominio de estudio.
+3. Lee `.claude/agent-memory/study.md` para contexto acumulado del dominio de estudio.
 4. Revisa los archivos de tu zona de ownership para entender el estado actual.
 5. Confirma que las interfaces de los hooks de solo lectura no han cambiado.
 6. Identifica TODOs o deuda tecnica pendiente en tus archivos.
-7. Lee `docs/claude-config/agent-memory/individual/ST-01-study-hub.md` (TU memoria personal — lecciones, patrones, métricas)
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/ST-01-study-hub.md` (TU memoria personal — lecciones, patrones, métricas)
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -71,7 +71,7 @@ Eres **ST-01 — Study Hub Browsing UI Agent**. Tu responsabilidad es mantener y
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/study-plans.md
+++ b/.claude/agents/study-plans.md
@@ -57,9 +57,9 @@ Eres **ST-04 — Study Plan Management Agent**. Tu responsabilidad es mantener y
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/study.md` para contexto acumulado del dominio de estudio
-4. Lee `docs/claude-config/agent-memory/individual/ST-04-study-plans.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/study.md` para contexto acumulado del dominio de estudio
+4. Lee `.claude/agent-memory/individual/ST-04-study-plans.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 6. Revisa los archivos de tu zona de ownership, priorizando los mas grandes: `StudyOrganizerWizard.tsx` (~1268L), `StudyPlanDashboard.tsx` (~881L), `useStudyPlans.ts` (~735L)
 7. Verifica que `types/study-plan.ts` este sincronizado con los tipos usados en hooks y componentes
 8. Resume brevemente lo que encontraste antes de comenzar cualquier tarea
@@ -140,7 +140,7 @@ Llama a `POST /api/ai/schedule-suggestion` con `{ courseId, topics, schedule, ta
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/study-progress.md
+++ b/.claude/agents/study-progress.md
@@ -59,11 +59,11 @@ Eres **ST-05 — Progress Tracking + Mastery Display Agent**. Tu responsabilidad
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/study.md` para contexto acumulado del dominio de estudio.
+3. Lee `.claude/agent-memory/study.md` para contexto acumulado del dominio de estudio.
 4. Revisa los archivos de tu zona de ownership, priorizando los servicios de API: `keywordMasteryApi.ts` (~529L), `topicProgressApi.ts` (~270L), `bktApi.ts` (~110L).
 5. Verifica la consistencia entre los hooks de mastery y los contextos que los exponen.
-6. Lee `docs/claude-config/agent-memory/individual/ST-05-study-progress.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/ST-05-study-progress.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -90,7 +90,7 @@ Eres **ST-05 — Progress Tracking + Mastery Display Agent**. Tu responsabilidad
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/study-queue.md
+++ b/.claude/agents/study-queue.md
@@ -41,11 +41,11 @@ Eres **ST-03 — Study Queue + Review Scheduling Agent**. Tu responsabilidad es 
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/study.md` para contexto acumulado del dominio de estudio.
+3. Lee `.claude/agent-memory/study.md` para contexto acumulado del dominio de estudio.
 4. Revisa los archivos de tu zona de ownership para entender el estado actual.
 5. Verifica que la formula NeedScore este correctamente implementada en `useStudyQueueData.ts`.
-6. Lee `docs/claude-config/agent-memory/individual/ST-03-study-queue.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/ST-03-study-queue.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -70,7 +70,7 @@ Eres **ST-03 — Study Queue + Review Scheduling Agent**. Tu responsabilidad es 
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/study-sessions.md
+++ b/.claude/agents/study-sessions.md
@@ -40,11 +40,11 @@ Eres **ST-02 — Study Session Flow + API Agent**. Tu responsabilidad es mantene
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/study.md` para contexto acumulado del dominio de estudio.
+3. Lee `.claude/agent-memory/study.md` para contexto acumulado del dominio de estudio.
 4. Revisa los archivos de tu zona de ownership para entender el estado actual.
 5. Verifica la consistencia entre `studySessionApi.ts` y `sa-activity-sessions.ts`.
-6. Lee `docs/claude-config/agent-memory/individual/ST-02-study-sessions.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/ST-02-study-sessions.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -65,7 +65,7 @@ Eres **ST-02 — Study Session Flow + API Agent**. Tu responsabilidad es mantene
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/summaries-backend-v2.md
+++ b/.claude/agents/summaries-backend-v2.md
@@ -22,7 +22,7 @@ Estos archivos son tu responsabilidad directa. Puedes leerlos, editarlos y crear
 
 Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coordinación explícita con el agente responsable:
 
-- `docs/claude-config/agent-memory/summaries.md` — Lee este archivo al inicio de cada sesión para entender el modelo de datos y estado actual del sistema de resúmenes.
+- `.claude/agent-memory/summaries.md` — Lee este archivo al inicio de cada sesión para entender el modelo de datos y estado actual del sistema de resúmenes.
 - Archivos de migración de base de datos — Para entender el schema actual.
 - `supabase/` — Configuración de Supabase, pero no modificar sin coordinación.
 - Componentes frontend que consumen las APIs — Para entender cómo se usan los endpoints.
@@ -34,11 +34,11 @@ Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coo
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` para sincronizarte con el modelo de datos y estado actual del sistema de resúmenes.
+3. Lee `.claude/agent-memory/summaries.md` para sincronizarte con el modelo de datos y estado actual del sistema de resúmenes.
 4. Revisa las rutas existentes en `routes/summaries*.ts` para tener un mapa mental de los endpoints disponibles.
 5. Verifica si hay endpoints pendientes de implementar o deprecar.
-6. Lee `docs/claude-config/agent-memory/individual/SM-02-summaries-backend.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/SM-02-summaries-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -70,7 +70,7 @@ Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coo
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/summaries-backend.md
+++ b/.claude/agents/summaries-backend.md
@@ -24,7 +24,7 @@ Sos el agente backend de la sección Resúmenes de AXON.
 - `openai-embeddings.ts`, `retrieval-strategies.ts` (infra-ai)
 - `crud-factory.ts` (infra-plumbing)
 
-## Al iniciar: leer `docs/claude-config/agent-memory/summaries.md`
+## Al iniciar: leer `.claude/agent-memory/summaries.md`
 
 ## Contexto técnico
 - Semantic chunking: divide summaries en chunks semánticos para RAG

--- a/.claude/agents/summaries-frontend-v2.md
+++ b/.claude/agents/summaries-frontend-v2.md
@@ -57,7 +57,7 @@ Eres SM-01, el agente responsable del frontend de resúmenes. Gestionas el visor
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/summaries.md`
+- `.claude/agent-memory/summaries.md`
 - Archivos del sistema de keywords (FC-05) para entender la integración de highlighting
 - Archivos del text highlighter (SM-06) para entender anotaciones
 - Tipos compartidos y servicios globales
@@ -69,11 +69,11 @@ Eres SM-01, el agente responsable del frontend de resúmenes. Gestionas el visor
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` para cargar el contexto actual del módulo de resúmenes.
+3. Lee `.claude/agent-memory/summaries.md` para cargar el contexto actual del módulo de resúmenes.
 4. Revisa los componentes principales del reader y el visor para entender el estado actual.
 5. Verifica que la paginación HTML y el tracking de lectura funcionen correctamente.
-6. Lee `docs/claude-config/agent-memory/individual/SM-01-summaries-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/SM-01-summaries-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -99,7 +99,7 @@ Eres SM-01, el agente responsable del frontend de resúmenes. Gestionas el visor
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/summaries-frontend.md
+++ b/.claude/agents/summaries-frontend.md
@@ -26,7 +26,7 @@ Sos el agente frontend de la sección Resúmenes de AXON.
 Todo fuera de tu zona. Escalar al lead para modificar lógica de otra zona.
 
 ## Al iniciar cada sesión
-1. Leer `docs/claude-config/agent-memory/summaries.md`
+1. Leer `.claude/agent-memory/summaries.md`
 
 ## Reglas de código
 - TypeScript strict, no `any`, no console.log

--- a/.claude/agents/summaries-tester.md
+++ b/.claude/agents/summaries-tester.md
@@ -83,13 +83,13 @@ deno test supabase/functions/server/tests/summary_hook_test.ts
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar — si no existe, notificá al usuario y continuá sin él
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento) — si no existe, notificá al usuario
-3. Lee `docs/claude-config/agent-memory/summaries.md` (contexto de sección)
-4. Lee `docs/claude-config/agent-memory/individual/SM-03-summaries-tester.md` (TU memoria personal — lecciones, patrones, métricas)
-5. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+3. Lee `.claude/agent-memory/summaries.md` (contexto de sección)
+4. Lee `.claude/agent-memory/individual/SM-03-summaries-tester.md` (TU memoria personal — lecciones, patrones, métricas)
+5. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/telegram-bot.md
+++ b/.claude/agents/telegram-bot.md
@@ -34,10 +34,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/messaging.md`
-4. Lee `docs/claude-config/agent-memory/individual/MG-01-telegram-bot.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/messaging.md`
+4. Lee `.claude/agent-memory/individual/MG-01-telegram-bot.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `sa-telegram.ts` existe
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -60,7 +60,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/test-orchestrator.md
+++ b/.claude/agents/test-orchestrator.md
@@ -17,7 +17,7 @@ Eres XX-06, el orquestador de tests de Axon. Tu responsabilidad es ejecutar todo
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 - Todo el codigo fuente (para entender fallos, pero sin modificar)
 
 ## Depends On
@@ -27,13 +27,13 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` (contexto compartido)
-4. Lee `docs/claude-config/agent-memory/individual/XX-06-test-orchestrator.md` (TU memoria personal — flaky tests, baselines, módulos problemáticos)
+3. Lee `.claude/agent-memory/cross-cutting.md` (contexto compartido)
+4. Lee `.claude/agent-memory/individual/XX-06-test-orchestrator.md` (TU memoria personal — flaky tests, baselines, módulos problemáticos)
 5. Ejecuta `npm run test` para correr los tests de frontend (Vitest)
 6. Ejecuta `deno test` para correr los tests de backend (Deno)
 7. Genera un reporte con: tests pasados, tests fallidos, tiempo de ejecucion
 8. Para cada fallo, incluye: nombre del test, archivo, linea, mensaje de error, y stack trace relevante
-9. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+9. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -69,7 +69,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** El Arquitecto (XX-01) durante el post-mortem
-- **Resultados:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
+- **Resultados:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Supervisor Metrics (Sección 5)
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si encontrás un hallazgo crítico que requiere acción inmediata
   - Si detectás un patrón de error que se repite en 3+ agentes

--- a/.claude/agents/text-highlighter.md
+++ b/.claude/agents/text-highlighter.md
@@ -19,7 +19,7 @@ Eres SM-06, el agente responsable del sistema de highlighting de texto y anotaci
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/summaries.md`
+- `.claude/agent-memory/summaries.md`
 - Archivos del módulo de summaries (SM-01) para entender la integración con el reader
 - Tipos compartidos y servicios globales
 
@@ -30,11 +30,11 @@ Eres SM-06, el agente responsable del sistema de highlighting de texto y anotaci
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` para cargar el contexto actual del módulo de resúmenes.
+3. Lee `.claude/agent-memory/summaries.md` para cargar el contexto actual del módulo de resúmenes.
 4. Revisa los componentes de highlighting y la toolbar para entender el estado actual.
 5. Verifica que el flujo de selección → toolbar → persistencia funcione correctamente.
-6. Lee `docs/claude-config/agent-memory/individual/SM-06-text-highlighter.md` (TU memoria personal — lecciones, patrones, métricas)
-7. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/SM-06-text-highlighter.md` (TU memoria personal — lecciones, patrones, métricas)
+7. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -58,7 +58,7 @@ Eres SM-06, el agente responsable del sistema de highlighting de texto y anotaci
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/tiptap-editor.md
+++ b/.claude/agents/tiptap-editor.md
@@ -23,7 +23,7 @@ Estos archivos son tu responsabilidad directa. Puedes leerlos, editarlos y crear
 
 Puedes leer estos archivos para obtener contexto, pero NO los modifiques sin coordinación explícita con el agente responsable:
 
-- `docs/claude-config/agent-memory/summaries.md` — Lee este archivo al inicio de cada sesión para entender el modelo de datos de resúmenes que el editor consume y produce.
+- `.claude/agent-memory/summaries.md` — Lee este archivo al inicio de cada sesión para entender el modelo de datos de resúmenes que el editor consume y produce.
 - Archivos de diseño en `design-system/` y `components/design-kit/` — Para respetar tokens visuales.
 - Rutas de API relacionadas con summaries — Para entender cómo se persiste el contenido.
 
@@ -34,10 +34,10 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` para sincronizarte con el estado actual del sistema de resúmenes.
+3. Lee `.claude/agent-memory/summaries.md` para sincronizarte con el estado actual del sistema de resúmenes.
 4. Verifica que las dependencias `@tiptap/react`, `@tiptap/starter-kit` y extensiones relacionadas estén actualizadas.
 5. Revisa si hay issues abiertos relacionados con el editor o el manejo de imágenes.
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de código
 
@@ -59,7 +59,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/type-guardian.md
+++ b/.claude/agents/type-guardian.md
@@ -22,7 +22,7 @@ Eres XX-04, el guardian del sistema de tipos TypeScript de Axon. Tu responsabili
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
+- `.claude/agent-memory/cross-cutting.md` — contexto compartido entre agentes cross-cutting
 
 ## Depends On
 Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
@@ -31,12 +31,12 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/cross-cutting.md` (contexto compartido)
-4. Lee `docs/claude-config/agent-memory/individual/XX-04-type-guardian.md` (TU memoria personal — duplicaciones, plan de consolidación, progreso)
+3. Lee `.claude/agent-memory/cross-cutting.md` (contexto compartido)
+4. Lee `.claude/agent-memory/individual/XX-04-type-guardian.md` (TU memoria personal — duplicaciones, plan de consolidación, progreso)
 5. Escanea todos los archivos en `types/` para detectar cambios recientes
 6. Verifica el estado actual de las duplicaciones conocidas (ver tu memoria individual)
 7. Reporta cualquier nuevo tipo duplicado o inconsistencia encontrada
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -69,7 +69,7 @@ Ninguna dependencia directa. Puede ejecutarse en cualquier fase.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/video-player.md
+++ b/.claude/agents/video-player.md
@@ -23,7 +23,7 @@ Eres SM-05, el agente del sistema de video de Axon. Tu responsabilidad es manten
 
 ## Zona de solo lectura
 
-- `docs/claude-config/agent-memory/summaries.md` — resumen de estado del proyecto
+- `.claude/agent-memory/summaries.md` — resumen de estado del proyecto
 
 ## Depends On
 - **SM-02** (summaries-backend-v2) — Provee los endpoints API de videos y la infraestructura backend (Mux webhooks, upload URLs, signed tokens) que el reproductor consume
@@ -32,12 +32,12 @@ Eres SM-05, el agente del sistema de video de Axon. Tu responsabilidad es manten
 
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Lee `docs/claude-config/agent-memory/summaries.md` para obtener contexto actualizado.
+3. Lee `.claude/agent-memory/summaries.md` para obtener contexto actualizado.
 4. Revisa el estado actual de `MuxVideoPlayer.tsx` y `VideoPlayer.tsx`.
 5. Verifica que `muxApi.ts` tenga los endpoints correctos.
 6. Comprueba que las queries de React Query esten alineadas con los endpoints del backend.
-7. Lee `docs/claude-config/agent-memory/individual/SM-05-video-player.md` (TU memoria personal — lecciones, patrones, métricas)
-8. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
+7. Lee `.claude/agent-memory/individual/SM-05-video-player.md` (TU memoria personal — lecciones, patrones, métricas)
+8. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` → tu fila en Agent Detail para ver historial QG y no repetir errores
 
 ## Reglas de codigo
 
@@ -72,7 +72,7 @@ Eres SM-05, el agente del sistema de video de Axon. Tu responsabilidad es manten
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/viewer3d-annotations.md
+++ b/.claude/agents/viewer3d-annotations.md
@@ -40,10 +40,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/3d-viewer.md`
-4. Lee `docs/claude-config/agent-memory/individual/3D-04-viewer3d-annotations.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/3d-viewer.md`
+4. Lee `.claude/agent-memory/individual/3D-04-viewer3d-annotations.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que los archivos de PinSystem existen en `src/app/components/viewer3d/`
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -65,7 +65,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/viewer3d-backend.md
+++ b/.claude/agents/viewer3d-backend.md
@@ -32,10 +32,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/3d-viewer.md`
-4. Lee `docs/claude-config/agent-memory/individual/3D-02-viewer3d-backend.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/3d-viewer.md`
+4. Lee `.claude/agent-memory/individual/3D-02-viewer3d-backend.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que las rutas de modelos existen en el backend
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -55,7 +55,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/viewer3d-frontend.md
+++ b/.claude/agents/viewer3d-frontend.md
@@ -34,10 +34,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/3d-viewer.md`
-4. Lee `docs/claude-config/agent-memory/individual/3D-01-viewer3d-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/3d-viewer.md`
+4. Lee `.claude/agent-memory/individual/3D-01-viewer3d-frontend.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `src/app/components/viewer3d/` existe
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -61,7 +61,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/viewer3d-upload.md
+++ b/.claude/agents/viewer3d-upload.md
@@ -34,10 +34,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/3d-viewer.md`
-4. Lee `docs/claude-config/agent-memory/individual/3D-03-viewer3d-upload.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/3d-viewer.md`
+4. Lee `.claude/agent-memory/individual/3D-03-viewer3d-upload.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que `src/app/components/professor/parts-manager/` existe
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (métricas globales y Error Ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -59,7 +59,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/agents/whatsapp-bot.md
+++ b/.claude/agents/whatsapp-bot.md
@@ -32,10 +32,10 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 ## Al iniciar cada sesion
 1. Lee el CLAUDE.md del repo donde vas a trabajar
 2. Lee `memory/feedback_agent_isolation.md` (reglas de aislamiento)
-3. Leer `docs/claude-config/agent-memory/messaging.md`
-4. Lee `docs/claude-config/agent-memory/individual/MG-02-whatsapp-bot.md` (TU memoria personal — lecciones, patrones, métricas)
+3. Leer `.claude/agent-memory/messaging.md`
+4. Lee `.claude/agent-memory/individual/MG-02-whatsapp-bot.md` (TU memoria personal — lecciones, patrones, métricas)
 5. Verificar que las rutas de WhatsApp existen en el backend
-6. Lee `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
+6. Lee `.claude/agent-memory/individual/AGENT-METRICS.md` (metricas globales y error ledger)
 
 ## Reglas de codigo
 - TypeScript strict, no `any`, no console.log
@@ -53,7 +53,7 @@ Todo fuera de tu zona. Escalar al lead para modificar logica de otra zona.
 
 ## Revisión y escalación
 - **Tu trabajo lo revisa:** XX-02 (quality-gate) después de cada sesión
-- **Resultados QG:** `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
+- **Resultados QG:** `.claude/agent-memory/individual/AGENT-METRICS.md` → Error Ledger + Agent Detail
 - **Cuándo escalar al Arquitecto (XX-01):**
   - Si necesitás modificar un archivo fuera de tu zona de ownership
   - Si encontrás un conflicto con el trabajo de otro agente

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,9 @@
       "Bash(grep *)",
       "Read",
       "Write(.claude/agent-memory/**)",
+      "Write(.claude/agent-memory-seed/**)",
       "Edit(.claude/agent-memory/**)",
+      "Edit(.claude/agent-memory-seed/**)",
       "Glob",
       "Grep",
       "Agent"

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist/
 package-lock.json
 .vercel
 .claude/worktrees/
-.claude/agent-memory/
+# .claude/agent-memory/ — tracked in git to preserve agent memory across sessions
 .claude/settings.local.json
 .claude/ralph-loop.local.md
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Test runner: Vitest 3.2.1 + React Testing Library. Run `npm test` (unit tests) o
 | **Lanzar agentes** | `.claude/agents/<nombre>.md` — 74 definiciones con rol, zona, reglas |
 | **Saber qué agente usar** | `.claude/AGENT-REGISTRY.md` — índice maestro con ownership |
 | **Orquestar multi-agente** | `.claude/MULTI-AGENT-PROCEDURE.md` — procedimiento completo |
-| **Ver métricas/salud** | `docs/claude-config/agent-memory/individual/AGENT-METRICS.md` |
+| **Ver métricas/salud** | `.claude/agent-memory/individual/AGENT-METRICS.md` |
 | **Qué agente toca qué archivo** | `.claude/SECTION-MAP.md` — mapa de 624 archivos |
 | **Reglas de aislamiento** | `.claude/memory/feedback_agent_isolation.md` |
 
@@ -265,7 +265,7 @@ Para tareas complejas, AXON tiene un sistema de 74 agentes especializados con me
 **SIEMPRE que se lance un agente (via Agent tool), el prompt DEBE incluir:**
 
 1. `Lee tu definicion en .claude/agents/<nombre>.md` — el archivo de 76 que define su rol, zona de ownership, archivos permitidos, reglas y dependencias.
-2. `Lee tu memoria en docs/claude-config/agent-memory/individual/<ID>.md` — lecciones aprendidas, patrones que funcionan, errores a evitar.
+2. `Lee tu memoria en .claude/agent-memory/individual/<ID>.md` — lecciones aprendidas, patrones que funcionan, errores a evitar.
 
 **Esto NO es opcional.** Los archivos `.claude/agents/*.md` son la fuente de verdad de lo que cada agente sabe y puede hacer. Sin leerlos, el agente opera a ciegas y puede:
 - Tocar archivos fuera de su zona de ownership (scope creep)
@@ -276,7 +276,7 @@ Para tareas complejas, AXON tiene un sistema de 74 agentes especializados con me
 **Formato obligatorio al invocar un agente:**
 ```
 Actua como [agente] ([ID]). Lee tu definicion en .claude/agents/<nombre>.md
-y tu memoria en docs/claude-config/agent-memory/individual/<ID>-<nombre>.md.
+y tu memoria en .claude/agent-memory/individual/<ID>-<nombre>.md.
 [Tarea concreta con archivos especificos].
 ```
 
@@ -293,7 +293,7 @@ El Arquitecto lee el AGENT-REGISTRY, selecciona agentes, resuelve dependencias, 
 |---------|--------|---------------|
 | `.claude/AGENT-REGISTRY.md` | Indice de 74 agentes con ownership y dependencias | Para saber que agente usar |
 | `.claude/agents/<nombre>.md` | Definicion de cada agente (rol, zona, reglas) | **SIEMPRE** al actuar como un agente |
-| `docs/claude-config/agent-memory/individual/<ID>.md` | Memoria personal del agente (lecciones, patrones, metricas) | **SIEMPRE** al iniciar como un agente |
+| `.claude/agent-memory/individual/<ID>.md` | Memoria personal del agente (lecciones, patrones, metricas) | **SIEMPRE** al iniciar como un agente |
 | `.claude/memory/feedback_agent_isolation.md` | Reglas de aislamiento + evolucion continua | SIEMPRE antes de escribir codigo |
 | `.claude/MULTI-AGENT-PROCEDURE.md` | Procedimiento completo del sistema | Para orquestacion multi-agente |
 | `.claude/SECTION-MAP.md` | Mapa de 624 archivos asignados a agentes | Para identificar que agente toca que |


### PR DESCRIPTION
## Summary

- **Restore 160 agent memory files** (7,836 lines) deleted by commit `2a25fde` on March 30, which claimed an ADR-001 migration to `docs/claude-config/agent-memory/` — a path that was never created
- **Fix 332 broken path references** across 77 files (76 agent definitions + CLAUDE.md) pointing to the phantom `docs/claude-config/` location, reverting them to `.claude/agent-memory/`
- **Remove `.claude/agent-memory/` from `.gitignore`** so memory persists across sessions
- **Add Write/Edit permissions** for `.claude/agent-memory-seed/**` in settings.json to stop agents from interrupting users with auth prompts when writing their own memory

## Root cause

Two commits on March 30 executed an incomplete migration:
1. `f527285` — changed all path references to `docs/claude-config/agent-memory/`
2. `2a25fde` — deleted all files at the original location

The destination was **never created**, destroying the entire agent memory system.

## Test plan

- [ ] Verify `ls .claude/agent-memory/individual/ | wc -l` returns 67+ files
- [ ] Verify `ls .claude/agent-memory-seed/individual/ | wc -l` returns 64+ files
- [ ] Verify `grep -r 'docs/claude-config/agent-memory' .claude/agents/` returns zero matches
- [ ] Launch any agent and confirm it can read its memory without errors
- [ ] Confirm agents can write to their memory without asking for permission

https://claude.ai/code/session_011X9597QaRBiTWba89d7NjN