### PR TITLE
refactor(schedule): extract METHOD_PILL to shared module

### DIFF
--- a/src/app/components/schedule/study-plan-dashboard/CompletionIndicators.tsx
+++ b/src/app/components/schedule/study-plan-dashboard/CompletionIndicators.tsx
@@ -7,15 +7,29 @@ import React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Clock } from 'lucide-react';
 import clsx from 'clsx';
-import { METHOD_ICONS, METHOD_LABELS, METHOD_COLORS } from '@/app/utils/studyMethodStyles';
+import { METHOD_ICONS, METHOD_LABELS, METHOD_COLORS, METHOD_PILL, type MethodPillStyle } from '@/app/utils/studyMethodStyles';
 import { gradients } from '@/app/design-system';
 
-export const METHOD_TAG_FIGMA: Record<string, { bg: string; border: string; text: string; iconStroke: string }> = {
-  flashcard: { bg: '#f0fdf6', border: 'rgba(198,240,223,0.8)', text: '#6ba88e', iconStroke: '#6ba88e' },
-  quiz: { bg: gradients.methodQuiz.css, border: 'rgba(253,230,138,0.6)', text: '#b45309', iconStroke: '#b45309' },
-  video: { bg: '#eff6ff', border: 'rgba(191,219,254,0.8)', text: '#3b82f6', iconStroke: '#3b82f6' },
-  resumo: { bg: '#faf5ff', border: 'rgba(221,214,254,0.8)', text: '#7c3aed', iconStroke: '#7c3aed' },
-  '3d': { bg: '#fff7ed', border: 'rgba(254,215,170,0.8)', text: '#c2410c', iconStroke: '#c2410c' },
+/**
+ * Figma-accurate variant of METHOD_PILL used by task cards.
+ * Identical to the shared METHOD_PILL except:
+ *   - quiz.bg uses the methodQuiz gradient (instead of solid hex)
+ *   - adds iconStroke (derived from text) for explicit icon coloring
+ * Built by extending the shared palette — no duplicated hex literals.
+ */
+type MethodTagFigmaStyle = MethodPillStyle & { iconStroke: string };
+
+const withIconStroke = (style: MethodPillStyle): MethodTagFigmaStyle => ({
+  ...style,
+  iconStroke: style.text,
+});
+
+export const METHOD_TAG_FIGMA: Record<string, MethodTagFigmaStyle> = {
+  flashcard: withIconStroke(METHOD_PILL.flashcard),
+  quiz: { ...withIconStroke(METHOD_PILL.quiz), bg: gradients.methodQuiz.css },
+  video: withIconStroke(METHOD_PILL.video),
+  resumo: withIconStroke(METHOD_PILL.resumo),
+  '3d': withIconStroke(METHOD_PILL['3d']),
 };
 
 export function CompletionCircle({ completed, onClick }: { completed: boolean; onClick: () => void }) {

--- a/src/app/components/schedule/weekMonth/types.tsx
+++ b/src/app/components/schedule/weekMonth/types.tsx
@@ -1,9 +1,11 @@
 // ============================================================
 // Shared types + constants for week/month schedule views.
+// Labels and pill colors are imported from the shared module.
 // ============================================================
 import React from 'react';
 import { Video, Zap, GraduationCap, FileText, Box } from 'lucide-react';
 import type { StudyPlanTask } from '@/app/types/study-plan';
+import { METHOD_LABELS, METHOD_PILL } from '@/app/utils/studyMethodStyles';
 
 /** Task annotated with its parent plan id. */
 export type TaskWithPlan = StudyPlanTask & { planId: string };
@@ -17,23 +19,9 @@ export const COMPACT_METHOD_ICONS: Record<string, React.ReactNode> = {
   '3d':      <Box size={9} />,
 };
 
-/** Display labels per study method. */
-export const METHOD_LABELS: Record<string, string> = {
-  video: 'Video',
-  flashcard: 'Flashcards',
-  quiz: 'Quiz',
-  resumo: 'Resumen',
-  '3d': 'Atlas 3D',
-};
-
-/** Pill color palette per study method. */
-export const METHOD_PILL: Record<string, { bg: string; text: string; border: string }> = {
-  flashcard: { bg: '#f0fdf6', text: '#6ba88e', border: 'rgba(198,240,223,0.8)' },
-  quiz:      { bg: '#fefce8', text: '#b45309', border: 'rgba(253,230,138,0.6)' },
-  video:     { bg: '#eff6ff', text: '#3b82f6', border: 'rgba(191,219,254,0.8)' },
-  resumo:    { bg: '#faf5ff', text: '#7c3aed', border: 'rgba(221,214,254,0.8)' },
-  '3d':      { bg: '#fff7ed', text: '#c2410c', border: 'rgba(254,215,170,0.8)' },
-};
+// Re-export from the shared module so existing consumers (CompactMethodPill, etc.)
+// continue to import from this file without changes.
+export { METHOD_LABELS, METHOD_PILL };
 
 /** Day-of-week headers for the month grid (Sunday-first). */
 export const DAY_HEADERS = ['DO', 'LU', 'MA', 'MI', 'JU', 'VI', 'SA'];

--- a/src/app/utils/studyMethodStyles.tsx
+++ b/src/app/utils/studyMethodStyles.tsx
@@ -29,6 +29,26 @@ export const METHOD_COLORS: Record<string, string> = {
   '3d': 'bg-orange-100 text-orange-700 border-orange-200',
 };
 
+/**
+ * Pill-style color palette (solid hex) for method tags/badges.
+ * Used by schedule views (WeekMonthViews) and extended by CompletionIndicators
+ * for its Figma-accurate gradient variant.
+ * Single source of truth — do NOT duplicate these hex values locally.
+ */
+export interface MethodPillStyle {
+  bg: string;
+  text: string;
+  border: string;
+}
+
+export const METHOD_PILL: Record<string, MethodPillStyle> = {
+  flashcard: { bg: '#f0fdf6', text: '#6ba88e', border: 'rgba(198,240,223,0.8)' },
+  quiz:      { bg: '#fefce8', text: '#b45309', border: 'rgba(253,230,138,0.6)' },
+  video:     { bg: '#eff6ff', text: '#3b82f6', border: 'rgba(191,219,254,0.8)' },
+  resumo:    { bg: '#faf5ff', text: '#7c3aed', border: 'rgba(221,214,254,0.8)' },
+  '3d':      { bg: '#fff7ed', text: '#c2410c', border: 'rgba(254,215,170,0.8)' },
+};
+
 /** Full study method definition (used in wizard) */
 export interface StudyMethodDef {
   id: string;


### PR DESCRIPTION
## Problem

QA audit (REFACTORING-AUDIT-2026-04-14) flagged duplicated method pill color constants across schedule UI. Verification found real (but narrower than reported) duplication:

- `METHOD_LABELS` was defined locally in `WeekMonthViews.tsx` despite an identical export already existing in `src/app/utils/studyMethodStyles.tsx`.
- The hex color palette for flashcard/video/resumo/3d was duplicated verbatim between `WeekMonthViews.METHOD_PILL` and `CompletionIndicators.METHOD_TAG_FIGMA`. Only quiz diverges (solid hex vs gradient), and `iconStroke` in METHOD_TAG_FIGMA always equalled `text`.
- `COMPACT_METHOD_ICONS` (size=9) is **not** duplicated — it's a legitimate local variant; left in place.

## Files affected

- `src/app/utils/studyMethodStyles.tsx` — adds canonical `METHOD_PILL` constant and `MethodPillStyle` type.
- `src/app/components/schedule/WeekMonthViews.tsx` — removes local `METHOD_LABELS` and `METHOD_PILL`, imports from shared module.
- `src/app/components/schedule/study-plan-dashboard/CompletionIndicators.tsx` — derives `METHOD_TAG_FIGMA` from shared `METHOD_PILL` via a helper; applies the `methodQuiz` gradient override and synthesizes `iconStroke` from `text`. No more duplicated hex literals.

## Fix

One source of truth for pill bg/text/border per study method. CompletionIndicators extends rather than re-declares, keeping its Figma-gradient quiz override local and explicit.

## Impact

- **Behavior preserved**: all color values identical, quiz gradient retained in CompletionIndicators, icon stroke colors unchanged.
- **Maintenance**: change a pill color in one place, all schedule views update.
- **Validation**: `tsc --noEmit` passes clean for the touched code (only pre-existing tsconfig deprecation warnings remain); `CompletionIndicators` test suite (37 tests) passes. `WeekMonthViews` and `StudyPlanDashboard` test suites fail to load due to a pre-existing missing `@testing-library/user-event` dep — confirmed present on base (unrelated to this PR).

## Test plan

- [x] Typecheck clean on touched files
- [x] CompletionIndicators unit tests (37) pass
- [ ] Visual QA on schedule week/month views and task cards (pill colors, quiz gradient)