### PR TITLE
fix(summary): escape keyword names before injection to prevent XSS

### DIFF
--- a/src/app/components/student/ReaderChunksTab.tsx
+++ b/src/app/components/student/ReaderChunksTab.tsx
@@ -133,7 +133,7 @@ export const ReaderChunksTab = React.memo(function ReaderChunksTab({
               >
                 {/<[a-z][\s\S]*>/i.test(chunk.content) ? (
                   <KeywordHighlighterInline summaryId={summaryId} onNavigateKeyword={onNavigateKeyword}>
-                    <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(enrichHtmlWithImages(replaceKeywordPlaceholders(chunk.content, keywords))) }} />
+                    <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(enrichHtmlWithImages(replaceKeywordPlaceholders(chunk.content, keywords, { escapeHtml: true }))) }} />
                   </KeywordHighlighterInline>
                 ) : (
                   <KeywordHighlighterInline summaryId={summaryId} onNavigateKeyword={onNavigateKeyword}>

--- a/src/app/components/student/ViewerBlock.tsx
+++ b/src/app/components/student/ViewerBlock.tsx
@@ -461,7 +461,7 @@ export const ViewerBlock = React.memo(function ViewerBlock({
       return (
         <div
           className="axon-prose max-w-none"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(html, keywords)) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(html, keywords, { escapeHtml: true })) }}
           role="article"
         />
       );
@@ -645,7 +645,7 @@ export const ViewerBlock = React.memo(function ViewerBlock({
             {/<[a-z][\s\S]*>/i.test(text) ? (
               <div
                 className="text-sm text-gray-700 leading-relaxed [&_p]:mb-1 [&_p:last-child]:mb-0"
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(text, keywords)) }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(replaceKeywordPlaceholders(text, keywords, { escapeHtml: true })) }}
               />
             ) : (
               <p className="text-sm text-gray-700 leading-relaxed">{replaceKeywordPlaceholders(text, keywords)}</p>

--- a/src/app/components/student/blocks/__tests__/renderTextWithKeywords.test.tsx
+++ b/src/app/components/student/blocks/__tests__/renderTextWithKeywords.test.tsx
@@ -252,4 +252,31 @@ describe('replaceKeywordPlaceholders', () => {
     );
     expect(result).toBe('palpitaciones, Síncope, edema');
   });
+
+  it('does NOT escape HTML in keyword names by default (plain-text mode)', () => {
+    const kw = makeKeyword({ id: 'abc-uuid-123', name: '<script>alert(1)</script>' });
+    const result = replaceKeywordPlaceholders('Ver {{abc-uuid-123}} aquí.', [kw]);
+    expect(result).toBe('Ver <script>alert(1)</script> aquí.');
+  });
+
+  it('escapes HTML in keyword names when escapeHtml option is set (XSS defense)', () => {
+    const kw = makeKeyword({ id: 'abc-uuid-123', name: '<img src=x onerror=alert(1)>' });
+    const result = replaceKeywordPlaceholders(
+      'Ver {{abc-uuid-123}} aquí.',
+      [kw],
+      { escapeHtml: true },
+    );
+    // Raw tag must not appear — angle brackets must be escaped
+    expect(result).not.toContain('<img');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+    // Entities must be present
+    expect(result).toBe('Ver &lt;img src=x onerror=alert(1)&gt; aquí.');
+  });
+
+  it('escapes all HTML-significant characters (& < > " \')', () => {
+    const kw = makeKeyword({ id: 'k1', name: `A&B<C>D"E'F` });
+    const result = replaceKeywordPlaceholders('X {{k1}} Y', [kw], { escapeHtml: true });
+    expect(result).toBe('X A&amp;B&lt;C&gt;D&quot;E&#39;F Y');
+  });
 });

--- a/src/app/components/student/blocks/renderTextWithKeywords.tsx
+++ b/src/app/components/student/blocks/renderTextWithKeywords.tsx
@@ -88,21 +88,48 @@ function wrapBareKeywordUuids(text: string, keywords: SummaryKeyword[]): string 
 }
 
 /**
+ * Escape HTML-significant characters to their entity equivalents.
+ * Used to prevent XSS when injecting untrusted strings (e.g. keyword names
+ * authored by professors) into HTML strings that will be rendered via
+ * dangerouslySetInnerHTML. Defense-in-depth: even though sanitizeHtml
+ * (DOMPurify) runs later in the pipeline, escaping at injection time
+ * prevents ever producing a dangerous HTML fragment in the first place.
+ */
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+function escapeHtml(s: string): string {
+  return String(s).replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch]);
+}
+
+/**
  * Replace {{uuid}} or {{name}} placeholders with keyword names in a plain string.
  * Also resolves bare keyword UUIDs (without {{}}).
  * Useful for HTML content rendered via dangerouslySetInnerHTML where React
  * components (KeywordChip) cannot be injected.
+ *
+ * Security: When `options.escapeHtml` is true (required for HTML contexts),
+ * keyword names are HTML-escaped before injection to prevent stored XSS via
+ * maliciously-named keywords. Plain-text consumers (React text children,
+ * string-matching utilities) should leave `escapeHtml` as the default `false`.
  */
 export function replaceKeywordPlaceholders(
   text: string,
   keywords: SummaryKeyword[] = [],
+  options: { escapeHtml?: boolean } = {},
 ): string {
+  const { escapeHtml: shouldEscape = false } = options;
   const normalized = wrapBareKeywordUuids(text, keywords);
   return normalized.replace(/\{\{([^}]+)\}\}/g, (_match, ref: string) => {
     const kw = keywords.find(
       k => (k.id === ref || k.name.toLowerCase() === ref.toLowerCase()) && k.is_active !== false,
     );
-    return kw ? kw.name : _match;
+    if (!kw) return _match;
+    return shouldEscape ? escapeHtml(kw.name) : kw.name;
   });
 }
 

--- a/src/app/components/summary/ChunkRenderer.tsx
+++ b/src/app/components/summary/ChunkRenderer.tsx
@@ -65,7 +65,7 @@ export const ChunkRenderer = React.memo(function ChunkRenderer({ chunks, keyword
           {isHtml(chunk.content) ? (
             <div
               className="axon-prose max-w-none"
-              dangerouslySetInnerHTML={{ __html: sanitizeHtml(enrichHtmlWithImages(replaceKeywordPlaceholders(chunk.content, keywords), 'light')) }}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(enrichHtmlWithImages(replaceKeywordPlaceholders(chunk.content, keywords, { escapeHtml: true }), 'light')) }}
             />
           ) : (
             <div className="text-gray-600 leading-relaxed">


### PR DESCRIPTION
## Problem

`replaceKeywordPlaceholders()` in `src/app/components/student/blocks/renderTextWithKeywords.tsx` injected raw keyword names into HTML strings that are later rendered via `dangerouslySetInnerHTML`. A professor who creates a keyword with a malicious name (e.g. `<img src=x onerror=alert(1)>`) could produce a dangerous HTML fragment during the pipeline.

## Impact

Stored XSS vector. Although `sanitizeHtml` (DOMPurify) runs as the final step in `ChunkRenderer`/`ReaderChunksTab`/`ViewerBlock` and would strip disallowed tags, the escape is missing at injection time. Defense-in-depth requires escaping before sanitization, not solely relying on it.

## Fix

- Add an `escapeHtml` option (default `false`) to `replaceKeywordPlaceholders`. When `true`, keyword names are HTML-escaped (`&`, `<`, `>`, `"`, `'`) before substitution.
- All HTML-context callers now pass `{ escapeHtml: true }`:
  - `ChunkRenderer.tsx`
  - `ReaderChunksTab.tsx`
  - `ViewerBlock.tsx` (both HTML branches at lines 464 and 648)
- Plain-text consumers (`TextHighlighter` string matching, `ViewerBlock` plain `<p>` branch, React text children) keep the default behavior — React already escapes text children, and changing this path would break string-matching utilities.
- Pipeline order in `ChunkRenderer` was already correct (`replaceKeywordPlaceholders -> enrichHtmlWithImages -> sanitizeHtml`), so no reordering was needed.

## Tests

Added 3 unit tests in `renderTextWithKeywords.test.tsx`:
1. Default plain-text mode preserves `<script>` literal (no escaping) — ensures plain-text consumers unchanged.
2. `{ escapeHtml: true }` converts `<img src=x onerror=alert(1)>` to entity-escaped form; asserts no raw `<` or `>` remains.
3. Full HTML-significant character set (`& < > " '`) is correctly escaped.

All 33 tests in `renderTextWithKeywords.test.tsx` pass, plus 33 in `TextHighlighter.test.tsx` (which mocks `replaceKeywordPlaceholders`).

## How to verify

1. Create a keyword with name `<img src=x onerror=alert(1)>` via the professor flow.
2. Reference it in a summary chunk with `{{<keyword-uuid>}}`.
3. Open the summary as a student. Before the fix the raw tag string is injected into HTML (DOMPurify saved us but the escaping layer was absent). After the fix the keyword name renders as literal text `<img src=x onerror=alert(1)>`.
4. Run `npx vitest run src/app/components/student/blocks/__tests__/renderTextWithKeywords.test.tsx`.