### PR TITLE
feat(sticky-notes): 4-slice quick notes with renaming

### DIFF
--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -3,20 +3,36 @@
 //
 // A floating, persistent "RAM-memory" notes panel that follows
 // the user as they scroll through a summary. Acts like a sticky
-// notepad: continuous text area, autosaved to the backend
-// (table public.sticky_notes via /sticky-notes endpoint) and
-// mirrored to localStorage for instant reads + offline fallback.
+// notepad divided into 4 independent "slices" (slots), each one
+// its own note. Opens on a 2x2 picker grid; clicking a slot
+// enters the editor for that slot. Back / prev / next navigation
+// is supported and the last-opened slot is persisted per summary.
 //
-// Design intent (per Stitch / shadcn-ui guidance):
-//   - Pinned to the right side of the viewport (position: fixed)
-//   - Collapsible to a small icon when not in use
-//   - Yellow paper aesthetic so it reads as a "sticky note"
-//   - Uses existing shadcn/ui primitives where possible
+// Storage:
+//   - Backend `content` field stores a JSON-serialized
+//     4-string array. Plain-text legacy notes are migrated into
+//     slot 0 on first load.
+//   - localStorage mirrors the same JSON for instant reads and
+//     offline fallback.
+//   - The last-opened slot is persisted per summary under
+//     `axon:sticky-notes:active:<summaryId>`.
 // ============================================================
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { StickyNote, X, Save, Trash2, Maximize2, Minimize2, CloudOff, Cloud } from 'lucide-react';
+import {
+  StickyNote,
+  X,
+  Save,
+  Trash2,
+  Maximize2,
+  Minimize2,
+  CloudOff,
+  Cloud,
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import {
   getStickyNote,
@@ -32,26 +48,89 @@ interface StickyNotesPanelProps {
 }
 
 const STORAGE_PREFIX = 'axon:sticky-notes:';
+const ACTIVE_SLOT_PREFIX = 'axon:sticky-notes:active:';
+const SLOT_COUNT = 4;
+const SLOT_LABELS = ['Nota 1', 'Nota 2', 'Nota 3', 'Nota 4'];
 
+type Slots = [string, string, string, string];
 type SyncStatus = 'idle' | 'saving' | 'saved' | 'offline';
 
-function readLocalNote(summaryId: string): string {
+function emptySlots(): Slots {
+  return ['', '', '', ''];
+}
+
+/**
+ * Parse a persisted content string into a 4-slot tuple.
+ * Back-compat: plain-text legacy notes are placed into slot 0.
+ */
+function parseSlots(raw: string | null | undefined): Slots {
+  if (!raw) return emptySlots();
   try {
-    return localStorage.getItem(STORAGE_PREFIX + summaryId) || '';
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const out = emptySlots();
+      for (let i = 0; i < SLOT_COUNT; i++) {
+        out[i] = typeof parsed[i] === 'string' ? parsed[i] : '';
+      }
+      return out;
+    }
   } catch {
-    return '';
+    /* legacy plain text */
+  }
+  const out = emptySlots();
+  out[0] = String(raw);
+  return out;
+}
+
+function serializeSlots(slots: Slots): string {
+  // If every slot is empty we persist an empty string so the
+  // clear/delete semantics keep working with the backend.
+  if (slots.every((s) => !s)) return '';
+  return JSON.stringify(slots);
+}
+
+function readLocalSlots(summaryId: string): Slots {
+  try {
+    return parseSlots(localStorage.getItem(STORAGE_PREFIX + summaryId));
+  } catch {
+    return emptySlots();
   }
 }
 
-function writeLocalNote(summaryId: string, value: string) {
+function writeLocalSlots(summaryId: string, slots: Slots) {
   try {
-    if (value) {
-      localStorage.setItem(STORAGE_PREFIX + summaryId, value);
+    const serialized = serializeSlots(slots);
+    if (serialized) {
+      localStorage.setItem(STORAGE_PREFIX + summaryId, serialized);
     } else {
       localStorage.removeItem(STORAGE_PREFIX + summaryId);
     }
   } catch {
     /* localStorage not available */
+  }
+}
+
+function readActiveSlot(summaryId: string): number | null {
+  try {
+    const raw = localStorage.getItem(ACTIVE_SLOT_PREFIX + summaryId);
+    if (raw === null) return null;
+    const n = Number(raw);
+    if (Number.isInteger(n) && n >= 0 && n < SLOT_COUNT) return n;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeActiveSlot(summaryId: string, slot: number | null) {
+  try {
+    if (slot === null) {
+      localStorage.removeItem(ACTIVE_SLOT_PREFIX + summaryId);
+    } else {
+      localStorage.setItem(ACTIVE_SLOT_PREFIX + summaryId, String(slot));
+    }
+  } catch {
+    /* ignore */
   }
 }
 
@@ -64,21 +143,24 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     }
   });
   const [expanded, setExpanded] = useState(false);
-  const [value, setValue] = useState('');
+  const [slots, setSlots] = useState<Slots>(emptySlots);
+  const [activeSlot, setActiveSlot] = useState<number | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
   const debounceRef = useRef<number | null>(null);
   // Tracks the summaryId for which the latest async load is valid (race-safety)
   const loadTokenRef = useRef<string | null>(null);
 
-  // Load note when summary changes — local first (instant), then backend (truth).
+  // Load notes when summary changes — local first (instant), then backend (truth).
   useEffect(() => {
     if (!summaryId) {
-      setValue('');
+      setSlots(emptySlots());
+      setActiveSlot(null);
       return;
     }
-    // Optimistic: show cached value immediately
-    setValue(readLocalNote(summaryId));
+    // Optimistic: show cached values immediately
+    setSlots(readLocalSlots(summaryId));
+    setActiveSlot(readActiveSlot(summaryId));
     setSyncStatus('idle');
     loadTokenRef.current = summaryId;
 
@@ -87,9 +169,9 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
         const remote = await getStickyNote(summaryId);
         // Bail if the user switched summaries while we were fetching
         if (loadTokenRef.current !== summaryId) return;
-        const remoteContent = remote?.content ?? '';
-        setValue(remoteContent);
-        writeLocalNote(summaryId, remoteContent);
+        const remoteSlots = parseSlots(remote?.content ?? '');
+        setSlots(remoteSlots);
+        writeLocalSlots(summaryId, remoteSlots);
       } catch {
         // Network/auth error → keep the localStorage value as fallback
         if (loadTokenRef.current !== summaryId) return;
@@ -107,18 +189,25 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     }
   }, [open]);
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const next = e.target.value;
-      setValue(next);
+  // Persist last-opened slot per summary
+  useEffect(() => {
+    if (!summaryId) return;
+    writeActiveSlot(summaryId, activeSlot);
+  }, [summaryId, activeSlot]);
+
+  const scheduleSave = useCallback(
+    (nextSlots: Slots) => {
       if (!summaryId) return;
       // Local mirror is synchronous → never lose typing
-      writeLocalNote(summaryId, next);
+      writeLocalSlots(summaryId, nextSlots);
       setSyncStatus('saving');
       if (debounceRef.current) window.clearTimeout(debounceRef.current);
       debounceRef.current = window.setTimeout(async () => {
         try {
-          await upsertStickyNote({ summary_id: summaryId, content: next });
+          await upsertStickyNote({
+            summary_id: summaryId,
+            content: serializeSlots(nextSlots),
+          });
           setSyncStatus('saved');
           setSavedAt(Date.now());
         } catch {
@@ -129,12 +218,39 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     [summaryId],
   );
 
-  const handleClear = useCallback(async () => {
+  const handleSlotChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (activeSlot === null) return;
+      const next = e.target.value;
+      setSlots((prev) => {
+        const updated = [...prev] as Slots;
+        updated[activeSlot] = next;
+        scheduleSave(updated);
+        return updated;
+      });
+    },
+    [activeSlot, scheduleSave],
+  );
+
+  const handleClearCurrent = useCallback(async () => {
+    if (activeSlot === null) return;
+    if (!slots[activeSlot]) return;
+    if (!window.confirm(`¿Borrar ${SLOT_LABELS[activeSlot]}?`)) return;
+    setSlots((prev) => {
+      const updated = [...prev] as Slots;
+      updated[activeSlot] = '';
+      scheduleSave(updated);
+      return updated;
+    });
+  }, [activeSlot, slots, scheduleSave]);
+
+  const handleClearAll = useCallback(async () => {
     if (!summaryId) return;
-    if (!value) return;
-    if (!window.confirm('¿Borrar todas las notas de este resumen?')) return;
-    setValue('');
-    writeLocalNote(summaryId, '');
+    if (slots.every((s) => !s)) return;
+    if (!window.confirm('¿Borrar TODAS las notas rápidas de este resumen?')) return;
+    const cleared = emptySlots();
+    setSlots(cleared);
+    writeLocalSlots(summaryId, cleared);
     setSyncStatus('saving');
     try {
       await deleteStickyNote(summaryId);
@@ -143,7 +259,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     } catch {
       setSyncStatus('offline');
     }
-  }, [summaryId, value]);
+  }, [summaryId, slots]);
 
   // Flush pending debounced save on unmount
   useEffect(() => {
@@ -152,10 +268,29 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     };
   }, []);
 
+  const goBackToPicker = useCallback(() => setActiveSlot(null), []);
+  const goPrevSlot = useCallback(() => {
+    setActiveSlot((s) => (s === null ? null : (s + SLOT_COUNT - 1) % SLOT_COUNT));
+  }, []);
+  const goNextSlot = useCallback(() => {
+    setActiveSlot((s) => (s === null ? null : (s + 1) % SLOT_COUNT));
+  }, []);
+
+  // Preview: first non-empty line, trimmed.
+  const slotPreview = useCallback((text: string): string => {
+    const firstLine = text.split('\n').find((l) => l.trim().length > 0) ?? '';
+    return firstLine.trim();
+  }, []);
+
+  const hasAnyContent = useMemo(() => slots.some((s) => s.length > 0), [slots]);
+
   // Don't render anything if there's no summary context yet
   if (!summaryId) return null;
   // SSR / non-browser: bail
   if (typeof document === 'undefined') return null;
+
+  const width = expanded ? 420 : 280;
+  const activeValue = activeSlot === null ? '' : slots[activeSlot];
 
   // Render into a portal at document.body so we escape any ancestor
   // stacking context (transformed motion.div, layout headers with z-index,
@@ -176,7 +311,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
             transition={{ duration: 0.18 }}
             className="flex flex-col rounded-2xl border border-amber-200 bg-amber-50 shadow-lg"
             style={{
-              width: expanded ? 420 : 280,
+              width,
               maxHeight: 'calc(100vh - 8rem)',
               backgroundImage:
                 'repeating-linear-gradient(180deg, transparent 0, transparent 27px, rgba(180, 130, 30, 0.08) 28px)',
@@ -185,15 +320,28 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
             {/* Header */}
             <div className="flex items-center justify-between px-3 py-2 border-b border-amber-200/70">
               <div className="flex items-center gap-2 min-w-0">
-                <div className="p-1.5 rounded-lg bg-amber-200/60">
-                  <StickyNote size={14} className="text-amber-700" />
-                </div>
+                {activeSlot !== null ? (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-amber-700 hover:bg-amber-200/60"
+                    onClick={goBackToPicker}
+                    aria-label="Volver"
+                    title="Volver"
+                  >
+                    <ArrowLeft size={14} />
+                  </Button>
+                ) : (
+                  <div className="p-1.5 rounded-lg bg-amber-200/60">
+                    <StickyNote size={14} className="text-amber-700" />
+                  </div>
+                )}
                 <div className="min-w-0">
                   <p
                     className="text-xs text-amber-900 truncate"
                     style={{ fontFamily: 'Georgia, serif' }}
                   >
-                    Notas rápidas
+                    {activeSlot === null ? 'Notas rápidas' : SLOT_LABELS[activeSlot]}
                   </p>
                   {contextLabel && (
                     <p className="text-[10px] text-amber-700/70 truncate">
@@ -203,6 +351,30 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                 </div>
               </div>
               <div className="flex items-center gap-1">
+                {activeSlot !== null && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-amber-700 hover:bg-amber-200/60"
+                      onClick={goPrevSlot}
+                      aria-label="Nota anterior"
+                      title="Nota anterior"
+                    >
+                      <ChevronLeft size={12} />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-amber-700 hover:bg-amber-200/60"
+                      onClick={goNextSlot}
+                      aria-label="Siguiente nota"
+                      title="Siguiente nota"
+                    >
+                      <ChevronRight size={12} />
+                    </Button>
+                  </>
+                )}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -226,19 +398,59 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
               </div>
             </div>
 
-            {/* Textarea */}
-            <textarea
-              value={value}
-              onChange={handleChange}
-              placeholder="Tu memoria RAM... escribe lo que necesites recordar mientras lees."
-              className="flex-1 resize-none bg-transparent px-4 py-3 text-sm text-amber-950 placeholder:text-amber-700/40 focus:outline-none"
-              style={{
-                fontFamily: 'Georgia, serif',
-                lineHeight: '28px',
-                minHeight: 220,
-              }}
-              spellCheck
-            />
+            {/* Body: picker (4 slices) or editor for one slot */}
+            {activeSlot === null ? (
+              <div
+                className="grid grid-cols-2 gap-2 p-3"
+                style={{ minHeight: 220 }}
+                role="list"
+                aria-label="Elegir nota"
+              >
+                {slots.map((text, i) => {
+                  const preview = slotPreview(text);
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setActiveSlot(i)}
+                      className="group flex flex-col items-start gap-1 rounded-xl border border-amber-200/80 bg-amber-100/40 px-3 py-2 text-left transition hover:bg-amber-100 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+                      style={{ minHeight: 92 }}
+                      aria-label={`${SLOT_LABELS[i]}${preview ? `: ${preview}` : ' (vacía)'}`}
+                      role="listitem"
+                    >
+                      <span
+                        className="text-[11px] font-semibold text-amber-800"
+                        style={{ fontFamily: 'Georgia, serif' }}
+                      >
+                        {SLOT_LABELS[i]}
+                      </span>
+                      <span
+                        className="line-clamp-3 text-[11px] leading-snug text-amber-900/80"
+                        style={{ fontFamily: 'Georgia, serif' }}
+                      >
+                        {preview || (
+                          <span className="italic text-amber-700/50">Vacía — tocá para escribir</span>
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <textarea
+                value={activeValue}
+                onChange={handleSlotChange}
+                placeholder={`Tu memoria RAM... ${SLOT_LABELS[activeSlot]}`}
+                className="flex-1 resize-none bg-transparent px-4 py-3 text-sm text-amber-950 placeholder:text-amber-700/40 focus:outline-none"
+                style={{
+                  fontFamily: 'Georgia, serif',
+                  lineHeight: '28px',
+                  minHeight: 220,
+                }}
+                spellCheck
+                autoFocus
+              />
+            )}
 
             {/* Footer */}
             <div className="flex items-center justify-between px-3 py-2 border-t border-amber-200/70 text-[10px] text-amber-700/80">
@@ -275,12 +487,13 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
               </div>
               <button
                 type="button"
-                onClick={handleClear}
-                disabled={!value}
+                onClick={activeSlot === null ? handleClearAll : handleClearCurrent}
+                disabled={activeSlot === null ? !hasAnyContent : !slots[activeSlot]}
                 className="flex items-center gap-1 text-amber-700/80 hover:text-red-600 disabled:opacity-30 disabled:hover:text-amber-700/80"
+                title={activeSlot === null ? 'Borrar todas' : 'Borrar esta nota'}
               >
                 <Trash2 size={10} />
-                Limpiar
+                {activeSlot === null ? 'Limpiar todo' : 'Limpiar'}
               </button>
             </div>
           </motion.div>
@@ -298,7 +511,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
             title="Abrir notas rápidas"
           >
             <StickyNote size={18} />
-            {value && (
+            {hasAnyContent && (
               <span className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-500 ring-2 ring-amber-50" />
             )}
           </motion.button>

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -9,9 +9,9 @@
 // is supported and the last-opened slot is persisted per summary.
 //
 // Storage:
-//   - Backend `content` field stores a JSON-serialized
-//     4-string array. Plain-text legacy notes are migrated into
-//     slot 0 on first load.
+//   - Backend `content` field stores a JSON-serialized array of 4
+//     `{ title, content }` objects. Legacy formats (plain text or a
+//     4-string array) are migrated automatically on first load.
 //   - localStorage mirrors the same JSON for instant reads and
 //     offline fallback.
 //   - The last-opened slot is persisted per summary under
@@ -32,6 +32,7 @@ import {
   ArrowLeft,
   ChevronLeft,
   ChevronRight,
+  Pencil,
 } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import {
@@ -50,18 +51,34 @@ interface StickyNotesPanelProps {
 const STORAGE_PREFIX = 'axon:sticky-notes:';
 const ACTIVE_SLOT_PREFIX = 'axon:sticky-notes:active:';
 const SLOT_COUNT = 4;
-const SLOT_LABELS = ['Nota 1', 'Nota 2', 'Nota 3', 'Nota 4'];
+const DEFAULT_SLOT_LABELS = ['Nota 1', 'Nota 2', 'Nota 3', 'Nota 4'];
+const MAX_TITLE_LENGTH = 40;
 
-type Slots = [string, string, string, string];
+interface Slot {
+  title: string;
+  content: string;
+}
+type Slots = [Slot, Slot, Slot, Slot];
 type SyncStatus = 'idle' | 'saving' | 'saved' | 'offline';
 
+function emptySlot(): Slot {
+  return { title: '', content: '' };
+}
+
 function emptySlots(): Slots {
-  return ['', '', '', ''];
+  return [emptySlot(), emptySlot(), emptySlot(), emptySlot()];
+}
+
+function displayTitle(slot: Slot, index: number): string {
+  return slot.title.trim() || DEFAULT_SLOT_LABELS[index];
 }
 
 /**
  * Parse a persisted content string into a 4-slot tuple.
- * Back-compat: plain-text legacy notes are placed into slot 0.
+ * Back-compat:
+ *   - Plain-text legacy notes → placed into slot 0 content.
+ *   - Array of strings (previous format) → wrapped with empty titles.
+ *   - Array of `{title, content}` (current format) → used directly.
  */
 function parseSlots(raw: string | null | undefined): Slots {
   if (!raw) return emptySlots();
@@ -70,7 +87,15 @@ function parseSlots(raw: string | null | undefined): Slots {
     if (Array.isArray(parsed)) {
       const out = emptySlots();
       for (let i = 0; i < SLOT_COUNT; i++) {
-        out[i] = typeof parsed[i] === 'string' ? parsed[i] : '';
+        const item = parsed[i];
+        if (typeof item === 'string') {
+          out[i] = { title: '', content: item };
+        } else if (item && typeof item === 'object') {
+          out[i] = {
+            title: typeof item.title === 'string' ? item.title : '',
+            content: typeof item.content === 'string' ? item.content : '',
+          };
+        }
       }
       return out;
     }
@@ -78,14 +103,14 @@ function parseSlots(raw: string | null | undefined): Slots {
     /* legacy plain text */
   }
   const out = emptySlots();
-  out[0] = String(raw);
+  out[0] = { title: '', content: String(raw) };
   return out;
 }
 
 function serializeSlots(slots: Slots): string {
-  // If every slot is empty we persist an empty string so the
-  // clear/delete semantics keep working with the backend.
-  if (slots.every((s) => !s)) return '';
+  // If every slot is entirely empty (no title, no content) we persist an
+  // empty string so the clear/delete semantics keep working with the backend.
+  if (slots.every((s) => !s.title && !s.content)) return '';
   return JSON.stringify(slots);
 }
 
@@ -224,7 +249,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
       const next = e.target.value;
       setSlots((prev) => {
         const updated = [...prev] as Slots;
-        updated[activeSlot] = next;
+        updated[activeSlot] = { ...updated[activeSlot], content: next };
         scheduleSave(updated);
         return updated;
       });
@@ -232,13 +257,27 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     [activeSlot, scheduleSave],
   );
 
+  const handleTitleChange = useCallback(
+    (index: number, rawTitle: string) => {
+      const next = rawTitle.slice(0, MAX_TITLE_LENGTH);
+      setSlots((prev) => {
+        const updated = [...prev] as Slots;
+        updated[index] = { ...updated[index], title: next };
+        scheduleSave(updated);
+        return updated;
+      });
+    },
+    [scheduleSave],
+  );
+
   const handleClearCurrent = useCallback(async () => {
     if (activeSlot === null) return;
-    if (!slots[activeSlot]) return;
-    if (!window.confirm(`¿Borrar ${SLOT_LABELS[activeSlot]}?`)) return;
+    const current = slots[activeSlot];
+    if (!current.content) return;
+    if (!window.confirm(`¿Borrar el contenido de "${displayTitle(current, activeSlot)}"?`)) return;
     setSlots((prev) => {
       const updated = [...prev] as Slots;
-      updated[activeSlot] = '';
+      updated[activeSlot] = { ...updated[activeSlot], content: '' };
       scheduleSave(updated);
       return updated;
     });
@@ -246,7 +285,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
 
   const handleClearAll = useCallback(async () => {
     if (!summaryId) return;
-    if (slots.every((s) => !s)) return;
+    if (slots.every((s) => !s.title && !s.content)) return;
     if (!window.confirm('¿Borrar TODAS las notas rápidas de este resumen?')) return;
     const cleared = emptySlots();
     setSlots(cleared);
@@ -282,7 +321,10 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     return firstLine.trim();
   }, []);
 
-  const hasAnyContent = useMemo(() => slots.some((s) => s.length > 0), [slots]);
+  const hasAnyContent = useMemo(
+    () => slots.some((s) => s.content.length > 0 || s.title.length > 0),
+    [slots],
+  );
 
   // Don't render anything if there's no summary context yet
   if (!summaryId) return null;
@@ -290,7 +332,8 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   if (typeof document === 'undefined') return null;
 
   const width = expanded ? 420 : 280;
-  const activeValue = activeSlot === null ? '' : slots[activeSlot];
+  const activeSlotValue: Slot =
+    activeSlot === null ? emptySlot() : slots[activeSlot];
 
   // Render into a portal at document.body so we escape any ancestor
   // stacking context (transformed motion.div, layout headers with z-index,
@@ -336,13 +379,27 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                     <StickyNote size={14} className="text-amber-700" />
                   </div>
                 )}
-                <div className="min-w-0">
-                  <p
-                    className="text-xs text-amber-900 truncate"
-                    style={{ fontFamily: 'Georgia, serif' }}
-                  >
-                    {activeSlot === null ? 'Notas rápidas' : SLOT_LABELS[activeSlot]}
-                  </p>
+                <div className="min-w-0 flex-1">
+                  {activeSlot === null ? (
+                    <p
+                      className="text-xs text-amber-900 truncate"
+                      style={{ fontFamily: 'Georgia, serif' }}
+                    >
+                      Notas rápidas
+                    </p>
+                  ) : (
+                    <input
+                      type="text"
+                      value={activeSlotValue.title}
+                      onChange={(e) => handleTitleChange(activeSlot, e.target.value)}
+                      placeholder={DEFAULT_SLOT_LABELS[activeSlot]}
+                      maxLength={MAX_TITLE_LENGTH}
+                      aria-label="Nombre de la nota"
+                      title="Cambiar nombre de la nota"
+                      className="w-full bg-transparent text-xs text-amber-900 placeholder:text-amber-700/50 focus:outline-none focus:ring-1 focus:ring-amber-400/60 rounded px-1 -mx-1"
+                      style={{ fontFamily: 'Georgia, serif' }}
+                    />
+                  )}
                   {contextLabel && (
                     <p className="text-[10px] text-amber-700/70 truncate">
                       {contextLabel}
@@ -406,41 +463,61 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                 role="list"
                 aria-label="Elegir nota"
               >
-                {slots.map((text, i) => {
-                  const preview = slotPreview(text);
+                {slots.map((slot, i) => {
+                  const preview = slotPreview(slot.content);
+                  const label = displayTitle(slot, i);
                   return (
-                    <button
+                    <div
                       key={i}
-                      type="button"
-                      onClick={() => setActiveSlot(i)}
-                      className="group flex flex-col items-start gap-1 rounded-xl border border-amber-200/80 bg-amber-100/40 px-3 py-2 text-left transition hover:bg-amber-100 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400/60"
-                      style={{ minHeight: 92 }}
-                      aria-label={`${SLOT_LABELS[i]}${preview ? `: ${preview}` : ' (vacía)'}`}
+                      className="group relative flex flex-col items-stretch gap-1 rounded-xl border border-amber-200/80 bg-amber-100/40 px-3 py-2 transition hover:bg-amber-100 hover:shadow-sm focus-within:ring-2 focus-within:ring-amber-400/60"
+                      style={{ minHeight: 96 }}
                       role="listitem"
                     >
-                      <span
-                        className="text-[11px] font-semibold text-amber-800"
-                        style={{ fontFamily: 'Georgia, serif' }}
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="text"
+                          value={slot.title}
+                          onChange={(e) => handleTitleChange(i, e.target.value)}
+                          onClick={(e) => e.stopPropagation()}
+                          placeholder={DEFAULT_SLOT_LABELS[i]}
+                          maxLength={MAX_TITLE_LENGTH}
+                          aria-label={`Nombre de ${DEFAULT_SLOT_LABELS[i]}`}
+                          title="Cambiar nombre"
+                          className="min-w-0 flex-1 bg-transparent text-[11px] font-semibold text-amber-800 placeholder:text-amber-700/50 focus:outline-none focus:ring-1 focus:ring-amber-400/60 rounded px-1 -mx-1"
+                          style={{ fontFamily: 'Georgia, serif' }}
+                        />
+                        <Pencil
+                          size={10}
+                          className="text-amber-700/40 group-hover:text-amber-700/80 shrink-0"
+                          aria-hidden
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setActiveSlot(i)}
+                        className="flex-1 text-left focus:outline-none"
+                        aria-label={`Abrir ${label}${preview ? `: ${preview}` : ' (vacía)'}`}
                       >
-                        {SLOT_LABELS[i]}
-                      </span>
-                      <span
-                        className="line-clamp-3 text-[11px] leading-snug text-amber-900/80"
-                        style={{ fontFamily: 'Georgia, serif' }}
-                      >
-                        {preview || (
-                          <span className="italic text-amber-700/50">Vacía — tocá para escribir</span>
-                        )}
-                      </span>
-                    </button>
+                        <span
+                          className="line-clamp-3 text-[11px] leading-snug text-amber-900/80"
+                          style={{ fontFamily: 'Georgia, serif' }}
+                        >
+                          {preview || (
+                            <span className="italic text-amber-700/50">
+                              Vacía — tocá para escribir
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    </div>
                   );
                 })}
               </div>
             ) : (
               <textarea
-                value={activeValue}
+                value={activeSlotValue.content}
                 onChange={handleSlotChange}
-                placeholder={`Tu memoria RAM... ${SLOT_LABELS[activeSlot]}`}
+                placeholder={`Tu memoria RAM... ${displayTitle(activeSlotValue, activeSlot)}`}
                 className="flex-1 resize-none bg-transparent px-4 py-3 text-sm text-amber-950 placeholder:text-amber-700/40 focus:outline-none"
                 style={{
                   fontFamily: 'Georgia, serif',
@@ -448,7 +525,6 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                   minHeight: 220,
                 }}
                 spellCheck
-                autoFocus
               />
             )}
 
@@ -488,7 +564,9 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
               <button
                 type="button"
                 onClick={activeSlot === null ? handleClearAll : handleClearCurrent}
-                disabled={activeSlot === null ? !hasAnyContent : !slots[activeSlot]}
+                disabled={
+                  activeSlot === null ? !hasAnyContent : !slots[activeSlot].content
+                }
                 className="flex items-center gap-1 text-amber-700/80 hover:text-red-600 disabled:opacity-30 disabled:hover:text-amber-700/80"
                 title={activeSlot === null ? 'Borrar todas' : 'Borrar esta nota'}
               >

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -73,6 +73,12 @@ function displayTitle(slot: Slot, index: number): string {
   return slot.title.trim() || DEFAULT_SLOT_LABELS[index];
 }
 
+// First non-empty line of a note body, used as preview text in the picker.
+function slotPreview(text: string): string {
+  const firstLine = text.split('\n').find((l) => l.trim().length > 0) ?? '';
+  return firstLine.trim();
+}
+
 /**
  * Parse a persisted content string into a 4-slot tuple.
  * Back-compat:
@@ -214,9 +220,16 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
     }
   }, [open]);
 
-  // Persist last-opened slot per summary
+  // Persist last-opened slot per summary. Skip writes until after the
+  // load effect has populated state for this summaryId, otherwise the
+  // previous summary's activeSlot leaks into the new summary's key.
+  const activeSlotHydratedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!summaryId) return;
+    if (activeSlotHydratedRef.current !== summaryId) {
+      activeSlotHydratedRef.current = summaryId;
+      return;
+    }
     writeActiveSlot(summaryId, activeSlot);
   }, [summaryId, activeSlot]);
 
@@ -273,11 +286,11 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   const handleClearCurrent = useCallback(async () => {
     if (activeSlot === null) return;
     const current = slots[activeSlot];
-    if (!current.content) return;
-    if (!window.confirm(`¿Borrar el contenido de "${displayTitle(current, activeSlot)}"?`)) return;
+    if (!current.title && !current.content) return;
+    if (!window.confirm(`¿Borrar "${displayTitle(current, activeSlot)}"?`)) return;
     setSlots((prev) => {
       const updated = [...prev] as Slots;
-      updated[activeSlot] = { ...updated[activeSlot], content: '' };
+      updated[activeSlot] = emptySlot();
       scheduleSave(updated);
       return updated;
     });
@@ -313,12 +326,6 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   }, []);
   const goNextSlot = useCallback(() => {
     setActiveSlot((s) => (s === null ? null : (s + 1) % SLOT_COUNT));
-  }, []);
-
-  // Preview: first non-empty line, trimmed.
-  const slotPreview = useCallback((text: string): string => {
-    const firstLine = text.split('\n').find((l) => l.trim().length > 0) ?? '';
-    return firstLine.trim();
   }, []);
 
   const hasAnyContent = useMemo(
@@ -478,7 +485,6 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                           type="text"
                           value={slot.title}
                           onChange={(e) => handleTitleChange(i, e.target.value)}
-                          onClick={(e) => e.stopPropagation()}
                           placeholder={DEFAULT_SLOT_LABELS[i]}
                           maxLength={MAX_TITLE_LENGTH}
                           aria-label={`Nombre de ${DEFAULT_SLOT_LABELS[i]}`}
@@ -565,7 +571,9 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                 type="button"
                 onClick={activeSlot === null ? handleClearAll : handleClearCurrent}
                 disabled={
-                  activeSlot === null ? !hasAnyContent : !slots[activeSlot].content
+                  activeSlot === null
+                    ? !hasAnyContent
+                    : !slots[activeSlot].content && !slots[activeSlot].title
                 }
                 className="flex items-center gap-1 text-amber-700/80 hover:text-red-600 disabled:opacity-30 disabled:hover:text-amber-700/80"
                 title={activeSlot === null ? 'Borrar todas' : 'Borrar esta nota'}


### PR DESCRIPTION
## Summary
- Split the right-side **Notas rápidas** panel into **4 independent slots** (notas), landing on a 2x2 picker with a preview of each one. Clicking a slot opens its editor; a header Back button returns to the picker and ‹ › chevrons cycle between notes.
- The **last-opened slot is persisted per summary** (`axon:sticky-notes:active:<summaryId>`) so you always return to where you left off.
- Each slot now has its **own editable title**, inline in the picker cards and in the editor header. Empty titles fall back to `Nota 1`..`Nota 4`. Renames autosave through the same debounced pipeline as content edits.
- **Zero backend migration**: the 4 slots are serialized as a JSON array of `{ title, content }` inside the existing `sticky_notes.content` column. Legacy plain-text and legacy `string[4]` payloads are auto-migrated on load, so existing notes are preserved (into slot 0 for plain text, or with empty titles for the earlier iteration).
- Review fixes applied before merge:
  - Guarded the `activeSlot` persistence effect against the first run after a `summaryId` swap so the previous summary's slot no longer leaks into the new summary's key.
  - `Limpiar` considers the title too — disabling correctly when slot is fully empty, and clearing title + content when invoked.
  - Hoisted `slotPreview` out of the component as a pure helper and dropped an obsolete `stopPropagation` on the picker title input.

## Test plan
- [ ] Open a summary; verify the picker shows 4 empty slots labeled `Nota 1`..`Nota 4`.
- [ ] Enter slot 2, type content, navigate away and back — content and active slot restored.
- [ ] Rename slot 3 from the picker card; reload — name persists.
- [ ] Rename a slot from the editor header; reload — name persists.
- [ ] Switch to a different summary, then back — each summary keeps its own 4 slots + its own active slot.
- [ ] `Limpiar` on a slot with only a title (no content) is enabled and clears the title.
- [ ] `Limpiar todo` from the picker empties all 4 slots.
- [ ] Offline: edits show "Solo local" and persist in localStorage; reconnection reconciles.
- [ ] Existing users with legacy plain-text notes see the text in slot 0 on first load.

https://claude.ai/code/session_01PiBkhYaF33H17gmPpXs7KG