### PR TITLE
feat: make StudyTimer and StickyNotes panels draggable

### DIFF
--- a/src/app/components/student/StudyTimer.tsx
+++ b/src/app/components/student/StudyTimer.tsx
@@ -1,13 +1,15 @@
 // ============================================================
 // Axon — Student: StudyTimer (Pomodoro)
 //
-// Fixed-position Pomodoro timer widget with study (25 min) and
+// Draggable Pomodoro timer widget with study (25 min) and
 // break (5 min) modes that auto-switch. Shows mm:ss countdown,
-// progress bar, and play/pause/reset controls.
+// progress bar, and play/pause/reset controls. User can drag
+// the widget by its header to reposition it anywhere on screen;
+// the chosen position is persisted in localStorage.
 // ============================================================
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Play, Pause, RotateCw, X, Plus, Minus } from 'lucide-react';
+import { Play, Pause, RotateCw, X, Plus, Minus, GripVertical } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiCall } from '@/app/lib/api';
 
@@ -19,6 +21,41 @@ const MIN_MINUTES = 1;
 const MAX_STUDY_MINUTES = 120;
 const MAX_BREAK_MINUTES = 30;
 const STEP_MINUTES = 5;
+
+// Persisted position (viewport coordinates in px, top-left origin)
+const POSITION_STORAGE_KEY = 'axon:studyTimer:position';
+// Approximate widget size used for bounds-clamping before layout is measured
+const ESTIMATED_WIDGET_WIDTH = 220;
+const ESTIMATED_WIDGET_HEIGHT = 180;
+const EDGE_MARGIN = 8;
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+function loadSavedPosition(): Position | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(POSITION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Position>;
+    if (typeof parsed.x !== 'number' || typeof parsed.y !== 'number') return null;
+    return { x: parsed.x, y: parsed.y };
+  } catch {
+    return null;
+  }
+}
+
+function clampToViewport(pos: Position, width: number, height: number): Position {
+  if (typeof window === 'undefined') return pos;
+  const maxX = Math.max(EDGE_MARGIN, window.innerWidth - width - EDGE_MARGIN);
+  const maxY = Math.max(EDGE_MARGIN, window.innerHeight - height - EDGE_MARGIN);
+  return {
+    x: Math.min(Math.max(EDGE_MARGIN, pos.x), maxX),
+    y: Math.min(Math.max(EDGE_MARGIN, pos.y), maxY),
+  };
+}
 
 type TimerMode = 'study' | 'break';
 
@@ -39,8 +76,87 @@ export function StudyTimer({ onClose }: StudyTimerProps) {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const sessionIdRef = useRef<string | null>(null);
 
+  // ── Draggable position state ─────────────────────────
+  // `position` is null on first load (widget uses default bottom-right CSS).
+  // Once the user drags, we switch to absolute x/y coordinates stored in localStorage.
+  const [position, setPosition] = useState<Position | null>(() => loadSavedPosition());
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragOffsetRef = useRef<Position>({ x: 0, y: 0 });
+  const didDragRef = useRef(false);
+
   const totalSeconds = mode === 'study' ? studyMinutes * 60 : breakMinutes * 60;
   const progress = 1 - seconds / totalSeconds;
+
+  // ── Drag handlers ────────────────────────────────────
+
+  const handleDragPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Ignore clicks on interactive children (e.g., close button)
+    if ((e.target as HTMLElement).closest('button')) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    dragOffsetRef.current = {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+    didDragRef.current = false;
+    setIsDragging(true);
+    // Seed position from current on-screen rect so the first move is smooth
+    // even when we were still using the default bottom/right CSS.
+    setPosition({ x: rect.left, y: rect.top });
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }, []);
+
+  const handleDragPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    const container = containerRef.current;
+    const width = container?.offsetWidth ?? ESTIMATED_WIDGET_WIDTH;
+    const height = container?.offsetHeight ?? ESTIMATED_WIDGET_HEIGHT;
+    const next = clampToViewport(
+      {
+        x: e.clientX - dragOffsetRef.current.x,
+        y: e.clientY - dragOffsetRef.current.y,
+      },
+      width,
+      height,
+    );
+    didDragRef.current = true;
+    setPosition(next);
+  }, [isDragging]);
+
+  const handleDragPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore if pointer was not captured
+    }
+    if (didDragRef.current && position) {
+      try {
+        window.localStorage.setItem(POSITION_STORAGE_KEY, JSON.stringify(position));
+      } catch {
+        // localStorage unavailable — silently ignore
+      }
+    }
+  }, [isDragging, position]);
+
+  // ── Re-clamp on window resize so the widget never falls off-screen ──
+
+  useEffect(() => {
+    if (!position) return;
+    const handleResize = () => {
+      const container = containerRef.current;
+      const width = container?.offsetWidth ?? ESTIMATED_WIDGET_WIDTH;
+      const height = container?.offsetHeight ?? ESTIMATED_WIDGET_HEIGHT;
+      setPosition((prev) => (prev ? clampToViewport(prev, width, height) : prev));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [position]);
 
   // ── Tick logic ───────────────────────────────────────
 
@@ -157,17 +273,36 @@ export function StudyTimer({ onClose }: StudyTimerProps) {
   const barBg = isBrk ? 'bg-amber-400' : 'bg-teal-400';
   const labelColor = isBrk ? 'text-amber-600' : 'text-teal-600';
 
+  // If the user has dragged the widget we use absolute x/y; otherwise we fall
+  // back to the original bottom-right CSS anchor so first-time users see it
+  // exactly where it used to be.
+  const positionStyle: React.CSSProperties = position
+    ? { left: `${position.x}px`, top: `${position.y}px`, right: 'auto', bottom: 'auto' }
+    : { right: '20px', bottom: '20px' };
+
   return (
     <div
-      className="fixed bottom-5 right-5 z-[400] min-w-[180px] rounded-2xl border border-gray-200 bg-white shadow-lg"
+      ref={containerRef}
+      className={`fixed z-[400] min-w-[180px] rounded-2xl border border-gray-200 bg-white shadow-lg ${isDragging ? 'select-none shadow-xl' : ''}`}
+      style={positionStyle}
       role="timer"
       aria-label={`${mode === 'study' ? 'Estudio' : 'Descanso'} ${display}`}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 pt-3 pb-1">
-        <span className={`text-xs font-semibold uppercase tracking-wide ${labelColor}`}>
-          {mode === 'study' ? 'Estudio' : 'Descanso'}
-        </span>
+      {/* Header — doubles as drag handle */}
+      <div
+        className="flex items-center justify-between px-3 pt-3 pb-1 cursor-grab active:cursor-grabbing touch-none"
+        onPointerDown={handleDragPointerDown}
+        onPointerMove={handleDragPointerMove}
+        onPointerUp={handleDragPointerUp}
+        onPointerCancel={handleDragPointerUp}
+        title="Arrastrar para mover"
+      >
+        <div className="flex items-center gap-1">
+          <GripVertical size={12} className="text-gray-300" aria-hidden="true" />
+          <span className={`text-xs font-semibold uppercase tracking-wide ${labelColor}`}>
+            {mode === 'study' ? 'Estudio' : 'Descanso'}
+          </span>
+        </div>
         <button
           onClick={onClose}
           className="rounded-full p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"

--- a/src/app/components/summary/StickyNotesPanel.tsx
+++ b/src/app/components/summary/StickyNotesPanel.tsx
@@ -50,9 +50,43 @@ interface StickyNotesPanelProps {
 
 const STORAGE_PREFIX = 'axon:sticky-notes:';
 const ACTIVE_SLOT_PREFIX = 'axon:sticky-notes:active:';
+const POSITION_STORAGE_KEY = 'axon:sticky-notes:position';
 const SLOT_COUNT = 4;
 const DEFAULT_SLOT_LABELS = ['Nota 1', 'Nota 2', 'Nota 3', 'Nota 4'];
 const MAX_TITLE_LENGTH = 40;
+
+// Approximate widget size used for bounds-clamping before layout is measured
+const ESTIMATED_WIDGET_WIDTH = 280;
+const ESTIMATED_WIDGET_HEIGHT = 360;
+const EDGE_MARGIN = 8;
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+function loadSavedPosition(): Position | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(POSITION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Position>;
+    if (typeof parsed.x !== 'number' || typeof parsed.y !== 'number') return null;
+    return { x: parsed.x, y: parsed.y };
+  } catch {
+    return null;
+  }
+}
+
+function clampToViewport(pos: Position, width: number, height: number): Position {
+  if (typeof window === 'undefined') return pos;
+  const maxX = Math.max(EDGE_MARGIN, window.innerWidth - width - EDGE_MARGIN);
+  const maxY = Math.max(EDGE_MARGIN, window.innerHeight - height - EDGE_MARGIN);
+  return {
+    x: Math.min(Math.max(EDGE_MARGIN, pos.x), maxX),
+    y: Math.min(Math.max(EDGE_MARGIN, pos.y), maxY),
+  };
+}
 
 interface Slot {
   title: string;
@@ -181,6 +215,90 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   const debounceRef = useRef<number | null>(null);
   // Tracks the summaryId for which the latest async load is valid (race-safety)
   const loadTokenRef = useRef<string | null>(null);
+
+  // ── Draggable position state ─────────────────────────
+  // `position` is null until the user drags; until then we use the original
+  // top:7.5rem / right:1rem CSS anchor so first-time users see the panel
+  // exactly where it used to be.
+  const [position, setPosition] = useState<Position | null>(() => loadSavedPosition());
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragOffsetRef = useRef<Position>({ x: 0, y: 0 });
+  const didDragRef = useRef(false);
+
+  const handleDragPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Ignore drags that start on interactive children (buttons, inputs, etc.)
+    const target = e.target as HTMLElement;
+    if (target.closest('button, input, textarea, a, [contenteditable="true"]')) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    dragOffsetRef.current = {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+    didDragRef.current = false;
+    setIsDragging(true);
+    // Seed position from current on-screen rect so the first move is smooth
+    // even when we were still using the default top/right CSS.
+    setPosition({ x: rect.left, y: rect.top });
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }, []);
+
+  const handleDragPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    const container = containerRef.current;
+    const width = container?.offsetWidth ?? ESTIMATED_WIDGET_WIDTH;
+    const height = container?.offsetHeight ?? ESTIMATED_WIDGET_HEIGHT;
+    const next = clampToViewport(
+      {
+        x: e.clientX - dragOffsetRef.current.x,
+        y: e.clientY - dragOffsetRef.current.y,
+      },
+      width,
+      height,
+    );
+    didDragRef.current = true;
+    setPosition(next);
+  }, [isDragging]);
+
+  const handleDragPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore if pointer was not captured
+    }
+    if (didDragRef.current && position) {
+      try {
+        window.localStorage.setItem(POSITION_STORAGE_KEY, JSON.stringify(position));
+      } catch {
+        // localStorage unavailable — silently ignore
+      }
+    }
+  }, [isDragging, position]);
+
+  // Re-clamp on window resize and on expand toggle (panel width changes
+  // 280 → 420 when expanded, so the right edge can fall off-screen).
+  useEffect(() => {
+    if (!position) return;
+    const reclamp = () => {
+      const container = containerRef.current;
+      const width = container?.offsetWidth ?? ESTIMATED_WIDGET_WIDTH;
+      const height = container?.offsetHeight ?? ESTIMATED_WIDGET_HEIGHT;
+      setPosition((prev) => (prev ? clampToViewport(prev, width, height) : prev));
+    };
+    // Defer to next frame so offsetWidth reflects the new expanded layout
+    const id = window.requestAnimationFrame(reclamp);
+    window.addEventListener('resize', reclamp);
+    return () => {
+      window.cancelAnimationFrame(id);
+      window.removeEventListener('resize', reclamp);
+    };
+  }, [position, expanded]);
 
   // Load notes when summary changes — local first (instant), then backend (truth).
   useEffect(() => {
@@ -342,13 +460,21 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
   const activeSlotValue: Slot =
     activeSlot === null ? emptySlot() : slots[activeSlot];
 
+  // If the user has dragged the panel we use absolute x/y; otherwise we fall
+  // back to the original top:7.5rem / right:1rem CSS anchor so first-time
+  // users see the panel where it used to be.
+  const wrapperPositionStyle: React.CSSProperties = position
+    ? { left: `${position.x}px`, top: `${position.y}px`, zIndex: 1000 }
+    : { top: '7.5rem', right: '1rem', zIndex: 1000 };
+
   // Render into a portal at document.body so we escape any ancestor
   // stacking context (transformed motion.div, layout headers with z-index,
   // overflow:hidden containers, etc.) and stay on top of the app header.
   return createPortal(
     <div
-      className="fixed right-4 print:hidden"
-      style={{ top: '7.5rem', zIndex: 1000 }}
+      ref={containerRef}
+      className="fixed print:hidden"
+      style={wrapperPositionStyle}
       aria-label="Notas rápidas"
     >
       <AnimatePresence mode="wait">
@@ -359,7 +485,7 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: 24 }}
             transition={{ duration: 0.18 }}
-            className="flex flex-col rounded-2xl border border-amber-200 bg-amber-50 shadow-lg"
+            className={`flex flex-col rounded-2xl border border-amber-200 bg-amber-50 shadow-lg ${isDragging ? 'select-none shadow-xl' : ''}`}
             style={{
               width,
               maxHeight: 'calc(100vh - 8rem)',
@@ -367,8 +493,15 @@ export function StickyNotesPanel({ summaryId, contextLabel }: StickyNotesPanelPr
                 'repeating-linear-gradient(180deg, transparent 0, transparent 27px, rgba(180, 130, 30, 0.08) 28px)',
             }}
           >
-            {/* Header */}
-            <div className="flex items-center justify-between px-3 py-2 border-b border-amber-200/70">
+            {/* Header — doubles as drag handle */}
+            <div
+              className="flex items-center justify-between px-3 py-2 border-b border-amber-200/70 cursor-grab active:cursor-grabbing touch-none"
+              onPointerDown={handleDragPointerDown}
+              onPointerMove={handleDragPointerMove}
+              onPointerUp={handleDragPointerUp}
+              onPointerCancel={handleDragPointerUp}
+              title="Arrastrar para mover"
+            >
               <div className="flex items-center gap-2 min-w-0">
                 {activeSlot !== null ? (
                   <Button


### PR DESCRIPTION
## Summary

Los dos widgets flotantes de la sesión de resumen — el cronómetro Pomodoro (`StudyTimer`) y el panel de Notas rápidas (`StickyNotesPanel`) — ahora se pueden arrastrar libremente por la pantalla. La posición elegida se persiste en `localStorage`, así que sobrevive reloads.

- **Drag handle**: el header de cada widget (cursor `grab` / `grabbing`). Clicks sobre botones, inputs o textareas NO inician drag, así que todos los controles existentes siguen funcionando.
- **Pointer events nativos**: funciona con mouse y con touch (móvil/tablet), sin librerías extras.
- **Clamp al viewport**: el widget no se puede arrastrar fuera de la pantalla, y se reajusta automáticamente al redimensionar la ventana. En el panel de notas también se reajusta cuando cambia entre collapsed (280px) y expanded (420px).
- **Compatibilidad hacia atrás**: usuarios que nunca dragean lo ven en la posición original (StudyTimer: `bottom-5 right-5`; StickyNotes: `top:7.5rem right:1rem`).
- **Persistencia**: `axon:studyTimer:position` y `axon:sticky-notes:position` en `localStorage`.

## Test plan

- [x] `npx vite build` — build limpio, sin errores.
- [x] `npx vitest run StudyTimer.test.tsx` — los 6 tests existentes pasan.
- [ ] Abrir un resumen, hacer click sostenido sobre el header del cronómetro y arrastrarlo → debe moverse.
- [ ] Abrir un resumen, hacer click sostenido sobre el header de Notas rápidas y arrastrarlo → debe moverse.
- [ ] Recargar la página → ambos widgets aparecen en la última posición.
- [ ] Arrastrar al borde de la pantalla → el widget queda dentro del viewport (clamp).
- [ ] Redimensionar ventana con los widgets en un extremo → se reajustan.
- [ ] Expandir el panel de notas (Maximize2) → el ancho pasa a 420px y se re-clampa si sale del viewport.
- [ ] Click en botones internos (cerrar, expand, back, prev/next, pencil) → NO dispara drag.
- [ ] Tocar y arrastrar en touch device → funciona igual que con mouse.
