### PR TITLE
feat(flashcards): complete Fase 5 adaptive session (host + route)

### DIFF
--- a/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
+++ b/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
@@ -51,3 +51,22 @@ Agente frontend de la sección Flashcards de AXON: implementa y modifica compone
 | Quality-gate PASS | 0 | — |
 | Quality-gate FAIL | 0 | — |
 | Scope creep incidents | 0 | — |
+
+## [2026-04-14] Session: Complete Fase 5 adaptive flashcard flow (host + route)
+- **Task**: Create `AdaptiveFlashcardView.tsx`, register `/student/adaptive-session` route, mirror the P0 grade-mapping fix in `useAdaptiveSession.ts`, add a smoke test, and open PR #425 on `feat/adaptive-flashcards-fase5`.
+- **Learned**:
+  - `useAdaptiveSession` returns a full ready-to-render API (`phase`, `currentCard`, `sessionCards`, `generationProgress`, etc.), so the host is basically a phase-to-screen router + URL param parsing + professor-card loader. The hook owns ALL state.
+  - `smRatingToFsrsGrade` (SM-2 rating 1-5 → FSRS grade 1-4) must be applied EVERYWHERE before `useReviewBatch.queueReview`. Any rating>=4 would otherwise reach the backend as 4 or 5 and get silently clamped. The `fix/flashcards-session-p0` branch fixed it in `useFlashcardEngine` but `useAdaptiveSession` was a second offender.
+  - `FlashcardItem` (flashcardApi) and `Flashcard` (types/content) are close but not identical: `front_image_url`/`back_image_url` vs `frontImageUrl`/`backImageUrl`. A local `mapItemToCard` in the host duplicates the module-private `mapApiCard` in `useFlashcardNavigation.ts`.
+- **Pattern**: For adaptive-style phase-driven views, keep the host dumb: read URL params → fetch initial data → pass into hook → switch on `phase` under an `<AnimatePresence mode="wait">`. Delegate back navigation via `useNavigate` with a constant back route.
+- **Mistake**: Expected the broader adaptive test suite to pass out-of-the-box after the grade-mapping fix — it didn't, because the existing `useAdaptiveSession.test.ts` asserted the PRE-fix `grade: 4`. Learning: when mirroring a fix from another branch, grep the tests of the modified file and align expectations in the SAME commit.
+- **Zone edge case**: `useAdaptiveSession.ts` does NOT match my glob (`useFlashcard*.ts`) nor contain "flashcard" in its filename. The task explicitly told me to fix it there. Flagged in the PR body for architect review.
+- **Files touched**:
+  - `src/app/hooks/useAdaptiveSession.ts` (P0 fix)
+  - `src/app/components/content/AdaptiveFlashcardView.tsx` (new)
+  - `src/app/routes/flashcard-student-routes.ts` (new route)
+  - `src/app/hooks/__tests__/useAdaptiveSession.test.ts` (align to P0 fix)
+  - `src/__tests__/e2e-adaptive-flashcard-session.test.tsx` (new, 6 cases)
+- **PR**: https://github.com/Matraca130/numero1_sseki_2325_55/pull/425
+- **Tests**: 6/6 new + 190/190 flashcard-adaptive suite
+- **Build**: Local `vite build` blocked by pre-existing env issue (workerd darwin-arm64 vs windows-64 in node_modules); CI will validate.

--- a/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
+++ b/.claude/agent-memory/individual/FC-01-flashcards-frontend.md
@@ -70,3 +70,20 @@ Agente frontend de la sección Flashcards de AXON: implementa y modifica compone
 - **PR**: https://github.com/Matraca130/numero1_sseki_2325_55/pull/425
 - **Tests**: 6/6 new + 190/190 flashcard-adaptive suite
 - **Build**: Local `vite build` blocked by pre-existing env issue (workerd darwin-arm64 vs windows-64 in node_modules); CI will validate.
+
+## [2026-04-14] Session: Extend adaptive smoke test to reviewing/partial/completed phases
+- **Task**: Quality-gate follow-up on PR #425. Added 3 cases to `src/__tests__/e2e-adaptive-flashcard-session.test.tsx` covering the 3 phases that were previously unasserted (only idle + generating had explicit coverage).
+- **Learned**:
+  - `useAdaptiveSession` does NOT expose a `restart()` method. The view's `onRestart` reuses `session.startSession(cards)` with the already-loaded professor cards — so tests should assert `mockStartSession` is called, not a `mockRestart`. The task wording said "restart() o equivalente" precisely because of this gap.
+  - When stub-mocking `AdaptivePartialSummary`/`AdaptiveCompletedScreen`, the stub needs to forward every callback the host wires. I under-built the stubs in the first pass (bare `<div/>`), which is fine for smoke-render-only tests but blocks interaction tests. Lesson: stub with callback-bearing buttons from the start if the plan includes wiring assertions.
+  - The task asked for "el mismo componente real que usa el flujo normal" for `SessionScreen`. Importing the actual `FlashcardSessionScreen` into the test would drag `AxonLogo` + `design-system` + `flashcard-types` + `studyQueueApi` types into the mock graph. Instead, I enhanced the existing stub on the `@/app/components/content/flashcard` barrel (same import path the host uses) with rate buttons that invoke `props.handleRate`. That still proves the wiring round-trip: host → barrel export → handleRate callback → hook. Flagged as a trade-off in the commit message.
+  - `mockSessionState` must be set BEFORE `render(<AdaptiveFlashcardView/>)` because the module-scoped mock captures the state by reference at call time. `beforeEach` resets to idle via `resetSession()`, so per-test overrides happen inline.
+  - For the `reviewing` phase, the host guards with `session.phase === 'reviewing' && session.currentCard` — BOTH must be truthy. Setting `phase` alone renders nothing. Also `sessionCards` must be populated since the stub reads `props.cards?.length`.
+- **Pattern**: Phase-driven view tests → stateful hook mock + stub screens with minimal forwarding + set state inline per test. Keeps dependency surface tight while proving the phase→screen→callback chain.
+- **Mistake**: Initially forgot to clear `mockHandleRate`/`mockSetIsRevealed` in `beforeEach` (they were declared but never cleared). Caught before running tests because I was explicitly adding rate assertions. Added to the beforeEach block.
+- **Mismatch hook↔view flagged**: `useAdaptiveSession` doesn't expose `restart()`. Not a bug per se — the view compensates by re-calling `startSession` — but it's worth noting for future maintainers. Documented in both the commit message and this memory entry.
+- **Files touched**:
+  - `src/__tests__/e2e-adaptive-flashcard-session.test.tsx` (+225 / -2)
+  - `.claude/agent-memory/individual/FC-01-flashcards-frontend.md` (session log)
+- **Commit**: `f6f9949c test(flashcards): extend adaptive smoke coverage to reviewing/partial/completed phases`
+- **Tests**: 9/9 in adaptive smoke file, 193/193 broader flashcard-adaptive suite (was 190 before +3).

--- a/src/__tests__/e2e-adaptive-flashcard-session.test.tsx
+++ b/src/__tests__/e2e-adaptive-flashcard-session.test.tsx
@@ -1,0 +1,318 @@
+// ============================================================
+// AdaptiveFlashcardView — Smoke test
+//
+// Verifies that the Fase 5 host component:
+//   1. renders without crashing
+//   2. mounts AdaptiveIdleLanding on the initial 'idle' phase
+//   3. calls the hook's startSession when onStart fires
+//   4. swaps to AdaptiveGenerationScreen when phase flips to
+//      'generating'
+//
+// Mocks: react-router, useAuth, useAdaptiveSession, flashcardApi,
+//        motion/react, lucide-react, shared components. This keeps
+//        the dependency surface tight.
+// ============================================================
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ── Router mocks ──────────────────────────────────────────
+const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams({
+  topicId: 'topic-xyz',
+  courseId: 'course-abc',
+  topicTitle: 'Neurología Básica',
+});
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams, vi.fn()] as const,
+}));
+
+// ── Auth mock ─────────────────────────────────────────────
+vi.mock('@/app/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'student-1', name: 'Test' } }),
+}));
+
+// ── motion/react + lucide-react (minimal) ────────────────
+vi.mock('motion/react', () => {
+  const motion = new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        return React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+          const { initial, animate, transition, whileHover, whileTap, exit, layout, ...rest } = props;
+          return React.createElement(prop as string, { ...rest, ref });
+        });
+      },
+    },
+  );
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock('lucide-react', () => {
+  const factory = (name: string) =>
+    function MockIcon(props: Record<string, unknown>) {
+      return <span data-testid={`icon-${name}`} {...props} />;
+    };
+  return new Proxy(
+    {},
+    { get: (_t, prop: string) => factory(prop) },
+  );
+});
+
+// ── Shared components (stub) ──────────────────────────────
+vi.mock('@/app/components/shared/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/app/components/shared/PageStates', () => ({
+  LoadingPage: () => <div data-testid="loading-page" />,
+  EmptyState: ({ title, actionLabel, onAction }: any) => (
+    <div data-testid="empty-state">
+      <span>{title}</span>
+      {actionLabel && <button onClick={onAction}>{actionLabel}</button>}
+    </div>
+  ),
+  ErrorState: ({ message, onRetry }: any) => (
+    <div data-testid="error-state">
+      <span>{message}</span>
+      {onRetry && <button onClick={onRetry}>Retry</button>}
+    </div>
+  ),
+}));
+
+// ── Adaptive screens (stubs with test hooks) ──────────────
+vi.mock('@/app/components/content/flashcard/adaptive', () => ({
+  AdaptiveIdleLanding: ({ topicTitle, cardCount, onStart, onBack }: any) => (
+    <div data-testid="idle-landing">
+      <span data-testid="idle-title">{topicTitle}</span>
+      <span data-testid="idle-count">{cardCount}</span>
+      <button data-testid="idle-start" onClick={onStart}>Start</button>
+      <button data-testid="idle-back" onClick={onBack}>Back</button>
+    </div>
+  ),
+  AdaptiveGenerationScreen: ({ progress, onCancel }: any) => (
+    <div data-testid="generating-screen">
+      <span>{progress.completed}/{progress.total}</span>
+      {onCancel && <button onClick={onCancel}>Cancel</button>}
+    </div>
+  ),
+  AdaptivePartialSummary: () => <div data-testid="partial-summary" />,
+  AdaptiveCompletedScreen: () => <div data-testid="completed-screen" />,
+}));
+
+vi.mock('@/app/components/content/flashcard', () => ({
+  SessionScreen: (props: any) => (
+    <div data-testid="session-screen">
+      <span data-testid="session-card-count">{props.cards?.length ?? 0}</span>
+    </div>
+  ),
+}));
+
+// ── flashcardApi mock ─────────────────────────────────────
+const mockGetFlashcardsByTopic = vi.fn();
+vi.mock('@/app/services/flashcardApi', () => ({
+  getFlashcardsByTopic: (...args: any[]) => mockGetFlashcardsByTopic(...args),
+}));
+
+// ── useAdaptiveSession mock — stateful, controllable ──────
+const mockStartSession = vi.fn();
+const mockGenerateMore = vi.fn();
+const mockAbortGeneration = vi.fn();
+const mockFinishSession = vi.fn().mockResolvedValue(undefined);
+const mockHandleRate = vi.fn();
+const mockSetIsRevealed = vi.fn();
+
+let mockSessionState: any = {
+  phase: 'idle',
+  currentCard: null,
+  currentIndex: 0,
+  totalCards: 0,
+  isRevealed: false,
+  currentRound: null,
+  currentRoundSource: null,
+  completedRounds: [],
+  roundCount: 0,
+  allStats: [],
+  allReviewCount: 0,
+  allCorrectCount: 0,
+  keywordMastery: new Map(),
+  topicSummary: null,
+  masteryLoading: false,
+  generationProgress: null,
+  lastGenerationResult: null,
+  generationError: null,
+  optimisticUpdates: { current: new Map() },
+  masteryDeltas: { current: [] },
+  sessionCards: [],
+  sessionStats: [],
+};
+
+vi.mock('@/app/hooks/useAdaptiveSession', () => ({
+  useAdaptiveSession: () => ({
+    ...mockSessionState,
+    startSession: mockStartSession,
+    generateMore: mockGenerateMore,
+    abortGeneration: mockAbortGeneration,
+    finishSession: mockFinishSession,
+    handleRate: mockHandleRate,
+    setIsRevealed: mockSetIsRevealed,
+  }),
+}));
+
+// Import AFTER mocks
+import { AdaptiveFlashcardView } from '@/app/components/content/AdaptiveFlashcardView';
+
+function resetSession() {
+  mockSessionState = {
+    ...mockSessionState,
+    phase: 'idle',
+    currentCard: null,
+    generationProgress: null,
+  };
+}
+
+describe('AdaptiveFlashcardView', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockStartSession.mockClear();
+    mockGenerateMore.mockClear();
+    mockAbortGeneration.mockClear();
+    mockFinishSession.mockClear();
+    mockGetFlashcardsByTopic.mockReset();
+    mockSearchParams = new URLSearchParams({
+      topicId: 'topic-xyz',
+      courseId: 'course-abc',
+      topicTitle: 'Neurología Básica',
+    });
+    resetSession();
+  });
+
+  it('renders the idle landing once professor cards load', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+        { id: 'fc-2', summary_id: 's1', keyword_id: 'k2', front: 'q2', back: 'a2', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+        { id: 'fc-3', summary_id: 's1', keyword_id: 'k3', front: 'q3', back: 'a3', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 3,
+      limit: 100,
+      offset: 0,
+    });
+
+    render(<AdaptiveFlashcardView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('idle-landing')).toBeTruthy();
+    });
+    expect(screen.getByTestId('idle-title').textContent).toBe('Neurología Básica');
+    expect(screen.getByTestId('idle-count').textContent).toBe('3');
+  });
+
+  it('triggers startSession with loaded cards when onStart fires', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    render(<AdaptiveFlashcardView />);
+    await waitFor(() => screen.getByTestId('idle-start'));
+
+    fireEvent.click(screen.getByTestId('idle-start'));
+
+    expect(mockStartSession).toHaveBeenCalledTimes(1);
+    const passed = mockStartSession.mock.calls[0][0];
+    expect(Array.isArray(passed)).toBe(true);
+    expect(passed).toHaveLength(1);
+    expect(passed[0].id).toBe('fc-1');
+    expect(passed[0].question).toBe('q1');
+    expect(passed[0].answer).toBe('a1');
+  });
+
+  it('renders AdaptiveGenerationScreen when phase is generating', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({ items: [], total: 0, limit: 100, offset: 0 });
+    // Empty cards short-circuits to empty-state — override with 1 card
+    mockGetFlashcardsByTopic.mockReset();
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    mockSessionState = {
+      ...mockSessionState,
+      phase: 'generating',
+      generationProgress: { completed: 2, total: 5, generated: 2, failed: 0 },
+    };
+
+    render(<AdaptiveFlashcardView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generating-screen')).toBeTruthy();
+    });
+    expect(screen.getByText('2/5')).toBeTruthy();
+  });
+
+  it('navigates back to /student/flashcards when idle onBack fires', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    render(<AdaptiveFlashcardView />);
+    await waitFor(() => screen.getByTestId('idle-back'));
+
+    fireEvent.click(screen.getByTestId('idle-back'));
+    expect(mockNavigate).toHaveBeenCalledWith('/student/flashcards');
+  });
+
+  it('shows empty-state when topicId is missing', async () => {
+    mockSearchParams = new URLSearchParams({ courseId: 'c1' });
+    render(<AdaptiveFlashcardView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeTruthy();
+    });
+    expect(mockGetFlashcardsByTopic).not.toHaveBeenCalled();
+  });
+
+  it('shows error-state and supports retry when fetch fails', async () => {
+    mockGetFlashcardsByTopic.mockRejectedValueOnce(new Error('boom'));
+
+    render(<AdaptiveFlashcardView />);
+    await waitFor(() => {
+      expect(screen.getByTestId('error-state')).toBeTruthy();
+    });
+
+    // Retry re-invokes the fetch
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => {
+      expect(screen.getByTestId('idle-landing')).toBeTruthy();
+    });
+  });
+});

--- a/src/__tests__/e2e-adaptive-flashcard-session.test.tsx
+++ b/src/__tests__/e2e-adaptive-flashcard-session.test.tsx
@@ -102,14 +102,74 @@ vi.mock('@/app/components/content/flashcard/adaptive', () => ({
       {onCancel && <button onClick={onCancel}>Cancel</button>}
     </div>
   ),
-  AdaptivePartialSummary: () => <div data-testid="partial-summary" />,
-  AdaptiveCompletedScreen: () => <div data-testid="completed-screen" />,
+  AdaptivePartialSummary: ({
+    allStats,
+    completedRounds,
+    lastGenerationResult,
+    onGenerateMore,
+    onFinish,
+  }: any) => (
+    <div data-testid="partial-summary">
+      <span data-testid="partial-stats-count">{allStats?.length ?? 0}</span>
+      <span data-testid="partial-rounds-count">{completedRounds?.length ?? 0}</span>
+      <span data-testid="partial-last-gen">
+        {lastGenerationResult ? 'has-gen' : 'no-gen'}
+      </span>
+      <button data-testid="partial-generate-more" onClick={() => onGenerateMore?.(10)}>
+        Generar más
+      </button>
+      <button data-testid="partial-finish" onClick={() => onFinish?.()}>
+        Finalizar
+      </button>
+    </div>
+  ),
+  AdaptiveCompletedScreen: ({
+    allStats,
+    completedRounds,
+    onRestart,
+    onExit,
+  }: any) => (
+    <div data-testid="completed-screen">
+      <span data-testid="completed-stats-count">{allStats?.length ?? 0}</span>
+      <span data-testid="completed-rounds-count">{completedRounds?.length ?? 0}</span>
+      <button data-testid="completed-restart" onClick={() => onRestart?.()}>
+        Reiniciar
+      </button>
+      <button data-testid="completed-exit" onClick={() => onExit?.()}>
+        Salir
+      </button>
+    </div>
+  ),
 }));
 
+// SessionScreen stub: mirrors the real component's public surface enough
+// for wiring assertions. We expose rate buttons that forward to the
+// `handleRate` prop so tests can verify the host → hook round-trip.
+// (We intentionally do NOT import the real FlashcardSessionScreen: its
+// transitive deps — AxonLogo, design-system, flashcard-types — would
+// balloon the mock surface. The host imports SessionScreen from this
+// exact barrel, so asserting against the stub still proves wiring.)
 vi.mock('@/app/components/content/flashcard', () => ({
   SessionScreen: (props: any) => (
     <div data-testid="session-screen">
       <span data-testid="session-card-count">{props.cards?.length ?? 0}</span>
+      <span data-testid="session-current-index">{props.currentIndex}</span>
+      <span data-testid="session-course-color">{props.courseColor}</span>
+      <button data-testid="session-show-answer" onClick={() => props.setIsRevealed?.(true)}>
+        Mostrar respuesta
+      </button>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          data-testid={`session-rate-${n}`}
+          onClick={() => props.handleRate?.(n)}
+        >
+          Rate {n}
+        </button>
+      ))}
+      <button data-testid="session-back" onClick={() => props.onBack?.()}>
+        Back
+      </button>
     </div>
   ),
 }));
@@ -184,6 +244,8 @@ describe('AdaptiveFlashcardView', () => {
     mockGenerateMore.mockClear();
     mockAbortGeneration.mockClear();
     mockFinishSession.mockClear();
+    mockHandleRate.mockClear();
+    mockSetIsRevealed.mockClear();
     mockGetFlashcardsByTopic.mockReset();
     mockSearchParams = new URLSearchParams({
       topicId: 'topic-xyz',
@@ -314,5 +376,166 @@ describe('AdaptiveFlashcardView', () => {
     await waitFor(() => {
       expect(screen.getByTestId('idle-landing')).toBeTruthy();
     });
+  });
+
+  // ══ Phase coverage: reviewing / partial-summary / completed ══
+  //
+  // These 3 tests pin the phase→screen mapping and wire-through of the
+  // hook's callbacks. They mock useAdaptiveSession with a fixed phase
+  // payload BEFORE render, then interact with the stubbed screens to
+  // assert that the expected hook method (or navigate) is invoked.
+
+  it('phase=reviewing renders SessionScreen and forwards rating to hook.handleRate', async () => {
+    const reviewingCards = [
+      { id: 'fc-1', front: 'q1', back: 'a1', question: 'q1', answer: 'a1', mastery: 0 },
+      { id: 'fc-2', front: 'q2', back: 'a2', question: 'q2', answer: 'a2', mastery: 0 },
+    ];
+
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+        { id: 'fc-2', summary_id: 's1', keyword_id: 'k2', front: 'q2', back: 'a2', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    });
+
+    mockSessionState = {
+      ...mockSessionState,
+      phase: 'reviewing',
+      currentCard: reviewingCards[0],
+      currentIndex: 0,
+      isRevealed: false,
+      sessionCards: reviewingCards,
+      sessionStats: [],
+      currentRound: { roundNumber: 1, source: 'professor', cardCount: 2, ratings: [] },
+      currentRoundSource: 'professor',
+    };
+
+    render(<AdaptiveFlashcardView />);
+
+    // The real FlashcardSessionScreen is imported from the flashcard
+    // barrel; our stub renders under data-testid="session-screen".
+    await waitFor(() => {
+      expect(screen.getByTestId('session-screen')).toBeTruthy();
+    });
+
+    // Host must pass through the session state to the screen props.
+    expect(screen.getByTestId('session-card-count').textContent).toBe('2');
+    expect(screen.getByTestId('session-current-index').textContent).toBe('0');
+    // Host passes ADAPTIVE_ACCENT (teal #14b8a6) as courseColor.
+    expect(screen.getByTestId('session-course-color').textContent).toBe('#14b8a6');
+
+    // Simulate rating "3" via the stub's rate button, which calls the
+    // handleRate prop the host wired to session.handleRate.
+    fireEvent.click(screen.getByTestId('session-rate-3'));
+    expect(mockHandleRate).toHaveBeenCalledTimes(1);
+    expect(mockHandleRate).toHaveBeenCalledWith(3);
+
+    // Back button should still navigate to /student/flashcards.
+    fireEvent.click(screen.getByTestId('session-back'));
+    expect(mockNavigate).toHaveBeenCalledWith('/student/flashcards');
+  });
+
+  it('phase=partial-summary renders AdaptivePartialSummary and wires onGenerateMore/onFinish', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    mockSessionState = {
+      ...mockSessionState,
+      phase: 'partial-summary',
+      allStats: [3, 4, 3, 5],
+      completedRounds: [
+        { roundNumber: 1, source: 'professor', cardCount: 4, ratings: [3, 4, 3, 5] },
+      ],
+      lastGenerationResult: {
+        cards: [],
+        errors: [],
+        stats: {
+          requested: 10,
+          generated: 8,
+          failed: 2,
+          uniqueKeywords: 5,
+          avgPKnow: 0.6,
+          totalTokens: 1000,
+          elapsedMs: 4200,
+        },
+      },
+    };
+
+    render(<AdaptiveFlashcardView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('partial-summary')).toBeTruthy();
+    });
+    // Hook state travelled through the host into the screen.
+    expect(screen.getByTestId('partial-stats-count').textContent).toBe('4');
+    expect(screen.getByTestId('partial-rounds-count').textContent).toBe('1');
+    expect(screen.getByTestId('partial-last-gen').textContent).toBe('has-gen');
+
+    // onGenerateMore → hook.generateMore(count)
+    fireEvent.click(screen.getByTestId('partial-generate-more'));
+    expect(mockGenerateMore).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMore).toHaveBeenCalledWith(10);
+
+    // onFinish → host.handleFinishAndExit → hook.finishSession()
+    fireEvent.click(screen.getByTestId('partial-finish'));
+    await waitFor(() => {
+      expect(mockFinishSession).toHaveBeenCalledTimes(1);
+    });
+    // finishSession is the hook's responsibility; host does NOT navigate
+    // away synchronously (the hook flips phase → completed on its own).
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('phase=completed renders AdaptiveCompletedScreen and wires onRestart/onExit', async () => {
+    mockGetFlashcardsByTopic.mockResolvedValueOnce({
+      items: [
+        { id: 'fc-1', summary_id: 's1', keyword_id: 'k1', front: 'q1', back: 'a1', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+        { id: 'fc-2', summary_id: 's1', keyword_id: 'k2', front: 'q2', back: 'a2', source: 'manual', is_active: true, deleted_at: null, created_at: '', updated_at: '' },
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    });
+
+    mockSessionState = {
+      ...mockSessionState,
+      phase: 'completed',
+      allStats: [3, 4, 5, 3, 4],
+      completedRounds: [
+        { roundNumber: 1, source: 'professor', cardCount: 2, ratings: [3, 4] },
+        { roundNumber: 2, source: 'ai', cardCount: 3, ratings: [5, 3, 4] },
+      ],
+    };
+
+    render(<AdaptiveFlashcardView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('completed-screen')).toBeTruthy();
+    });
+    expect(screen.getByTestId('completed-stats-count').textContent).toBe('5');
+    expect(screen.getByTestId('completed-rounds-count').textContent).toBe('2');
+
+    // onRestart: the hook does NOT expose a `restart` method. The host
+    // re-invokes session.startSession(cards) with the previously loaded
+    // professor cards. Assert that, not a non-existent hook.restart().
+    fireEvent.click(screen.getByTestId('completed-restart'));
+    expect(mockStartSession).toHaveBeenCalledTimes(1);
+    const passed = mockStartSession.mock.calls[0][0];
+    expect(Array.isArray(passed)).toBe(true);
+    expect(passed).toHaveLength(2);
+    expect(passed[0].id).toBe('fc-1');
+
+    // onExit → navigate back to /student/flashcards
+    fireEvent.click(screen.getByTestId('completed-exit'));
+    expect(mockNavigate).toHaveBeenCalledWith('/student/flashcards');
   });
 });

--- a/src/app/components/content/AdaptiveFlashcardView.tsx
+++ b/src/app/components/content/AdaptiveFlashcardView.tsx
@@ -28,6 +28,7 @@ import { AnimatePresence } from 'motion/react';
 import { useAuth } from '@/app/context/AuthContext';
 import { useAdaptiveSession } from '@/app/hooks/useAdaptiveSession';
 import { getFlashcardsByTopic, type FlashcardItem } from '@/app/services/flashcardApi';
+import { logger } from '@/app/lib/logger';
 import { ErrorBoundary } from '@/app/components/shared/ErrorBoundary';
 import { LoadingPage, EmptyState, ErrorState } from '@/app/components/shared/PageStates';
 import type { Flashcard } from '@/app/types/content';
@@ -104,7 +105,7 @@ export function AdaptiveFlashcardView() {
         .map(mapItemToCard);
       setCards(active);
     } catch (err) {
-      if (import.meta.env.DEV) console.warn('[AdaptiveFlashcardView] Failed to load cards:', err);
+      logger.warn('[AdaptiveFlashcardView] Failed to load cards', err);
       setLoadError('No pudimos cargar las flashcards del tema. Intenta de nuevo.');
       setCards(null);
     } finally {

--- a/src/app/components/content/AdaptiveFlashcardView.tsx
+++ b/src/app/components/content/AdaptiveFlashcardView.tsx
@@ -1,0 +1,277 @@
+// ============================================================
+// AdaptiveFlashcardView — Host for the adaptive (AI-driven) flashcard
+// session flow. Sibling of FlashcardView.tsx.
+//
+// v4.5.0 (Fase 5): Standalone route that consumes useAdaptiveSession
+// and orchestrates the phase-specific screens from
+// components/content/flashcard/adaptive/*.
+//
+// URL contract (from FlashcardView DeckScreen "Con IA" button):
+//   /student/adaptive-session?topicId=...&courseId=...&topicTitle=...
+//
+// studentId is derived from useAuth() and the professor card list is
+// loaded from /flashcards-by-topic — the URL does NOT carry cardCount
+// or studentId (the view is self-sufficient).
+//
+// Phase → Screen mapping:
+//   idle              → AdaptiveIdleLanding
+//   reviewing         → FlashcardSessionScreen (SessionScreen)
+//   generating        → AdaptiveGenerationScreen
+//   partial-summary   → AdaptivePartialSummary
+//   completed         → AdaptiveCompletedScreen
+// ============================================================
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { AnimatePresence } from 'motion/react';
+
+import { useAuth } from '@/app/context/AuthContext';
+import { useAdaptiveSession } from '@/app/hooks/useAdaptiveSession';
+import { getFlashcardsByTopic, type FlashcardItem } from '@/app/services/flashcardApi';
+import { ErrorBoundary } from '@/app/components/shared/ErrorBoundary';
+import { LoadingPage, EmptyState, ErrorState } from '@/app/components/shared/PageStates';
+import type { Flashcard } from '@/app/types/content';
+
+import { SessionScreen } from './flashcard';
+import {
+  AdaptiveIdleLanding,
+  AdaptiveGenerationScreen,
+  AdaptivePartialSummary,
+  AdaptiveCompletedScreen,
+} from './flashcard/adaptive';
+
+// ── Constants ─────────────────────────────────────────────
+const ADAPTIVE_ACCENT = '#14b8a6';
+const BACK_ROUTE = '/student/flashcards';
+
+// ── Helpers ───────────────────────────────────────────────
+// Map FlashcardItem (API shape) → Flashcard (UI shape expected by
+// useAdaptiveSession.startSession and SessionScreen). This mirrors the
+// module-private mapApiCard() in useFlashcardNavigation.ts; we can't
+// import that, so we duplicate the minimum shape.
+function mapItemToCard(item: FlashcardItem): Flashcard {
+  return {
+    id: item.id,
+    front: item.front || '',
+    back: item.back || '',
+    question: item.front || '',
+    answer: item.back || '',
+    mastery: 0,
+    difficulty: 'normal',
+    keywords: [],
+    summary_id: item.summary_id,
+    keyword_id: item.keyword_id,
+    subtopic_id: item.subtopic_id ?? null,
+    source: item.source,
+    image: item.front_image_url || item.back_image_url || undefined,
+    frontImageUrl: item.front_image_url ?? null,
+    backImageUrl: item.back_image_url ?? null,
+  };
+}
+
+// ══════════════════════════════════════════════════════════
+// COMPONENT
+// ══════════════════════════════════════════════════════════
+
+export function AdaptiveFlashcardView() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const studentId = user?.id ?? null;
+  const [searchParams] = useSearchParams();
+
+  const topicId = searchParams.get('topicId');
+  const courseId = searchParams.get('courseId') ?? '';
+  const topicTitle = searchParams.get('topicTitle') || 'Sesión Adaptativa';
+
+  // ── Load professor cards for the topic ──
+  const [cards, setCards] = useState<Flashcard[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadCards = useCallback(async () => {
+    if (!topicId) {
+      setLoading(false);
+      setLoadError('Falta el topic para iniciar la sesión adaptativa.');
+      return;
+    }
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await getFlashcardsByTopic(topicId);
+      const items = Array.isArray(data) ? data : data?.items || [];
+      const active = items
+        .filter((c: FlashcardItem) => c.is_active !== false && !c.deleted_at)
+        .map(mapItemToCard);
+      setCards(active);
+    } catch (err) {
+      if (import.meta.env.DEV) console.warn('[AdaptiveFlashcardView] Failed to load cards:', err);
+      setLoadError('No pudimos cargar las flashcards del tema. Intenta de nuevo.');
+      setCards(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [topicId]);
+
+  useEffect(() => {
+    loadCards();
+  }, [loadCards]);
+
+  // ── Adaptive session hook ──
+  const session = useAdaptiveSession({
+    studentId,
+    courseId,
+    topicId,
+  });
+
+  const goBack = useCallback(() => {
+    navigate(BACK_ROUTE);
+  }, [navigate]);
+
+  const handleStart = useCallback(() => {
+    if (!cards || cards.length === 0) return;
+    session.startSession(cards);
+  }, [cards, session]);
+
+  const handleRestart = useCallback(() => {
+    // Re-run the flow from idle with the same card set
+    if (cards && cards.length > 0) {
+      session.startSession(cards);
+    } else {
+      loadCards();
+    }
+  }, [cards, session, loadCards]);
+
+  const handleFinishAndExit = useCallback(async () => {
+    await session.finishSession();
+  }, [session]);
+
+  const handleExitAfterCompletion = useCallback(() => {
+    navigate(BACK_ROUTE);
+  }, [navigate]);
+
+  const totalCards = useMemo(() => cards?.length ?? 0, [cards]);
+
+  // ── Early states ──
+  if (!topicId) {
+    return (
+      <ErrorBoundary>
+        <div className="flex h-full bg-surface-dashboard items-center justify-center">
+          <EmptyState
+            title="Tema no encontrado"
+            description="La sesión adaptativa requiere un topic válido."
+            actionLabel="Volver a Flashcards"
+            onAction={goBack}
+          />
+        </div>
+      </ErrorBoundary>
+    );
+  }
+
+  if (loading && !cards) {
+    return (
+      <ErrorBoundary>
+        <div className="flex h-full bg-surface-dashboard">
+          <LoadingPage />
+        </div>
+      </ErrorBoundary>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <ErrorBoundary>
+        <div className="flex h-full bg-surface-dashboard items-center justify-center">
+          <ErrorState message={loadError} onRetry={loadCards} />
+        </div>
+      </ErrorBoundary>
+    );
+  }
+
+  if (!cards || cards.length === 0) {
+    return (
+      <ErrorBoundary>
+        <div className="flex h-full bg-surface-dashboard items-center justify-center">
+          <EmptyState
+            title="Sin flashcards"
+            description="Este tema todavía no tiene flashcards del profesor. La sesión adaptativa necesita un punto de partida."
+            actionLabel="Volver"
+            onAction={goBack}
+          />
+        </div>
+      </ErrorBoundary>
+    );
+  }
+
+  // ── Main phase-driven render ──
+  return (
+    <ErrorBoundary>
+      <div className="flex h-full bg-surface-dashboard relative overflow-hidden">
+        <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+          <AnimatePresence mode="wait">
+            {session.phase === 'idle' && (
+              <AdaptiveIdleLanding
+                key="idle"
+                topicTitle={topicTitle}
+                cardCount={totalCards}
+                onStart={handleStart}
+                onBack={goBack}
+              />
+            )}
+
+            {session.phase === 'reviewing' && session.currentCard && (
+              <SessionScreen
+                key={`session-round-${session.currentRound?.roundNumber ?? 0}`}
+                cards={session.sessionCards}
+                currentIndex={session.currentIndex}
+                isRevealed={session.isRevealed}
+                setIsRevealed={session.setIsRevealed}
+                handleRate={session.handleRate}
+                sessionStats={session.sessionStats}
+                courseColor={ADAPTIVE_ACCENT}
+                onBack={goBack}
+              />
+            )}
+
+            {session.phase === 'generating' && session.generationProgress && (
+              <AdaptiveGenerationScreen
+                key="generating"
+                progress={session.generationProgress}
+                onCancel={session.abortGeneration}
+              />
+            )}
+
+            {session.phase === 'partial-summary' && (
+              <AdaptivePartialSummary
+                key="partial"
+                allStats={session.allStats}
+                completedRounds={session.completedRounds}
+                keywordMastery={session.keywordMastery}
+                topicSummary={session.topicSummary}
+                masteryLoading={session.masteryLoading}
+                masteryDeltas={session.masteryDeltas.current}
+                lastGenerationResult={session.lastGenerationResult}
+                generationError={session.generationError}
+                onGenerateMore={session.generateMore}
+                onFinish={handleFinishAndExit}
+              />
+            )}
+
+            {session.phase === 'completed' && (
+              <AdaptiveCompletedScreen
+                key="completed"
+                allStats={session.allStats}
+                completedRounds={session.completedRounds}
+                masteryDeltas={session.masteryDeltas.current}
+                topicSummary={session.topicSummary}
+                onRestart={handleRestart}
+                onExit={handleExitAfterCompletion}
+              />
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+export default AdaptiveFlashcardView;

--- a/src/app/hooks/__tests__/useAdaptiveSession.test.ts
+++ b/src/app/hooks/__tests__/useAdaptiveSession.test.ts
@@ -183,8 +183,10 @@ describe('useAdaptiveSession', () => {
     });
 
     expect(mockQueueReview).toHaveBeenCalledTimes(1);
+    // AUDIT P0 #1: SM-2 UI rating 4 ("Bien") now maps to FSRS grade 3
+    // via smRatingToFsrsGrade before hitting useReviewBatch.
     expect(mockQueueReview).toHaveBeenCalledWith(
-      expect.objectContaining({ grade: 4 }),
+      expect.objectContaining({ grade: 3 }),
     );
 
     // After delay, should advance

--- a/src/app/hooks/useAdaptiveSession.ts
+++ b/src/app/hooks/useAdaptiveSession.ts
@@ -75,6 +75,7 @@ import {
   type AdaptiveGenerationResult,
 } from '@/app/services/adaptiveGenerationApi';
 import { countCorrect } from '@/app/lib/session-stats';
+import { smRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
 import type { OptimisticCardUpdate, CardMasteryDelta } from './useFlashcardEngine';
 
 // ── Types ─────────────────────────────────────────────────
@@ -255,8 +256,15 @@ export function useAdaptiveSession(opts: UseAdaptiveSessionOpts) {
     const responseTimeMs = Date.now() - cardStartTimeRef.current;
     const sq = masteryMap?.get(card.id);
 
+    // AUDIT P0 #1: translate SM-2 UI rating (1-5) to FSRS grade (1-4)
+    // before handing it to the batch hook / backend. Without this, a SM-2
+    // rating of 5 would reach the backend as grade=5 and get silently
+    // clamped, corrupting FSRS stability/difficulty updates. Mirrors the
+    // same fix applied in useFlashcardEngine on fix/flashcards-session-p0.
+    const fsrsGrade = smRatingToFsrsGrade(rating as SmRating);
+
     const result: QueueReviewResult = queueReview({
-      card, grade: rating, responseTimeMs, currentPKnow: sq?.p_know,
+      card, grade: fsrsGrade, responseTimeMs, currentPKnow: sq?.p_know,
     });
 
     optimisticRef.current.set(card.id, {

--- a/src/app/routes/flashcard-student-routes.ts
+++ b/src/app/routes/flashcard-student-routes.ts
@@ -16,5 +16,11 @@ export const flashcardStudentRoutes: RouteObject[] = [
     path: 'review-session',
     lazy: () => lazyRetry(() => import('@/app/components/content/ReviewSessionView')).then(m => ({ Component: m.ReviewSessionView })),
   },
+  {
+    // Fase 5 (v4.5.0): adaptive AI-driven flashcard session.
+    // Query params: topicId, courseId, topicTitle (set by FlashcardView).
+    path: 'adaptive-session',
+    lazy: () => lazyRetry(() => import('@/app/components/content/AdaptiveFlashcardView')).then(m => ({ Component: m.AdaptiveFlashcardView })),
+  },
   // Agent 3: agrega nuevas rutas de flashcard aqui
 ];


### PR DESCRIPTION
## Summary

Fase 5 (v4.5.0) of the adaptive flashcard flow was left half-finished: the `useAdaptiveSession` hook and the 8 screens under `flashcard/adaptive/` existed but had no consumer, and `FlashcardView` navigated to `/student/adaptive-session` — a route that was never registered, so the DeckScreen "Con IA" button 404'd.

This PR closes the loop:

- **AdaptiveFlashcardView** (`src/app/components/content/AdaptiveFlashcardView.tsx`) — new host component that parses `topicId`/`courseId`/`topicTitle` from URL params, loads professor cards via `getFlashcardsByTopic`, feeds them to `useAdaptiveSession`, and maps each phase (`idle`, `reviewing`, `generating`, `partial-summary`, `completed`) to its corresponding screen. Reuses `FlashcardSessionScreen` for the in-round review so the grade-mapping fix applies uniformly.
- **Route registration** (`flashcard-student-routes.ts`) — lazy-loaded `adaptive-session` path under the student segment.
- **P0 grade fix mirrored into `useAdaptiveSession.ts`** — `fix/flashcards-session-p0` added `smRatingToFsrsGrade` integration in `useFlashcardEngine`; that fix is NOT on `main` yet and the adaptive hook had the same bug. Applied the identical translation before handing the rating to `useReviewBatch.queueReview`.
- **Smoke test** (`src/__tests__/e2e-adaptive-flashcard-session.test.tsx`) — 6 cases covering load→idle, idle→startSession, phase-to-screen mapping for generating, back navigation, missing topic, fetch-error retry.
- **Hook test update** — `useAdaptiveSession` test expected `grade: 4` from a UI rating of 4; after the P0 fix it correctly receives `grade: 3` (SM-2 "Bien" → FSRS "Good"). Test aligned.

## Test plan

- [x] `npx vitest run src/__tests__/e2e-adaptive-flashcard-session.test.tsx` — 6 passed
- [x] `npx vitest run useAdaptiveSession flashcard adaptive` — 190 passed / 0 failed across 11 files
- [ ] `npm run build` — local build errored on an unrelated pre-existing environment issue (`@cloudflare/workerd-darwin-arm64` present instead of `windows-64`), blocking `vite.config.ts` from loading before any source compiles. Not caused by this PR. CI will validate on clean Linux runner.
- [ ] Manual: navigate to `/student/flashcards`, open a deck, click "Con IA" — should land on the idle landing instead of 404ing.

## Notes / caveats

- **Ownership edge case**: `useAdaptiveSession.ts` filename does not match the flashcards-frontend agent's glob (`useFlashcard*.ts` / `useReview*.ts`) nor contain "flashcard". The task explicitly directed me to apply the P0 fix there; flagging for the architect's awareness in case zone globs should be extended.
- **URL contract**: `FlashcardView.tsx:82-83` passes `topicId`, `courseId`, `topicTitle`. I intentionally did NOT add `cardCount`/`studentId` to the navigate — the view derives `cardCount` from the API fetch (which it must run anyway to populate `startSession`) and `studentId` from `useAuth()`. No mismatch; left `FlashcardView` untouched as the task required.
- **`mapApiCard` duplication**: the equivalent helper in `useFlashcardNavigation.ts` is module-private, so a local `mapItemToCard` is duplicated in `AdaptiveFlashcardView`. Could be extracted in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)