### PR TITLE
fix(flashcards): session P0 audit fixes (grade mapping, a11y, batch persistence)

### DIFF
--- a/src/__tests__/e2e-fsrs-study-intelligence.test.ts
+++ b/src/__tests__/e2e-fsrs-study-intelligence.test.ts
@@ -75,7 +75,7 @@ function makeBktState(overrides: Partial<BktState> = {}): BktState {
 
 describe('FSRS Grade Translation Pipeline', () => {
 
-  // Test 1: New card scheduling — SM-2 rating 1 (Again) maps to FSRS grade 1
+  // Test 1: New card scheduling — UI rating 1 (Again) maps to FSRS grade 1
   it('maps Again rating to FSRS grade 1 with continuous grade 0.0', () => {
     const result = translateRating(1);
     expect(result.fsrsGrade).toBe(1);
@@ -85,7 +85,7 @@ describe('FSRS Grade Translation Pipeline', () => {
   });
 
   // Test 2: Good rating increases interval — FSRS grade 3 is "correct"
-  it('maps Good rating (SM-2=3) to FSRS grade 3 with positive recall signal', () => {
+  it('maps Good rating (UI=3) to FSRS grade 3 with positive recall signal', () => {
     const result = translateRating(3);
     expect(result.fsrsGrade).toBe(3);
     expect(result.continuousGrade).toBe(0.65);
@@ -106,8 +106,8 @@ describe('FSRS Grade Translation Pipeline', () => {
     expect(isCorrect(2, 'bkt')).toBe(false);
   });
 
-  // Test 5: SM-2 ratings 3 and 4 collapse into the same FSRS grade 3
-  it('SM-2 ratings 3 (ok) and 4 (good) both map to FSRS grade 3 (Good)', () => {
+  // Test 5: UI ratings 3 and 4 collapse into the same FSRS grade 3
+  it('UI ratings 3 (ok) and 4 (good) both map to FSRS grade 3 (Good)', () => {
     expect(smRatingToFsrsGrade(3)).toBe(3);
     expect(smRatingToFsrsGrade(4)).toBe(3);
   });
@@ -464,7 +464,7 @@ describe('E2E: Full Review Cycle — Grade → Mastery → Stats → Color', () 
     const fsrsGrades = translated.map(t => t.fsrsGrade);
     expect(fsrsGrades).toEqual([1, 3, 3, 4, 2]);
 
-    // Step 3: Compute session stats from the SM-2 ratings
+    // Step 3: Compute session stats from the UI ratings
     const correct = countCorrect(smRatings);
     expect(correct).toBe(3); // ratings 3, 4, 5 are >= 3
 

--- a/src/app/components/content/flashcard/FlashcardDeckScreen.tsx
+++ b/src/app/components/content/flashcard/FlashcardDeckScreen.tsx
@@ -136,11 +136,20 @@ export function DeckScreen({ topic, sectionIdx, sectionName, onStart, onBack, on
                 </div>
               </div>
               <div className="flex items-center gap-1.5 overflow-x-auto pb-1 -mb-1 scrollbar-hide">
-                {FILTER_PILLS.map(f => (
-                  <button key={f.key} onClick={() => setFilterMastery(f.key)} className={clsx("px-2.5 py-1 rounded-full text-[11px] font-medium transition-all whitespace-nowrap shrink-0", filterMastery === f.key ? `${f.color} ring-1 ring-current/20 shadow-sm` : "text-gray-400 hover:text-gray-600 hover:bg-gray-50")}>
-                    {f.label} ({countForFilter(f.key)})
-                  </button>
-                ))}
+                {FILTER_PILLS.map(f => {
+                  const isActive = filterMastery === f.key;
+                  return (
+                    <button
+                      key={f.key}
+                      type="button"
+                      onClick={() => setFilterMastery(f.key)}
+                      aria-pressed={isActive}
+                      className={clsx("px-2.5 py-1 rounded-full text-[11px] font-medium transition-all whitespace-nowrap shrink-0", isActive ? `${f.color} ring-1 ring-current/20 shadow-sm` : "text-gray-400 hover:text-gray-600 hover:bg-gray-50")}
+                    >
+                      {f.label} ({countForFilter(f.key)})
+                    </button>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/src/app/components/content/flashcard/FlashcardSessionScreen.tsx
+++ b/src/app/components/content/flashcard/FlashcardSessionScreen.tsx
@@ -280,18 +280,18 @@ export function SessionScreen({ cards, currentIndex, isRevealed, setIsRevealed, 
               {/* ── Reveal Button (only when NOT revealed) ── */}
               {!isRevealed && (
                 <div className="mt-auto flex flex-col items-center pb-8 md:pb-10 gap-3">
-                  <motion.div
-                    role="button"
-                    tabIndex={0}
+                  {/* AUDIT P1 #4: native <button> instead of role=button div */}
+                  <motion.button
+                    type="button"
                     onClick={() => setIsRevealed(true)}
-                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setIsRevealed(true); }}
+                    aria-label="Mostrar respuesta (Espacio o Enter)"
                     className="bg-[#1B3B36] text-white px-8 py-3.5 rounded-full shadow-lg shadow-[#1B3B36]/20 hover:-translate-y-1 hover:shadow-xl hover:bg-[#244e47] transition-all flex items-center gap-2.5 text-sm cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-[#2a8c7a] focus-visible:ring-offset-2"
                     style={{ fontWeight: 600 }}
                     whileHover={{ y: -2 }}
                     whileTap={{ scale: 0.97 }}
                   >
                     <Eye size={16} /> Mostrar Respuesta
-                  </motion.div>
+                  </motion.button>
                   <span className="hidden sm:flex items-center gap-1.5 text-[10px] text-gray-300">
                     <Keyboard size={10} />
                     Espacio o Enter para revelar
@@ -316,7 +316,9 @@ export function SessionScreen({ cards, currentIndex, isRevealed, setIsRevealed, 
                       {RATINGS.map((rate) => (
                         <button
                           key={rate.value}
+                          type="button"
                           onClick={() => handleRate(rate.value)}
+                          aria-label={`Calificar ${rate.value}: ${rate.label}`}
                           className="group flex flex-col items-center gap-1.5 transition-transform active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-[#2a8c7a] rounded-xl"
                         >
                           <div className={clsx(

--- a/src/app/components/content/flashcard/FlashcardSessionScreen.tsx
+++ b/src/app/components/content/flashcard/FlashcardSessionScreen.tsx
@@ -54,6 +54,19 @@ export function SessionScreen({ cards, currentIndex, isRevealed, setIsRevealed, 
     // Ignore when typing in inputs
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
 
+    // AUDIT P0 #3: Escape actually closes the session (the "Salir (Esc)"
+    // button advertised this but nothing was intercepting it).
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onBack();
+      return;
+    }
+
+    // AUDIT P0 #3: ignore key events fired with modifiers so browser
+    // shortcuts (Ctrl+R, Cmd+1 to switch tabs, Alt+Arrow, etc.) don't
+    // accidentally trigger a rating or reveal.
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+
     if (!isRevealed) {
       if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault();
@@ -67,7 +80,7 @@ export function SessionScreen({ cards, currentIndex, isRevealed, setIsRevealed, 
         handleRate(num);
       }
     }
-  }, [isRevealed, setIsRevealed, handleRate]);
+  }, [isRevealed, setIsRevealed, handleRate, onBack]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/app/components/dashboard/DashboardCharts.responsive.tsx
+++ b/src/app/components/dashboard/DashboardCharts.responsive.tsx
@@ -119,7 +119,7 @@ export const MasteryDonut = React.memo(function MasteryDonut({ data, totalCards 
       className={`${components.chartCard.base} min-w-0`}
     >
       <h3 className="text-lg font-semibold text-gray-900 mb-1" style={headingStyle}>Nivel de Dominio</h3>
-      <p className="text-sm text-gray-500 mb-4 sm:mb-6">Basado en la metodologia SM2</p>
+      <p className="text-sm text-gray-500 mb-4 sm:mb-6">Basado en la metodología FSRS</p>
 
       <div className="h-[180px] sm:h-[220px] relative min-w-0">
         <ChartErrorBoundary height="100%">

--- a/src/app/components/dashboard/DashboardCharts.tsx
+++ b/src/app/components/dashboard/DashboardCharts.tsx
@@ -118,7 +118,7 @@ export function MasteryDonut({ data, totalCards }: MasteryDonutProps) {
       className={`${components.chartCard.base} min-w-0`}
     >
       <h3 className="text-lg font-semibold text-gray-900 mb-1" style={headingStyle}>Nivel de Dominio</h3>
-      <p className="text-sm text-gray-500 mb-4 sm:mb-6">Basado en la metodologia SM2</p>
+      <p className="text-sm text-gray-500 mb-4 sm:mb-6">Basado en la metodología FSRS</p>
 
       <div className="h-[180px] sm:h-[220px] relative min-w-0">
         <ChartErrorBoundary height="100%">

--- a/src/app/hooks/__tests__/useFlashcardEngine.test.ts
+++ b/src/app/hooks/__tests__/useFlashcardEngine.test.ts
@@ -267,7 +267,7 @@ describe('useFlashcardEngine', () => {
   // ══════════════════════════════════════════════════════════
 
   describe('handleRate (non-last card)', () => {
-    it('calls queueReview with the current card', async () => {
+    it('calls queueReview with the current card (SM-2→FSRS translated grade)', async () => {
       const { result } = renderHook(() => useFlashcardEngine(DEFAULT_OPTS));
 
       await act(async () => {
@@ -275,14 +275,16 @@ describe('useFlashcardEngine', () => {
       });
 
       act(() => {
-        result.current.handleRate(4);
+        result.current.handleRate(4); // SM-2 rating "Fácil"
       });
 
       expect(mockQueueReview).toHaveBeenCalledTimes(1);
+      // Audit P0 #1: engine translates SM-2 4 → FSRS 3 (Good) via
+      // smRatingToFsrsGrade before forwarding to useReviewBatch.
       expect(mockQueueReview).toHaveBeenCalledWith(
         expect.objectContaining({
           card: THREE_CARDS[0],
-          grade: 4,
+          grade: 3,
         }),
       );
     });

--- a/src/app/hooks/__tests__/useFlashcardEngine.test.ts
+++ b/src/app/hooks/__tests__/useFlashcardEngine.test.ts
@@ -267,7 +267,7 @@ describe('useFlashcardEngine', () => {
   // ══════════════════════════════════════════════════════════
 
   describe('handleRate (non-last card)', () => {
-    it('calls queueReview with the current card (SM-2→FSRS translated grade)', async () => {
+    it('calls queueReview with the current card (UI→FSRS translated grade)', async () => {
       const { result } = renderHook(() => useFlashcardEngine(DEFAULT_OPTS));
 
       await act(async () => {
@@ -275,12 +275,12 @@ describe('useFlashcardEngine', () => {
       });
 
       act(() => {
-        result.current.handleRate(4); // SM-2 rating "Fácil"
+        result.current.handleRate(4); // UI rating "Fácil"
       });
 
       expect(mockQueueReview).toHaveBeenCalledTimes(1);
-      // Audit P0 #1: engine translates SM-2 4 → FSRS 3 (Good) via
-      // smRatingToFsrsGrade before forwarding to useReviewBatch.
+      // Audit P0 #1: engine translates UI 4 → FSRS 3 (Good) via
+      // uiRatingToFsrsGrade before forwarding to useReviewBatch.
       expect(mockQueueReview).toHaveBeenCalledWith(
         expect.objectContaining({
           card: THREE_CARDS[0],

--- a/src/app/hooks/flashcard-types.ts
+++ b/src/app/hooks/flashcard-types.ts
@@ -20,18 +20,21 @@ export interface MasteryStats {
 // ── Constants ──
 
 /**
- * SM-2 5-level grading scale — the ONLY scale the UI renders.
+ * 5-level UI rating buttons — the ONLY scale the flashcard
+ * session screen renders. Axon does NOT use the SM-2 algorithm;
+ * the extra granularity is purely a UX choice. Real scheduling
+ * runs on FSRS v4 on the backend.
  *
  * Flow of a rating through the system:
  *   1. User clicks one of these buttons → rating: 1..5
  *   2. `useFlashcardEngine.handleRate(rating)` receives it
- *   3. `smRatingToFsrsGrade(rating)` (from `@/app/lib/grade-mapper`)
+ *   3. `uiRatingToFsrsGrade(rating)` (from `@/app/lib/grade-mapper`)
  *      translates 1..5 → FSRS 1..4
  *   4. The FSRS grade is what reaches `useReviewBatch` and the
  *      backend `POST /review-batch` endpoint (PATH B)
  *
  * Do NOT pass these values directly to `queueReview()` or any
- * backend call — always run them through `smRatingToFsrsGrade()`
+ * backend call — always run them through `uiRatingToFsrsGrade()`
  * first. See audit 2026-04-14 P0 #1 for history.
  */
 export const RATINGS = [

--- a/src/app/hooks/flashcard-types.ts
+++ b/src/app/hooks/flashcard-types.ts
@@ -19,20 +19,27 @@ export interface MasteryStats {
 
 // ── Constants ──
 
+/**
+ * SM-2 5-level grading scale — the ONLY scale the UI renders.
+ *
+ * Flow of a rating through the system:
+ *   1. User clicks one of these buttons → rating: 1..5
+ *   2. `useFlashcardEngine.handleRate(rating)` receives it
+ *   3. `smRatingToFsrsGrade(rating)` (from `@/app/lib/grade-mapper`)
+ *      translates 1..5 → FSRS 1..4
+ *   4. The FSRS grade is what reaches `useReviewBatch` and the
+ *      backend `POST /review-batch` endpoint (PATH B)
+ *
+ * Do NOT pass these values directly to `queueReview()` or any
+ * backend call — always run them through `smRatingToFsrsGrade()`
+ * first. See audit 2026-04-14 P0 #1 for history.
+ */
 export const RATINGS = [
   { value: 1, label: 'No sé', color: 'bg-rose-500', hover: 'hover:bg-rose-600', text: 'text-rose-500', desc: 'Repetir pronto' },
   { value: 2, label: 'Difícil', color: 'bg-orange-500', hover: 'hover:bg-orange-600', text: 'text-orange-500', desc: 'Necesito repasar' },
   { value: 3, label: 'Regular', color: 'bg-yellow-400', hover: 'hover:bg-yellow-500', text: 'text-yellow-500', desc: 'Algo de duda' },
   { value: 4, label: 'Fácil', color: 'bg-lime-500', hover: 'hover:bg-lime-600', text: 'text-lime-600', desc: 'Lo entendí bien' },
   { value: 5, label: 'Perfecto', color: 'bg-emerald-500', hover: 'hover:bg-emerald-600', text: 'text-emerald-500', desc: 'Memorizado' },
-] as const;
-
-/** FSRS 4-level grading scale (used by FlashcardReviewer + ReviewSessionView) */
-export const GRADES = [
-  { value: 1, label: 'Otra vez', color: 'bg-red-500 hover:bg-red-600', desc: 'No la sabía' },
-  { value: 2, label: 'Difícil', color: 'bg-orange-500 hover:bg-orange-600', desc: 'Con mucho esfuerzo' },
-  { value: 3, label: 'Bien', color: 'bg-emerald-500 hover:bg-emerald-600', desc: 'Con algo de esfuerzo' },
-  { value: 4, label: 'Fácil', color: 'bg-blue-500 hover:bg-blue-600', desc: 'Muy fácil' },
 ] as const;
 
 // ── Pure Utilities ──

--- a/src/app/hooks/useFlashcardEngine.ts
+++ b/src/app/hooks/useFlashcardEngine.ts
@@ -24,6 +24,7 @@ import type { StudyQueueItem } from '@/app/lib/studyQueueApi';
 import * as sessionApi from '@/app/services/studySessionApi';
 import { useReviewBatch } from './useReviewBatch';
 import { postSessionAnalytics } from '@/app/lib/sessionAnalytics';
+import { smRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
 
 // ── Optimistic update type ────────────────────────────────
 
@@ -173,12 +174,18 @@ export function useFlashcardEngine({ studentId, courseId, topicId, masteryMap, o
     if (card) {
       const sq = masteryMap?.get(card.id);
 
+      // AUDIT P0 #1: translate SM-2 UI rating (1-5) to FSRS grade (1-4)
+      // before handing it to the batch hook / backend. Without this,
+      // a SM-2 rating of 5 would reach the backend as grade=5 and get
+      // silently clamped, corrupting FSRS stability/difficulty updates.
+      const fsrsGrade = smRatingToFsrsGrade(rating as SmRating);
+
       // queueReview handles: BKT heuristic estimation,
       // intra-session BKT accumulation, and BatchReviewItem queuing.
       // PATH B: no FSRS computation — backend does this.
       const result = queueReview({
         card,
-        grade: rating,
+        grade: fsrsGrade,
         responseTimeMs,
         currentPKnow: sq?.p_know,
       });

--- a/src/app/hooks/useFlashcardEngine.ts
+++ b/src/app/hooks/useFlashcardEngine.ts
@@ -24,7 +24,7 @@ import type { StudyQueueItem } from '@/app/lib/studyQueueApi';
 import * as sessionApi from '@/app/services/studySessionApi';
 import { useReviewBatch } from './useReviewBatch';
 import { postSessionAnalytics } from '@/app/lib/sessionAnalytics';
-import { smRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
+import { uiRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
 
 // ── Optimistic update type ────────────────────────────────
 
@@ -174,11 +174,12 @@ export function useFlashcardEngine({ studentId, courseId, topicId, masteryMap, o
     if (card) {
       const sq = masteryMap?.get(card.id);
 
-      // AUDIT P0 #1: translate SM-2 UI rating (1-5) to FSRS grade (1-4)
+      // AUDIT P0 #1: translate the 1-5 UI rating to FSRS grade (1-4)
       // before handing it to the batch hook / backend. Without this,
-      // a SM-2 rating of 5 would reach the backend as grade=5 and get
+      // a UI rating of 5 would reach the backend as grade=5 and get
       // silently clamped, corrupting FSRS stability/difficulty updates.
-      const fsrsGrade = smRatingToFsrsGrade(rating as SmRating);
+      // (Axon does not use SM-2 — the 1-5 scale is purely UX.)
+      const fsrsGrade = uiRatingToFsrsGrade(rating as SmRating);
 
       // queueReview handles: BKT heuristic estimation,
       // intra-session BKT accumulation, and BatchReviewItem queuing.

--- a/src/app/hooks/useFlashcardEngine.ts
+++ b/src/app/hooks/useFlashcardEngine.ts
@@ -188,6 +188,9 @@ export function useFlashcardEngine({ studentId, courseId, topicId, masteryMap, o
         grade: fsrsGrade,
         responseTimeMs,
         currentPKnow: sq?.p_know,
+        // AUDIT P1 #5: pass sessionId so useReviewBatch persists
+        // the running batch to localStorage on every queued review.
+        sessionId: sessionIdRef.current,
       });
 
       // Build optimistic update (engine-specific, not in hook)

--- a/src/app/hooks/useReviewBatch.ts
+++ b/src/app/hooks/useReviewBatch.ts
@@ -43,7 +43,9 @@ export interface ReviewableCard {
 export interface QueueReviewParams {
   /** Card being reviewed — only needs id + subtopic_id */
   card: ReviewableCard;
-  /** Grade from the UI (1-5). */
+  /** FSRS grade (1-4). Callers using the SM-2 UI scale (1-5) must
+   *  translate via `smRatingToFsrsGrade` from `@/app/lib/grade-mapper`
+   *  BEFORE calling queueReview. */
   grade: number;
   /** Time in ms the student took to respond */
   responseTimeMs: number;
@@ -54,6 +56,14 @@ export interface QueueReviewParams {
    * Defaults to 0 if omitted (safe for first review).
    */
   currentPKnow?: number;
+  /**
+   * Backend session id for this review.
+   * When provided, each call to queueReview also writes the
+   * running batch to localStorage so a tab crash / hard refresh
+   * does not lose the already-answered cards (audit P1 #5).
+   * Local/offline ids (prefix `local-`) are ignored.
+   */
+  sessionId?: string | null;
   // NOTE: existingFsrs is NO LONGER accepted.
   // PATH B: the backend reads FSRS state from the DB.
 }
@@ -157,7 +167,7 @@ export function useReviewBatch() {
   const sessionBktRef = useRef<Map<string, number>>(new Map());
 
   const queueReview = useCallback((params: QueueReviewParams): QueueReviewResult => {
-    const { card, grade, responseTimeMs, currentPKnow } = params;
+    const { card, grade, responseTimeMs, currentPKnow, sessionId } = params;
 
     const isCorrect = grade >= 3;
 
@@ -184,6 +194,15 @@ export function useReviewBatch() {
     }
 
     batchQueueRef.current.push(batchItem);
+
+    // AUDIT P1 #5: persist the in-progress batch after every queued
+    // review so an unexpected tab close / crash / refresh still lets
+    // `retryPendingBatches()` replay the answers on next mount.
+    // Skip local/offline sessions — the backend has no record to
+    // attach them to yet.
+    if (sessionId && !sessionId.startsWith('local-')) {
+      savePendingBatch(sessionId, batchQueueRef.current);
+    }
 
     return { isCorrect, estimatedPKnow, previousPKnow: resolvedPKnow };
   }, []);

--- a/src/app/hooks/useReviewBatch.ts
+++ b/src/app/hooks/useReviewBatch.ts
@@ -43,9 +43,9 @@ export interface ReviewableCard {
 export interface QueueReviewParams {
   /** Card being reviewed — only needs id + subtopic_id */
   card: ReviewableCard;
-  /** FSRS grade (1-4). Callers using the SM-2 UI scale (1-5) must
-   *  translate via `smRatingToFsrsGrade` from `@/app/lib/grade-mapper`
-   *  BEFORE calling queueReview. */
+  /** FSRS grade (1-4). Callers rendering the 1-5 UI rating buttons
+   *  must translate via `uiRatingToFsrsGrade` from
+   *  `@/app/lib/grade-mapper` BEFORE calling queueReview. */
   grade: number;
   /** Time in ms the student took to respond */
   responseTimeMs: number;

--- a/src/app/lib/__tests__/grade-mapper.test.ts
+++ b/src/app/lib/__tests__/grade-mapper.test.ts
@@ -6,7 +6,7 @@
 // ============================================================
 
 import {
-  smRatingToFsrsGrade,
+  uiRatingToFsrsGrade,
   fsrsGradeToFloat,
   isCorrect,
   isRecovering,
@@ -17,27 +17,27 @@ import {
   type FsrsGrade,
 } from '@/app/lib/grade-mapper';
 
-// ── smRatingToFsrsGrade ─────────────────────────────────────
+// ── uiRatingToFsrsGrade ─────────────────────────────────────
 
-describe('smRatingToFsrsGrade', () => {
-  it('SM-2 1 (again) → FSRS 1 (Again)', () => {
-    expect(smRatingToFsrsGrade(1)).toBe(1);
+describe('uiRatingToFsrsGrade', () => {
+  it('UI 1 (again) → FSRS 1 (Again)', () => {
+    expect(uiRatingToFsrsGrade(1)).toBe(1);
   });
 
-  it('SM-2 2 (hard) → FSRS 2 (Hard)', () => {
-    expect(smRatingToFsrsGrade(2)).toBe(2);
+  it('UI 2 (hard) → FSRS 2 (Hard)', () => {
+    expect(uiRatingToFsrsGrade(2)).toBe(2);
   });
 
-  it('SM-2 3 (ok) → FSRS 3 (Good)', () => {
-    expect(smRatingToFsrsGrade(3)).toBe(3);
+  it('UI 3 (ok) → FSRS 3 (Good)', () => {
+    expect(uiRatingToFsrsGrade(3)).toBe(3);
   });
 
-  it('SM-2 4 (good) → FSRS 3 (Good) — same bucket as 3', () => {
-    expect(smRatingToFsrsGrade(4)).toBe(3);
+  it('UI 4 (good) → FSRS 3 (Good) — same bucket as 3', () => {
+    expect(uiRatingToFsrsGrade(4)).toBe(3);
   });
 
-  it('SM-2 5 (perfect) → FSRS 4 (Easy)', () => {
-    expect(smRatingToFsrsGrade(5)).toBe(4);
+  it('UI 5 (perfect) → FSRS 4 (Easy)', () => {
+    expect(uiRatingToFsrsGrade(5)).toBe(4);
   });
 });
 

--- a/src/app/lib/grade-mapper.ts
+++ b/src/app/lib/grade-mapper.ts
@@ -5,9 +5,13 @@
 // different components of the Axon evaluation system.
 //
 // SCALES IN PLAY:
-//   SM-2 (legacy frontend):  1-5  (1=again, 2=hard, 3=ok, 4=good, 5=perfect)
-//   FSRS (backend spec):     1-4  (1=Again, 2=Hard, 3=Good, 4=Easy)
-//   Continuous (spec v4.2):  0.0-1.0 (Again=0.0, Hard=0.35, Good=0.65, Easy=1.0)
+//   UI rating (flashcard buttons):  1-5  (1=again, 2=hard, 3=ok, 4=good, 5=perfect)
+//   FSRS (backend spec):            1-4  (1=Again, 2=Hard, 3=Good, 4=Easy)
+//   Continuous (spec v4.2):         0.0-1.0 (Again=0.0, Hard=0.35, Good=0.65, Easy=1.0)
+//
+// Axon does NOT use the SM-2 algorithm. The 1-5 scale is purely a
+// UX granularity choice for the flashcard session screen. Real
+// scheduling is FSRS v4 on the backend.
 //
 // isCorrect THRESHOLDS (per spec v4.2):
 //   FSRS:     grade >= 2 (Hard counts as successful recall)
@@ -17,7 +21,7 @@
 // USAGE:
 //   This module is the SINGLE SOURCE OF TRUTH for grade translation.
 //   INTEGRATED (audit 2026-04-14, P0 #1): `useFlashcardEngine.ts`
-//   imports `smRatingToFsrsGrade()` to translate the 1-5 UI rating
+//   imports `uiRatingToFsrsGrade()` to translate the 1-5 UI rating
 //   to the 1-4 backend grade before it reaches `useReviewBatch` and
 //   the backend `batch-review.ts` endpoint (PATH B).
 //
@@ -37,7 +41,9 @@
 export type FsrsGrade = 1 | 2 | 3 | 4;
 
 /**
- * SM-2 rating scale (1-5), as currently used by the frontend UI.
+ * UI rating scale (1-5) used by the flashcard session buttons.
+ * Purely a UX granularity choice — Axon does NOT use the SM-2
+ * algorithm. Scheduling is FSRS v4 on the backend.
  * - 1 = Again (blackout)
  * - 2 = Hard (incorrect but familiar)
  * - 3 = Good (correct with difficulty)
@@ -80,19 +86,20 @@ export const IS_CORRECT_THRESHOLD: Record<GradeContext, FsrsGrade> = {
 // ── Grade Translation Functions ──────────────────────────
 
 /**
- * Convert SM-2 UI rating (1-5) to FSRS backend grade (1-4).
+ * Convert the 1-5 UI rating from the flashcard session buttons
+ * to the FSRS backend grade (1-4).
  *
  * Mapping rationale:
- *   SM-2 1 (again)   → FSRS 1 (Again)  — total failure
- *   SM-2 2 (hard)    → FSRS 2 (Hard)   — recalled but struggled
- *   SM-2 3 (ok)      → FSRS 3 (Good)   — standard correct recall
- *   SM-2 4 (good)    → FSRS 3 (Good)   — good recall (same FSRS bucket)
- *   SM-2 5 (perfect) → FSRS 4 (Easy)   — effortless recall
+ *   UI 1 (again)   → FSRS 1 (Again)  — total failure
+ *   UI 2 (hard)    → FSRS 2 (Hard)   — recalled but struggled
+ *   UI 3 (ok)      → FSRS 3 (Good)   — standard correct recall
+ *   UI 4 (good)    → FSRS 3 (Good)   — good recall (same FSRS bucket)
+ *   UI 5 (perfect) → FSRS 4 (Easy)   — effortless recall
  *
- * This is the function that useFlashcardEngine.ts will call
- * when PATH B is deployed.
+ * Called by useFlashcardEngine.ts and any future consumer that
+ * forwards ratings to the FSRS PATH B backend.
  */
-export function smRatingToFsrsGrade(rating: SmRating): FsrsGrade {
+export function uiRatingToFsrsGrade(rating: SmRating): FsrsGrade {
   switch (rating) {
     case 1: return 1; // Again → Again
     case 2: return 2; // Hard → Hard
@@ -102,10 +109,17 @@ export function smRatingToFsrsGrade(rating: SmRating): FsrsGrade {
     default: {
       // Defensive: clamp unknown values
       const clamped = Math.max(1, Math.min(5, rating)) as SmRating;
-      return smRatingToFsrsGrade(clamped);
+      return uiRatingToFsrsGrade(clamped);
     }
   }
 }
+
+/**
+ * @deprecated Use `uiRatingToFsrsGrade`. Kept as an alias to avoid
+ * breaking external consumers during the SM-2 → UI rename.
+ * Will be removed once all callers migrate.
+ */
+export const smRatingToFsrsGrade = uiRatingToFsrsGrade;
 
 /**
  * Convert FSRS grade (1-4) to continuous float (0.0-1.0).
@@ -147,10 +161,10 @@ export function isRecovering(
 
 /**
  * Complete grade translation pipeline for a flashcard review.
- * Takes an SM-2 UI rating and returns all the grade representations
+ * Takes a 1-5 UI rating and returns all the grade representations
  * needed by different parts of the system.
  *
- * Usage example (future, when PATH B is deployed):
+ * Usage example:
  * ```ts
  * const { fsrsGrade, continuousGrade, isCorrectFsrs, isCorrectBkt } =
  *   translateRating(userRating);
@@ -160,11 +174,12 @@ export function isRecovering(
  * ```
  */
 export function translateRating(rating: SmRating) {
-  const fsrsGrade = smRatingToFsrsGrade(rating);
+  const fsrsGrade = uiRatingToFsrsGrade(rating);
   const continuousGrade = fsrsGradeToFloat(fsrsGrade);
 
   return {
-    /** Original SM-2 rating from UI (1-5) */
+    /** Original 1-5 UI rating (kept under `smRating` key for
+     *  backward compatibility with pre-rename consumers) */
     smRating: rating,
     /** FSRS grade for backend (1-4) */
     fsrsGrade,

--- a/src/app/lib/grade-mapper.ts
+++ b/src/app/lib/grade-mapper.ts
@@ -16,12 +16,10 @@
 //
 // USAGE:
 //   This module is the SINGLE SOURCE OF TRUTH for grade translation.
-//   When PATH B is deployed, useFlashcardEngine.ts will import
-//   `smRatingToFsrsGrade()` to translate the 1-5 UI rating to
-//   the 1-4 backend grade before sending it to batch-review.
-//
-// BLOCKED: Integration into useFlashcardEngine.ts is deferred
-//          until PATH B is deployed on the backend (per Guidelines).
+//   INTEGRATED (audit 2026-04-14, P0 #1): `useFlashcardEngine.ts`
+//   imports `smRatingToFsrsGrade()` to translate the 1-5 UI rating
+//   to the 1-4 backend grade before it reaches `useReviewBatch` and
+//   the backend `batch-review.ts` endpoint (PATH B).
 //
 // BACKEND PR: https://github.com/Matraca130/axon-backend/pull/60
 //             (batch-review.ts PATH B, based on PR #59 libs)

--- a/src/app/types/student.ts
+++ b/src/app/types/student.ts
@@ -51,7 +51,7 @@ export interface StudentPreferences {
   language: string; // 'es-AR', 'en', 'es'
   dailyGoalMinutes: number;
   notificationsEnabled: boolean;
-  spacedRepetitionAlgorithm: 'sm2' | 'fsrs' | 'simple';
+  spacedRepetitionAlgorithm: 'fsrs' | 'simple';
 }
 
 /** Aggregate study statistics */
@@ -103,7 +103,8 @@ export interface FlashcardReview {
   reviewedAt: string; // ISO date
   rating: 1 | 2 | 3 | 4 | 5; // 1=again, 5=easy
   responseTimeMs: number;
-  // SM-2 fields
+  // Legacy scheduling fields (kept for historical review logs;
+  // live scheduling is driven by FSRS v4 on the backend)
   ease: number;
   interval: number; // days until next review
   repetitions: number;


### PR DESCRIPTION
## Summary
Address P0/P1 findings from flashcards session audit (2026-04-14).

- **P0** Integrate `smRatingToFsrsGrade` in `useFlashcardEngine` — fixes silent FSRS stability corruption where SM-2 rating 4 was collapsed to FSRS Easy.
- **P0** Remove unused `GRADES`, document `RATINGS` flow.
- **P0** Escape key closes session; rating/reveal handlers ignore modifier combos.
- **P1** a11y — native `<button>` for reveal, `aria-label` on rating buttons, `aria-pressed` on filter pills.
- **P1** Persist review batch per item (survives tab crash mid-session).

## Test plan
- [x] `vitest run flashcard` — 168/168
- [x] `vitest run useReviewBatch grade-mapper` — 61/61
- [ ] Manual smoke: session flow, Escape, keyboard rating, reload mid-session
- [ ] Verify `useAdaptiveSession` residual fix (follow-up commit in same branch)

## Follow-ups
- Backend PR `fix/review-batch-transactional` (paired).
- Once both land, harden backend validator to `[1,4]` and drop legacy SM-2=5 branch in `mapToFsrsGrade`.

Audit report and quality-gate verdict: GO.