### PR TITLE
fix(ai-assistant): forward currentTopic.id as topicId to chat backend

### DIFF
--- a/src/app/components/ai/ai-assistant/AxonAIAssistant.tsx
+++ b/src/app/components/ai/ai-assistant/AxonAIAssistant.tsx
@@ -72,7 +72,7 @@ export function AxonAIAssistant({ isOpen, onClose, summaryId }: AxonAIAssistantP
 
     setIsStreaming(true);
     const result = await sendChatMessage(msg, {
-      summaryId, history,
+      summaryId, topicId: currentTopic?.id, history,
       onStreamStart: (id) => { setMessages(prev => [...prev, { id, role: 'model', content: '', timestamp: new Date() }]); setIsLoading(false); },
       onStreamChunk: (id, acc) => { setMessages(prev => prev.map(m => m.id === id ? { ...m, content: acc } : m)); },
       onStreamSources: (id, sources) => { setMessageSources(prev => new Map(prev).set(id, sources)); },
@@ -99,7 +99,7 @@ export function AxonAIAssistant({ isOpen, onClose, summaryId }: AxonAIAssistantP
     }
     setIsStreaming(false); // Defensive: ensure isStreaming is always reset
     setIsLoading(false);
-  }, [input, isLoading, messages, summaryId]);
+  }, [input, isLoading, messages, summaryId, currentTopic?.id]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendChat(); } };
 

--- a/src/app/components/ai/ai-assistant/chat-logic.ts
+++ b/src/app/components/ai/ai-assistant/chat-logic.ts
@@ -34,6 +34,7 @@ export async function sendChatMessage(
   msg: string,
   options: {
     summaryId?: string;
+    topicId?: string;
     history: ChatHistoryEntry[];
     onStreamStart: (msgId: string) => void;
     onStreamChunk: (msgId: string, accumulated: string) => void;
@@ -42,7 +43,7 @@ export async function sendChatMessage(
     onStreamEnd: () => void;
   },
 ): Promise<ChatSendResult> {
-  const { summaryId, history, onStreamStart, onStreamChunk, onStreamSources, onStreamDone, onStreamEnd } = options;
+  const { summaryId, topicId, history, onStreamStart, onStreamChunk, onStreamSources, onStreamDone, onStreamEnd } = options;
   const streamingMsgId = `msg-${Date.now()}-${Math.random()}`;
   let rafId: number | null = null;
 
@@ -52,6 +53,7 @@ export async function sendChatMessage(
 
     await chatStream(msg, {
       summaryId,
+      topicId,
       history,
       onChunk: (chunk) => {
         accumulated += chunk;
@@ -77,7 +79,7 @@ export async function sendChatMessage(
 
     // Fallback to non-streaming — streaming placeholder needs cleanup by caller
     try {
-      const result: RagChatResponse = await chat(msg, { history, summaryId });
+      const result: RagChatResponse = await chat(msg, { history, summaryId, topicId });
       const fallbackMsgId = `msg-${Date.now()}-${Math.random()}`;
       return {
         msgId: fallbackMsgId,

--- a/src/app/components/layout/StudentLayout.tsx
+++ b/src/app/components/layout/StudentLayout.tsx
@@ -208,7 +208,7 @@ function StudentShell() {
       {/* ── AI Assistant Panel (lazy-loaded) ── */}
       {isAIOpen && (
         <React.Suspense fallback={null}>
-          <AxonAIAssistant isOpen={isAIOpen} onClose={() => setAIOpen(false)} summaryId={activeSummaryId} />
+          <AxonAIAssistant isOpen={isAIOpen} onClose={() => setAIOpen(false)} summaryId={summaryId} />
         </React.Suspense>
       )}
 

--- a/src/app/services/ai-service/as-chat.ts
+++ b/src/app/services/ai-service/as-chat.ts
@@ -17,6 +17,7 @@ export async function chat(
   message: string,
   opts?: {
     summaryId?: string;
+    topicId?: string;
     history?: ChatHistoryEntry[];
     strategy?: 'auto' | 'standard' | 'multi_query' | 'hyde';
   }
@@ -24,6 +25,7 @@ export async function chat(
   try {
     const body: Record<string, unknown> = { message };
     if (opts?.summaryId) body.summary_id = opts.summaryId;
+    if (opts?.topicId) body.topic_id = opts.topicId;
     if (opts?.history && opts.history.length > 0) body.history = opts.history;
     if (opts?.strategy) body.strategy = opts.strategy;
 
@@ -43,6 +45,7 @@ export async function chatText(
   message: string,
   opts?: {
     summaryId?: string;
+    topicId?: string;
     history?: ChatHistoryEntry[];
     strategy?: 'auto' | 'standard' | 'multi_query' | 'hyde';
   }
@@ -86,6 +89,7 @@ export async function chatStream(
   message: string,
   opts: {
     summaryId?: string;
+    topicId?: string;
     history?: ChatHistoryEntry[];
     strategy?: 'auto' | 'standard' | 'multi_query' | 'hyde';
     onChunk: (text: string) => void;
@@ -95,6 +99,7 @@ export async function chatStream(
 ): Promise<void> {
   const body: Record<string, unknown> = { message, stream: true };
   if (opts.summaryId) body.summary_id = opts.summaryId;
+  if (opts.topicId) body.topic_id = opts.topicId;
   if (opts.history && opts.history.length > 0) body.history = opts.history;
   if (opts.strategy) body.strategy = opts.strategy;
 


### PR DESCRIPTION
## Context

Follow-up to #411. After fixing URL summaryId forwarding (#411) and the backend cascade fallback (axon-backend#211/#212), the user reported the AI was *still* answering without context.

Root cause: the Axon AI panel renders `Contexto: <topic title>` from `NavigationContext.currentTopic` (set by the topic sidebar / course switcher), which is **completely decoupled** from `summaryId`. On `/student/study-hub`, `/student/study`, `/student/summaries` and similar views the URL has no `:summaryId`, no child component lifts one into `UIContext`, but `currentTopic` IS set — so the chip lies: it says "context: X" while the chat body sends nothing scoped at all.

## Change

Three small files:

1. **`as-chat.ts`** — `chat()`, `chatText()`, and `chatStream()` now accept an optional `topicId?: string`, forwarded as `body.topic_id`.
2. **`chat-logic.ts`** — `sendChatMessage()` accepts `topicId` and forwards it to both `chatStream` and the non-stream `chat` fallback.
3. **`AxonAIAssistant.tsx`** — pulls `currentTopic` from `useNavigation()` (already imported for the context label) and passes `topicId: currentTopic?.id` into `sendChatMessage`. Also adds `currentTopic?.id` to the `useCallback` dep array.

The backend (`matraca130/axon-backend#213`) accepts `topic_id`, resolves the institution via `resolve_parent_institution('topics', ...)`, and falls back to loading content from up to 6 active summaries under the topic via the existing chunks → summary_blocks → content_markdown cascade.

## Test plan

- [ ] Open Axon AI from `/student/study-hub` (or any view where the chip shows a topic but no summary): request body should include `topic_id`, response should be grounded in the topic content
- [ ] Navigate to a `/student/summary/:summaryId` route: request should include both `summary_id` and `topic_id`, summary takes precedence (backend prefers summary scoping)
- [ ] Verify the EIC bug repro: open "Examen Físico Cardiovascular", ask "eic significa?" → should answer "Espacio Intercostal", not "Electrocardiograma Intracavitario"