### PR TITLE
refactor(types): centralize CalendarEvent + rename mock collisions

### DIFF
--- a/src/app/components/calendar/CalendarView.tsx
+++ b/src/app/components/calendar/CalendarView.tsx
@@ -35,7 +35,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useSwipeable } from 'react-swipeable';
 
 import { useCalendarEvents } from '@/app/hooks/useCalendarEvents';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { useCalendarUI } from '@/app/hooks/useCalendarUI';
 import { useHeatmap } from '@/app/hooks/useHeatmap';
 import type { HeatmapLevel } from '@/app/lib/calendar-constants';

--- a/src/app/components/calendar/CountdownWidget.tsx
+++ b/src/app/components/calendar/CountdownWidget.tsx
@@ -14,7 +14,7 @@ import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { EVENT_COLORS, type EventType } from '@/app/lib/calendar-constants';
 import { cn } from '@/app/components/ui/utils';
 import { ExamPrepPanel } from './ExamPrepPanel';

--- a/src/app/components/calendar/DayCell.tsx
+++ b/src/app/components/calendar/DayCell.tsx
@@ -13,7 +13,7 @@
 import { useMemo } from 'react';
 import { ZINDEX, HEATMAP_CLASSES } from '@/app/lib/calendar-constants';
 import type { HeatmapLevel } from '@/app/lib/calendar-constants';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { cn } from '@/app/components/ui/utils';
 
 // ── Props ───────────────────────────────────────────────────

--- a/src/app/components/calendar/EventBadge.tsx
+++ b/src/app/components/calendar/EventBadge.tsx
@@ -13,7 +13,7 @@
 
 import { EVENT_COLORS } from '@/app/lib/calendar-constants';
 import type { EventType } from '@/app/lib/calendar-constants';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { useMediaQuery } from '@/app/hooks/useMediaQuery';
 
 // ── Props ───────────────────────────────────────────────────

--- a/src/app/components/calendar/ExamDetailsPanel.tsx
+++ b/src/app/components/calendar/ExamDetailsPanel.tsx
@@ -20,7 +20,7 @@ import { es } from 'date-fns/locale';
 
 import { useMediaQuery } from '@/app/hooks/useMediaQuery';
 import { createFocusManager } from '@/app/lib/calendar-focus';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { EVENT_COLORS, type EventType } from '@/app/lib/calendar-constants';
 import { cn } from '@/app/components/ui/utils';
 

--- a/src/app/components/calendar/ExamForm.tsx
+++ b/src/app/components/calendar/ExamForm.tsx
@@ -20,7 +20,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Trash2, Loader2 } from 'lucide-react';
 
 import { apiCall } from '@/app/lib/api';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';

--- a/src/app/components/calendar/WeekView.tsx
+++ b/src/app/components/calendar/WeekView.tsx
@@ -18,7 +18,7 @@ import {
 } from 'date-fns';
 import { es } from 'date-fns/locale';
 
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { cn } from '@/app/components/ui/utils';
 import { formatDateISO, getEventColor } from '@/app/lib/calendar-utils';
 

--- a/src/app/components/calendar/__tests__/CountdownWidget.test.tsx
+++ b/src/app/components/calendar/__tests__/CountdownWidget.test.tsx
@@ -5,7 +5,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { CountdownWidget } from '../CountdownWidget';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 // Mock ExamPrepPanel to avoid react-query dependency
 vi.mock('../ExamPrepPanel', () => ({

--- a/src/app/components/calendar/__tests__/DayCell.test.tsx
+++ b/src/app/components/calendar/__tests__/DayCell.test.tsx
@@ -5,7 +5,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DayCell } from '../DayCell';
 import type { DayCellProps } from '../DayCell';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 import { HEATMAP_CLASSES } from '@/app/lib/calendar-constants';
 import type { HeatmapLevel } from '@/app/lib/calendar-constants';
 

--- a/src/app/components/calendar/__tests__/EventBadge.test.tsx
+++ b/src/app/components/calendar/__tests__/EventBadge.test.tsx
@@ -4,7 +4,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { EventBadge, EventBadgeOverflow } from '../EventBadge';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 // ── Mock useMediaQuery (default: desktop) ───────────────────
 

--- a/src/app/components/calendar/__tests__/WeekView.test.tsx
+++ b/src/app/components/calendar/__tests__/WeekView.test.tsx
@@ -5,7 +5,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WeekView } from '../WeekView';
 import type { WeekViewProps } from '../WeekView';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 // ── Helpers ─────────────────────────────────────────────────
 

--- a/src/app/components/content/KnowledgeHeatmapView.tsx
+++ b/src/app/components/content/KnowledgeHeatmapView.tsx
@@ -23,7 +23,12 @@ import { AxonPageHeader } from '@/app/components/shared/AxonPageHeader';
 import { headingStyle, components, colors } from '@/app/design-system';
 import { MobileDrawer } from '@/app/components/layout/MobileDrawer';
 
-interface CalendarEvent {
+/**
+ * Local mock-data shape for the hardcoded CALENDAR_EVENTS array.
+ * NOT the canonical CalendarEvent (see `@/app/types/calendar`).
+ * This type represents a day slot in the mock UI skeleton.
+ */
+interface MockCalendarDayEvent {
   day: number;
   title: string;
   category: 'science' | 'arts' | 'core';
@@ -39,7 +44,7 @@ interface HeatLevel {
   level: 'high' | 'med' | 'none';
 }
 
-const CALENDAR_EVENTS: CalendarEvent[] = [
+const CALENDAR_EVENTS: MockCalendarDayEvent[] = [
   { day: 4, title: 'Fisiologia II', category: 'science', cards: 15 },
   { day: 6, title: 'Anatomia Patológica', category: 'arts', cards: 48, isUrgent: true, isDue: true },
   { day: 11, title: 'Fisiologia II', category: 'science', time: '10:00 - 11:30' },
@@ -173,7 +178,7 @@ export function KnowledgeHeatmapView() {
   const getEventsForDay = (day: number) => {
     const data = activityMap.get(day);
     const mockEvents = CALENDAR_EVENTS.filter(e => e.day === day);
-    if (isConnected && data && data.minutes > 0) { const realEvent: CalendarEvent = { day, title: `${data.sessions} sesión(es)`, category: 'core', cards: data.cards > 0 ? data.cards : undefined, noteText: `${data.minutes} min estudiados` }; return mockEvents.length > 0 ? mockEvents : [realEvent]; }
+    if (isConnected && data && data.minutes > 0) { const realEvent: MockCalendarDayEvent = { day, title: `${data.sessions} sesión(es)`, category: 'core', cards: data.cards > 0 ? data.cards : undefined, noteText: `${data.minutes} min estudiados` }; return mockEvents.length > 0 ? mockEvents : [realEvent]; }
     return mockEvents;
   };
 

--- a/src/app/components/content/MasteryDashboardView.tsx
+++ b/src/app/components/content/MasteryDashboardView.tsx
@@ -23,7 +23,12 @@ import { headingStyle, components, colors } from '@/app/design-system';
 import { MobileDrawer } from '@/app/components/layout/MobileDrawer';
 
 // Mock data
-interface CalendarEvent {
+/**
+ * Local mock-data shape for the hardcoded CALENDAR_EVENTS array.
+ * NOT the canonical CalendarEvent (see `@/app/types/calendar`).
+ * This type represents a day slot in the mock UI skeleton.
+ */
+interface MockCalendarDayEvent {
   day: number;
   title: string;
   category: 'science' | 'arts' | 'core';
@@ -31,7 +36,7 @@ interface CalendarEvent {
   hasReview?: boolean;
 }
 
-const CALENDAR_EVENTS: CalendarEvent[] = [
+const CALENDAR_EVENTS: MockCalendarDayEvent[] = [
   { day: 4, title: 'Fisiología II', category: 'science', time: '10:00 - 11:30' },
   { day: 6, title: 'Anatomía Patológica', category: 'arts', time: '14:00 - 15:30', hasReview: true },
   { day: 11, title: 'Fisiología II', category: 'science', time: '10:00 - 11:30' },

--- a/src/app/hooks/__tests__/useCalendarEvents.test.ts
+++ b/src/app/hooks/__tests__/useCalendarEvents.test.ts
@@ -9,13 +9,13 @@
 // ============================================================
 
 import { describe, it, expect } from 'vitest';
-import {
-  calendarKeys,
-  type CalendarEvent,
-  type HeatmapEntry,
-  type CalendarTask,
-  type CalendarData,
-} from '@/app/hooks/useCalendarEvents';
+import { calendarKeys } from '@/app/hooks/useCalendarEvents';
+import type {
+  CalendarEvent,
+  HeatmapEntry,
+  CalendarTask,
+  CalendarData,
+} from '@/app/types/calendar';
 
 describe('useCalendarEvents — query keys', () => {
   it('calendarKeys.data returns a tuple with correct structure', () => {

--- a/src/app/hooks/__tests__/useFinalsWeek.test.ts
+++ b/src/app/hooks/__tests__/useFinalsWeek.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useFinalsWeek, toISOWeekKey } from '@/app/hooks/useFinalsWeek';
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 // ── Fixture Helper ─────────────────────────────────────────────
 

--- a/src/app/hooks/__tests__/useHeatmap.test.ts
+++ b/src/app/hooks/__tests__/useHeatmap.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useHeatmap } from '@/app/hooks/useHeatmap';
-import type { HeatmapEntry } from '@/app/hooks/useCalendarEvents';
+import type { HeatmapEntry } from '@/app/types/calendar';
 
 describe('useHeatmap', () => {
   it('returns empty map and 0 streak for empty input', () => {

--- a/src/app/hooks/useCalendarEvents.ts
+++ b/src/app/hooks/useCalendarEvents.ts
@@ -14,42 +14,17 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { format } from 'date-fns';
 import { apiCall } from '@/app/lib/api';
+import type {
+  CalendarEvent,
+  HeatmapEntry,
+  CalendarTask,
+  CalendarData,
+} from '@/app/types/calendar';
 
-// ── Types ───────────────────────────────────────────────────
-
-export interface CalendarEvent {
-  id: string;
-  student_id: string;
-  course_id: string;
-  institution_id: string;
-  title: string;
-  date: string;          // ISO date string YYYY-MM-DD
-  time: string | null;
-  location: string | null;
-  is_final: boolean;
-  exam_type: string;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface HeatmapEntry {
-  date: string;          // ISO date string YYYY-MM-DD
-  minutes: number;       // Total study minutes for this day
-}
-
-export interface CalendarTask {
-  id: string;
-  student_id: string;
-  title: string;
-  scheduled_date: string;
-  status: string;
-}
-
-export interface CalendarData {
-  events: CalendarEvent[];
-  heatmap: HeatmapEntry[];
-  tasks: CalendarTask[];
-}
+// ── Types (canonical shapes live in @/app/types/calendar) ───
+// Re-exported here for backward compatibility with existing
+// consumers that import from '@/app/hooks/useCalendarEvents'.
+export type { CalendarEvent, HeatmapEntry, CalendarTask, CalendarData };
 
 // ── Query Key ───────────────────────────────────────────────
 

--- a/src/app/hooks/useFinalsWeek.ts
+++ b/src/app/hooks/useFinalsWeek.ts
@@ -11,7 +11,7 @@
 import { useMemo } from 'react';
 import { parseISO, getISOWeek, getISOWeekYear } from 'date-fns';
 
-import type { CalendarEvent } from '@/app/hooks/useCalendarEvents';
+import type { CalendarEvent } from '@/app/types/calendar';
 
 // ── Helpers ────────────────────────────────────────────────
 

--- a/src/app/hooks/useHeatmap.ts
+++ b/src/app/hooks/useHeatmap.ts
@@ -17,7 +17,7 @@ import {
   STREAK_THRESHOLD_MINUTES,
   type HeatmapLevel,
 } from '@/app/lib/calendar-constants';
-import type { HeatmapEntry } from '@/app/hooks/useCalendarEvents';
+import type { HeatmapEntry } from '@/app/types/calendar';
 
 // ── Types ───────────────────────────────────────────────────
 

--- a/src/app/types/calendar.ts
+++ b/src/app/types/calendar.ts
@@ -1,0 +1,48 @@
+// ============================================================
+// Axon — Calendar Types (canonical single source of truth)
+//
+// Canonical shapes for the student calendar domain. Consumed
+// by useCalendarEvents() and all calendar/* components. The
+// producer is GET /calendar/data (Supabase Edge Function).
+// ============================================================
+
+/** A scheduled exam/event returned by GET /calendar/data (DB-backed). */
+export interface CalendarEvent {
+  id: string;
+  student_id: string;
+  course_id: string;
+  institution_id: string;
+  title: string;
+  /** ISO date string YYYY-MM-DD */
+  date: string;
+  time: string | null;
+  location: string | null;
+  is_final: boolean;
+  exam_type: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Daily study-minutes entry for the calendar heatmap overlay. */
+export interface HeatmapEntry {
+  /** ISO date string YYYY-MM-DD */
+  date: string;
+  /** Total study minutes for this day */
+  minutes: number;
+}
+
+/** A scheduled student task (study plan / reminder) shown on the calendar. */
+export interface CalendarTask {
+  id: string;
+  student_id: string;
+  title: string;
+  scheduled_date: string;
+  status: string;
+}
+
+/** Unified payload returned by GET /calendar/data?from=&to=&types=all. */
+export interface CalendarData {
+  events: CalendarEvent[];
+  heatmap: HeatmapEntry[];
+  tasks: CalendarTask[];
+}

--- a/src/app/types/platform.ts
+++ b/src/app/types/platform.ts
@@ -205,8 +205,10 @@ export interface Topic {
 }
 
 // Canonical Summary type lives in summariesApi.ts (matches actual API response).
-// Re-exported here for backward compatibility.
-export type { Summary } from '@/app/services/summariesApi';
+// Imported locally so it can be referenced by ContentHierarchy below, and
+// re-exported for backward compatibility with consumers that import it from here.
+import type { Summary } from '@/app/services/summariesApi';
+export type { Summary };
 
 export interface Keyword {
   id: UUID;


### PR DESCRIPTION
## Summary
Centralizes `CalendarEvent` after discovering the audit's "3 duplicate definitions" were in fact **3 homonymous but structurally disjoint types**:

| Source | Shape | Use |
|---|---|---|
| `hooks/useCalendarEvents.ts` (producer) | `{id, student_id, course_id, institution_id, title, date: string (ISO), time, location, is_final, exam_type, created_at, updated_at}` | DB entity from `GET /calendar/data` |
| `KnowledgeHeatmapView.tsx` (mock) | `{day: number, title, category: 'science'\|'arts'\|'core', cards?, time?, isUrgent?, isDue?, noteText?}` | Hardcoded placeholder data |
| `MasteryDashboardView.tsx` (mock) | `{day: number, title, category: 'science'\|'arts'\|'core', time?, hasReview?}` | Hardcoded placeholder data |

The two mock shapes use `day: number` (1–31 index) and a fixed `category` enum; the producer uses `date: string` (ISO) and a DB-backed `exam_type`. **Zero field overlap** — unioning them would have created a meaningless junk type and broken type safety on the real consumers.

### Resolution
- New canonical file `src/app/types/calendar.ts` with the producer's shape + adjacent cluster (`HeatmapEntry`, `CalendarTask`, `CalendarData`) — `CalendarData.events: CalendarEvent[]` ties them together.
- Mock types renamed to `MockCalendarDayEvent` (file-scoped, not exported) with JSDoc clarifying they are NOT the canonical type.
- 21 files updated to import from `@/app/types/calendar`: producer hook, 2 consumer hooks (`useFinalsWeek`, `useHeatmap`), 7 calendar components, 6 test files, and the 2 mock-collision files.

### Bonus fix
`types/platform.ts:231` had a pre-existing `TS2304` because `Summary` was `export type { Summary } from '...'` (type-only re-export) but `ContentHierarchy.summaries: Summary[]` referenced it in a value position. Converted to `import type` + `export type` pattern. Baseline tsc count went 22212 → 22211.

### Note on Summary
`Summary` was **already SSOT** on main — canonical at `services/summariesApi.ts:24`, re-exported from `types/platform.ts`. The audit claim of 3 definitions was stale. No shape changes in this PR.

## Test plan
- [x] `tsc --noEmit` — zero new errors (22212 → 22211)
- [ ] `npm run build` — run in environment with `node_modules` installed
- [ ] Open `/student/calendar` → verify events load from producer
- [ ] Open Knowledge Heatmap → verify mock calendar grid renders
- [ ] Open Mastery Dashboard → verify mock calendar grid renders
- [ ] Run test suites: `hooks/__tests__/useCalendarEvents.test.ts`, `components/calendar/__tests__/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)