### PR TITLE
feat(sticky-notes): floating RAM-memory notepad on student summaries

### DIFF
--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
 import { SidebarOutline } from '@/app/components/student/SidebarOutline';
+import { StickyNotesPanel } from '@/app/components/summary/StickyNotesPanel';
 import { MasteryLegend } from '@/app/components/student/MasteryLegend';
 import { SearchBar } from '@/app/components/student/SearchBar';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/tabs';
@@ -391,6 +392,7 @@ export function StudentSummaryReader({
   };
 
   return (
+    <>
     <motion.div
       ref={readerRef}
       initial={{ opacity: 0, x: 10 }}
@@ -756,5 +758,10 @@ export function StudentSummaryReader({
         </div>{/* end flex-1 content wrapper */}
       </div>{/* end flex layout */}
     </motion.div>
+    <StickyNotesPanel
+      summaryId={summary.id}
+      contextLabel={summary.title || topicName}
+    />
+    </>
   );
 }

--- a/src/app/components/content/SummaryView.tsx
+++ b/src/app/components/content/SummaryView.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/app/context/AuthContext';
 import { useContentTree } from '@/app/context/ContentTreeContext';
 import { SummaryHeader } from '@/app/components/summary/SummaryHeader';
 import { ChunkRenderer } from '@/app/components/summary/ChunkRenderer';
+import { StickyNotesPanel } from '@/app/components/summary/StickyNotesPanel';
 import { KeywordsManager } from '@/app/components/professor/KeywordsManager';
 import { VideosManager } from '@/app/components/professor/VideosManager';
 import { QuickKeywordCreator } from '@/app/components/professor/QuickKeywordCreator';
@@ -328,28 +329,38 @@ export function SummaryView() {
   // ── Student path — always uses unified StudentSummaryReader ──
   if (!isProfessor && selectedSummary) {
     return (
-      <StudentSummaryReader
-        summary={selectedSummary}
-        topicName={breadcrumb.topicName}
-        readingState={readingState}
-        onBack={handleBack}
-        onReadingStateChanged={(rs) => {
-          queryClient.setQueryData(
-            queryKeys.readingState(selectedSummary.id),
-            rs,
-          );
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.topicProgress(selectedSummary.topic_id),
-          });
-        }}
-        onNavigateKeyword={handleNavigateKeyword}
-      />
+      <>
+        <StudentSummaryReader
+          summary={selectedSummary}
+          topicName={breadcrumb.topicName}
+          readingState={readingState}
+          onBack={handleBack}
+          onReadingStateChanged={(rs) => {
+            queryClient.setQueryData(
+              queryKeys.readingState(selectedSummary.id),
+              rs,
+            );
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.topicProgress(selectedSummary.topic_id),
+            });
+          }}
+          onNavigateKeyword={handleNavigateKeyword}
+        />
+        <StickyNotesPanel
+          summaryId={selectedSummary.id}
+          contextLabel={selectedSummary.title || breadcrumb.topicName}
+        />
+      </>
     );
   }
 
   // ── Professor path ──────────────────────────────────────
   return (
     <div className="flex flex-col h-full">
+      <StickyNotesPanel
+        summaryId={selectedSummaryId}
+        contextLabel={selectedSummary?.title || breadcrumb.topicName}
+      />
       {/* Header */}
       {selectedSummary && (
         <div className="px-6 pt-6">

--- a/src/app/components/content/SummaryView.tsx
+++ b/src/app/components/content/SummaryView.tsx
@@ -32,7 +32,6 @@ import { useAuth } from '@/app/context/AuthContext';
 import { useContentTree } from '@/app/context/ContentTreeContext';
 import { SummaryHeader } from '@/app/components/summary/SummaryHeader';
 import { ChunkRenderer } from '@/app/components/summary/ChunkRenderer';
-import { StickyNotesPanel } from '@/app/components/summary/StickyNotesPanel';
 import { KeywordsManager } from '@/app/components/professor/KeywordsManager';
 import { VideosManager } from '@/app/components/professor/VideosManager';
 import { QuickKeywordCreator } from '@/app/components/professor/QuickKeywordCreator';
@@ -329,38 +328,28 @@ export function SummaryView() {
   // ── Student path — always uses unified StudentSummaryReader ──
   if (!isProfessor && selectedSummary) {
     return (
-      <>
-        <StudentSummaryReader
-          summary={selectedSummary}
-          topicName={breadcrumb.topicName}
-          readingState={readingState}
-          onBack={handleBack}
-          onReadingStateChanged={(rs) => {
-            queryClient.setQueryData(
-              queryKeys.readingState(selectedSummary.id),
-              rs,
-            );
-            queryClient.invalidateQueries({
-              queryKey: queryKeys.topicProgress(selectedSummary.topic_id),
-            });
-          }}
-          onNavigateKeyword={handleNavigateKeyword}
-        />
-        <StickyNotesPanel
-          summaryId={selectedSummary.id}
-          contextLabel={selectedSummary.title || breadcrumb.topicName}
-        />
-      </>
+      <StudentSummaryReader
+        summary={selectedSummary}
+        topicName={breadcrumb.topicName}
+        readingState={readingState}
+        onBack={handleBack}
+        onReadingStateChanged={(rs) => {
+          queryClient.setQueryData(
+            queryKeys.readingState(selectedSummary.id),
+            rs,
+          );
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.topicProgress(selectedSummary.topic_id),
+          });
+        }}
+        onNavigateKeyword={handleNavigateKeyword}
+      />
     );
   }
 
   // ── Professor path ──────────────────────────────────────
   return (
     <div className="flex flex-col h-full">
-      <StickyNotesPanel
-        summaryId={selectedSummaryId}
-        contextLabel={selectedSummary?.title || breadcrumb.topicName}
-      />
       {/* Header */}
       {selectedSummary && (
         <div className="px-6 pt-6">

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -1,0 +1,234 @@
+// ============================================================
+// Axon — StickyNotesPanel
+//
+// A floating, persistent "RAM-memory" notes panel that follows
+// the user as they scroll through a summary. Acts like a sticky
+// notepad: continuous text area, autosaved to localStorage,
+// keyed by summaryId so each summary keeps its own scratchpad.
+//
+// Design intent (per Stitch / shadcn-ui guidance):
+//   - Pinned to the right side of the viewport (position: fixed)
+//   - Collapsible to a small icon when not in use
+//   - Yellow paper aesthetic so it reads as a "sticky note"
+//   - Uses existing shadcn/ui primitives where possible
+// ============================================================
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { StickyNote, X, Save, Trash2, Maximize2, Minimize2 } from 'lucide-react';
+import { Button } from '@/app/components/ui/button';
+
+interface StickyNotesPanelProps {
+  /** Identifier used to scope notes per summary. */
+  summaryId: string | null | undefined;
+  /** Optional label shown in the header. */
+  contextLabel?: string;
+}
+
+const STORAGE_PREFIX = 'axon:sticky-notes:';
+
+function readNote(summaryId: string): string {
+  try {
+    return localStorage.getItem(STORAGE_PREFIX + summaryId) || '';
+  } catch {
+    return '';
+  }
+}
+
+function writeNote(summaryId: string, value: string) {
+  try {
+    if (value) {
+      localStorage.setItem(STORAGE_PREFIX + summaryId, value);
+    } else {
+      localStorage.removeItem(STORAGE_PREFIX + summaryId);
+    }
+  } catch {
+    /* localStorage not available */
+  }
+}
+
+export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelProps) {
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('axon:sticky-notes:open') !== '0';
+    } catch {
+      return true;
+    }
+  });
+  const [expanded, setExpanded] = useState(false);
+  const [value, setValue] = useState('');
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const debounceRef = useRef<number | null>(null);
+
+  // Load note when summary changes
+  useEffect(() => {
+    if (!summaryId) {
+      setValue('');
+      return;
+    }
+    setValue(readNote(summaryId));
+  }, [summaryId]);
+
+  // Persist open/closed state
+  useEffect(() => {
+    try {
+      localStorage.setItem('axon:sticky-notes:open', open ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, [open]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const next = e.target.value;
+      setValue(next);
+      if (!summaryId) return;
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+      debounceRef.current = window.setTimeout(() => {
+        writeNote(summaryId, next);
+        setSavedAt(Date.now());
+      }, 400);
+    },
+    [summaryId],
+  );
+
+  const handleClear = useCallback(() => {
+    if (!summaryId) return;
+    if (!value) return;
+    if (!window.confirm('¿Borrar todas las notas de este resumen?')) return;
+    setValue('');
+    writeNote(summaryId, '');
+    setSavedAt(Date.now());
+  }, [summaryId, value]);
+
+  // Don't render anything if there's no summary context yet
+  if (!summaryId) return null;
+
+  return (
+    <div
+      className="fixed right-4 z-40 print:hidden"
+      style={{ top: '6rem' }}
+      aria-label="Notas rápidas"
+    >
+      <AnimatePresence mode="wait">
+        {open ? (
+          <motion.div
+            key="panel"
+            initial={{ opacity: 0, x: 24 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 24 }}
+            transition={{ duration: 0.18 }}
+            className="flex flex-col rounded-2xl border border-amber-200 bg-amber-50 shadow-lg"
+            style={{
+              width: expanded ? 420 : 280,
+              maxHeight: 'calc(100vh - 8rem)',
+              backgroundImage:
+                'repeating-linear-gradient(180deg, transparent 0, transparent 27px, rgba(180, 130, 30, 0.08) 28px)',
+            }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-3 py-2 border-b border-amber-200/70">
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="p-1.5 rounded-lg bg-amber-200/60">
+                  <StickyNote size={14} className="text-amber-700" />
+                </div>
+                <div className="min-w-0">
+                  <p
+                    className="text-xs text-amber-900 truncate"
+                    style={{ fontFamily: 'Georgia, serif' }}
+                  >
+                    Notas rápidas
+                  </p>
+                  {contextLabel && (
+                    <p className="text-[10px] text-amber-700/70 truncate">
+                      {contextLabel}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-amber-700 hover:bg-amber-200/60"
+                  onClick={() => setExpanded((v) => !v)}
+                  aria-label={expanded ? 'Contraer' : 'Expandir'}
+                  title={expanded ? 'Contraer' : 'Expandir'}
+                >
+                  {expanded ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-amber-700 hover:bg-amber-200/60"
+                  onClick={() => setOpen(false)}
+                  aria-label="Cerrar notas"
+                  title="Cerrar"
+                >
+                  <X size={12} />
+                </Button>
+              </div>
+            </div>
+
+            {/* Textarea */}
+            <textarea
+              value={value}
+              onChange={handleChange}
+              placeholder="Tu memoria RAM... escribe lo que necesites recordar mientras lees."
+              className="flex-1 resize-none bg-transparent px-4 py-3 text-sm text-amber-950 placeholder:text-amber-700/40 focus:outline-none"
+              style={{
+                fontFamily: 'Georgia, serif',
+                lineHeight: '28px',
+                minHeight: 220,
+              }}
+              spellCheck
+            />
+
+            {/* Footer */}
+            <div className="flex items-center justify-between px-3 py-2 border-t border-amber-200/70 text-[10px] text-amber-700/80">
+              <div className="flex items-center gap-1">
+                <Save size={10} />
+                <span>
+                  {savedAt
+                    ? `Guardado ${new Date(savedAt).toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}`
+                    : 'Autoguardado'}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleClear}
+                disabled={!value}
+                className="flex items-center gap-1 text-amber-700/80 hover:text-red-600 disabled:opacity-30 disabled:hover:text-amber-700/80"
+              >
+                <Trash2 size={10} />
+                Limpiar
+              </button>
+            </div>
+          </motion.div>
+        ) : (
+          <motion.button
+            key="fab"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            onClick={() => setOpen(true)}
+            className="relative flex h-12 w-12 items-center justify-center rounded-full border border-amber-200 bg-amber-50 text-amber-700 shadow-lg hover:bg-amber-100"
+            aria-label="Abrir notas rápidas"
+            title="Abrir notas rápidas"
+          >
+            <StickyNote size={18} />
+            {value && (
+              <span className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-amber-50" />
+            )}
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default StickyNotesPanel;

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -14,6 +14,7 @@
 //   - Uses existing shadcn/ui primitives where possible
 // ============================================================
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { StickyNote, X, Save, Trash2, Maximize2, Minimize2, CloudOff, Cloud } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
@@ -153,11 +154,16 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
 
   // Don't render anything if there's no summary context yet
   if (!summaryId) return null;
+  // SSR / non-browser: bail
+  if (typeof document === 'undefined') return null;
 
-  return (
+  // Render into a portal at document.body so we escape any ancestor
+  // stacking context (transformed motion.div, layout headers with z-index,
+  // overflow:hidden containers, etc.) and stay on top of the app header.
+  return createPortal(
     <div
-      className="fixed right-4 z-40 print:hidden"
-      style={{ top: '6rem' }}
+      className="fixed right-4 print:hidden"
+      style={{ top: '7.5rem', zIndex: 1000 }}
       aria-label="Notas rápidas"
     >
       <AnimatePresence mode="wait">
@@ -298,7 +304,8 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
           </motion.button>
         )}
       </AnimatePresence>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -3,8 +3,9 @@
 //
 // A floating, persistent "RAM-memory" notes panel that follows
 // the user as they scroll through a summary. Acts like a sticky
-// notepad: continuous text area, autosaved to localStorage,
-// keyed by summaryId so each summary keeps its own scratchpad.
+// notepad: continuous text area, autosaved to the backend
+// (table public.sticky_notes via /sticky-notes endpoint) and
+// mirrored to localStorage for instant reads + offline fallback.
 //
 // Design intent (per Stitch / shadcn-ui guidance):
 //   - Pinned to the right side of the viewport (position: fixed)
@@ -14,8 +15,13 @@
 // ============================================================
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { StickyNote, X, Save, Trash2, Maximize2, Minimize2 } from 'lucide-react';
+import { StickyNote, X, Save, Trash2, Maximize2, Minimize2, CloudOff, Cloud } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
+import {
+  getStickyNote,
+  upsertStickyNote,
+  deleteStickyNote,
+} from '@/app/services/stickyNotesApi';
 
 interface StickyNotesPanelProps {
   /** Identifier used to scope notes per summary. */
@@ -26,7 +32,9 @@ interface StickyNotesPanelProps {
 
 const STORAGE_PREFIX = 'axon:sticky-notes:';
 
-function readNote(summaryId: string): string {
+type SyncStatus = 'idle' | 'saving' | 'saved' | 'offline';
+
+function readLocalNote(summaryId: string): string {
   try {
     return localStorage.getItem(STORAGE_PREFIX + summaryId) || '';
   } catch {
@@ -34,7 +42,7 @@ function readNote(summaryId: string): string {
   }
 }
 
-function writeNote(summaryId: string, value: string) {
+function writeLocalNote(summaryId: string, value: string) {
   try {
     if (value) {
       localStorage.setItem(STORAGE_PREFIX + summaryId, value);
@@ -57,15 +65,36 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   const [expanded, setExpanded] = useState(false);
   const [value, setValue] = useState('');
   const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
   const debounceRef = useRef<number | null>(null);
+  // Tracks the summaryId for which the latest async load is valid (race-safety)
+  const loadTokenRef = useRef<string | null>(null);
 
-  // Load note when summary changes
+  // Load note when summary changes — local first (instant), then backend (truth).
   useEffect(() => {
     if (!summaryId) {
       setValue('');
       return;
     }
-    setValue(readNote(summaryId));
+    // Optimistic: show cached value immediately
+    setValue(readLocalNote(summaryId));
+    setSyncStatus('idle');
+    loadTokenRef.current = summaryId;
+
+    (async () => {
+      try {
+        const remote = await getStickyNote(summaryId);
+        // Bail if the user switched summaries while we were fetching
+        if (loadTokenRef.current !== summaryId) return;
+        const remoteContent = remote?.content ?? '';
+        setValue(remoteContent);
+        writeLocalNote(summaryId, remoteContent);
+      } catch {
+        // Network/auth error → keep the localStorage value as fallback
+        if (loadTokenRef.current !== summaryId) return;
+        setSyncStatus('offline');
+      }
+    })();
   }, [summaryId]);
 
   // Persist open/closed state
@@ -82,23 +111,45 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
       const next = e.target.value;
       setValue(next);
       if (!summaryId) return;
+      // Local mirror is synchronous → never lose typing
+      writeLocalNote(summaryId, next);
+      setSyncStatus('saving');
       if (debounceRef.current) window.clearTimeout(debounceRef.current);
-      debounceRef.current = window.setTimeout(() => {
-        writeNote(summaryId, next);
-        setSavedAt(Date.now());
-      }, 400);
+      debounceRef.current = window.setTimeout(async () => {
+        try {
+          await upsertStickyNote({ summary_id: summaryId, content: next });
+          setSyncStatus('saved');
+          setSavedAt(Date.now());
+        } catch {
+          setSyncStatus('offline');
+        }
+      }, 600);
     },
     [summaryId],
   );
 
-  const handleClear = useCallback(() => {
+  const handleClear = useCallback(async () => {
     if (!summaryId) return;
     if (!value) return;
     if (!window.confirm('¿Borrar todas las notas de este resumen?')) return;
     setValue('');
-    writeNote(summaryId, '');
-    setSavedAt(Date.now());
+    writeLocalNote(summaryId, '');
+    setSyncStatus('saving');
+    try {
+      await deleteStickyNote(summaryId);
+      setSyncStatus('saved');
+      setSavedAt(Date.now());
+    } catch {
+      setSyncStatus('offline');
+    }
   }, [summaryId, value]);
+
+  // Flush pending debounced save on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   // Don't render anything if there's no summary context yet
   if (!summaryId) return null;
@@ -186,15 +237,35 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
             {/* Footer */}
             <div className="flex items-center justify-between px-3 py-2 border-t border-amber-200/70 text-[10px] text-amber-700/80">
               <div className="flex items-center gap-1">
-                <Save size={10} />
-                <span>
-                  {savedAt
-                    ? `Guardado ${new Date(savedAt).toLocaleTimeString([], {
+                {syncStatus === 'offline' ? (
+                  <>
+                    <CloudOff size={10} className="text-amber-700/60" />
+                    <span title="Guardado localmente — sin conexión al servidor">
+                      Solo local
+                    </span>
+                  </>
+                ) : syncStatus === 'saving' ? (
+                  <>
+                    <Save size={10} />
+                    <span>Guardando...</span>
+                  </>
+                ) : savedAt ? (
+                  <>
+                    <Cloud size={10} />
+                    <span>
+                      Guardado{' '}
+                      {new Date(savedAt).toLocaleTimeString([], {
                         hour: '2-digit',
                         minute: '2-digit',
-                      })}`
-                    : 'Autoguardado'}
-                </span>
+                      })}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <Save size={10} />
+                    <span>Autoguardado en la nube</span>
+                  </>
+                )}
               </div>
               <button
                 type="button"

--- a/src/app/services/stickyNotesApi.ts
+++ b/src/app/services/stickyNotesApi.ts
@@ -1,0 +1,52 @@
+// ============================================================
+// Axon — Sticky Notes API Service
+//
+// Per-student "RAM-memory" scratchpad, one note per summary.
+// Backed by table public.sticky_notes (RLS-protected by student_id).
+//
+// Endpoints (mounted under /server in Edge Functions):
+//   GET    /sticky-notes?summary_id=xxx
+//   POST   /sticky-notes        body: { summary_id, content }
+//   DELETE /sticky-notes?summary_id=xxx
+// ============================================================
+
+import { apiCall } from '@/app/lib/api';
+import { getErrorMessage, hasHttpStatus } from '@/app/utils/getErrorMessage';
+
+export interface StickyNote {
+  id: string;
+  student_id: string;
+  summary_id: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getStickyNote(summaryId: string): Promise<StickyNote | null> {
+  try {
+    const result = await apiCall<StickyNote | null>(
+      `/sticky-notes?summary_id=${encodeURIComponent(summaryId)}`,
+    );
+    return result ?? null;
+  } catch (e: unknown) {
+    if (getErrorMessage(e).includes('404') || hasHttpStatus(e, 404)) return null;
+    throw e;
+  }
+}
+
+export async function upsertStickyNote(data: {
+  summary_id: string;
+  content: string;
+}): Promise<StickyNote> {
+  return apiCall<StickyNote>('/sticky-notes', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteStickyNote(summaryId: string): Promise<{ deleted: boolean }> {
+  return apiCall<{ deleted: boolean }>(
+    `/sticky-notes?summary_id=${encodeURIComponent(summaryId)}`,
+    { method: 'DELETE' },
+  );
+}


### PR DESCRIPTION
## Summary

Floating "RAM-memory" notepad pinned to the right side of the student summary reader, with backend persistence (table `public.sticky_notes`, already live in production) and a localStorage mirror for instant reads + offline fallback.

## What you get
- Yellow sticky-note panel that follows the student as they scroll any summary.
- Continuous textarea, autosaved to backend with debounce (600 ms).
- Status indicator: **Guardando...** → **Guardado HH:MM** (Cloud icon) or **Solo local** (CloudOff) when offline.
- Collapsible to a small FAB; expandable from 280px to 420px width.
- One scratchpad per `(student, summary)` pair. Each summary has its own.
- Clear button with confirm.

## Files
- **NEW** `src/app/components/summary/StickyNotesPanel.tsx` — the panel itself, rendered via React Portal to `document.body` so it escapes any ancestor stacking context (the `StudentSummaryReader` root motion.div has a transform).
- **NEW** `src/app/services/stickyNotesApi.ts` — `getStickyNote / upsertStickyNote / deleteStickyNote` against `/sticky-notes`.
- **MODIFIED** `src/app/components/content/StudentSummaryReader.tsx` — mounts the panel as a sibling of the root motion.div via fragment, passing `summary.id` and `summary.title || topicName`.

## Backend dependency
The `/sticky-notes` endpoints + `sticky_notes` table from matraca130/axon-backend#205 are **already merged and live** (table applied via Supabase MCP, Edge Function redeployed by `deploy.yml`). No coordination needed.

## Test plan
- [x] `npx tsc --noEmit` → no errors from new files.
- [ ] Log in as student, open any published summary. Yellow panel pinned at top-right.
- [ ] Type something → footer flips to "Guardando..." then "Guardado HH:MM" with Cloud icon within ~600ms.
- [ ] Scroll the summary → panel stays anchored to viewport, never clipped by the green app header.
- [ ] Reload → text is restored.
- [ ] Open a different summary → independent scratchpad appears.
- [ ] Open DevTools → check `sticky_notes` row exists in Supabase table editor with the typed content.
- [ ] Disconnect network → footer shows "Solo local" with CloudOff icon, typing still works.