### PR TITLE
fix(useKeywordPageNavigation): repair syntax error from PR #413 squash-merge

### DIFF
--- a/src/app/hooks/useKeywordPageNavigation.ts
+++ b/src/app/hooks/useKeywordPageNavigation.ts
@@ -1,7 +1,6 @@
 import { useMemo, useRef, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
 import type { SummaryKeyword } from '@/app/services/summariesApi';
-import { convert } from 'html-to-text';
 
 interface KeywordPageNavParams {
   summaryId: string;
@@ -32,10 +31,6 @@ export function useKeywordPageNavigation({
     const map = new Map<string, number>();
     if (!keywords.length || totalPages <= 1) return map;
 
-    const pageTexts = isHtmlContent
-      ? htmlPages.map(h =>
-          convert(h, {
-            wordwrap: false,
     const pageTexts = (isHtmlContent
       ? htmlPages.map(h => h.replace(/<[^>]+>/g, ''))
       : textPages.map(lines => lines.join('\n'))


### PR DESCRIPTION
## TL;DR

Production Vercel deploys have been **frozen since 23:20:51 UTC** because the squash-merge of PR #413 (AXO-143) shipped a syntax error in `useKeywordPageNavigation.ts`. Every push to `main` since then fails to build, so the alias is stuck on the previous READY deployment (PR #412 — `dpl_5jY2u...`).

This PR fixes the syntax error so production can deploy again.

## Vercel build error (`dpl_Aa7pnp67nXwq1QKyYFMHecr6yALU`)

```
[vite:esbuild] Transform failed with 1 error:
/vercel/path0/src/app/hooks/useKeywordPageNavigation.ts:39:10:
ERROR: Expected ":" but found "pageTexts"

37 |     convert(h, {
38 |       wordwrap: false,
39 |     const pageTexts = (isHtmlContent
   |     ^
40 |     ? htmlPages.map(h => h.replace(/<[^>]+>/g, ''))
41 |     : textPages.map(lines => lines.join('\n'))
```

## Root cause

When PR #413 was squashed, the squash collapsed two competing transformations of `keywordPageMap` into a broken file:

1. The original `htmlPages.map(h => convert(h, { wordwrap: false, ... }))` block from the pre-CodeQL-fix `html-to-text` path was left **unclosed**.
2. Immediately after, `const pageTexts = (isHtmlContent ? ...` from the Copilot CodeQL autofix tried to **re-declare** the same variable inside that half-open object literal.
3. The orphan `import { convert } from 'html-to-text'` was left at the top.

Three commits stacked on the same area without a clean merge resolution:
- `84f1f97` — original "Extract useKeywordPageNavigation hook" (used `convert`)
- `72a2f8a` — Copilot Autofix for `Incomplete multi-character sanitization` (replaced `convert` with regex)
- `f3fae62` — gemini-code-assist tweak

The squash merger picked code from both paths and the result didn't parse.

## Fix

Keep the regex-based path the Copilot autofix intended, drop the dead `html-to-text` import. Single `useMemo`, single `pageTexts` declaration. No behavior change vs. what the autofix was trying to land.

```ts
const pageTexts = (isHtmlContent
  ? htmlPages.map(h => h.replace(/<[^>]+>/g, ''))
  : textPages.map(lines => lines.join('\n'))
).map(t => t.toLowerCase());
```

## Test plan

- [ ] Vercel build succeeds on `main` after merge
- [ ] Production alias updates to the new deployment SHA
- [ ] Smoke test: open Axon AI on a topic page, verify chat behaviour unchanged from PR #412 baseline
- [ ] Verify `keywordPageMap` still navigates correctly between summary pages when clicking a keyword