### PR TITLE
refactor(student): lift ViewerBlock annotation props to AnnotationContext

### DIFF
--- a/src/app/components/student/SummaryViewer.tsx
+++ b/src/app/components/student/SummaryViewer.tsx
@@ -29,6 +29,7 @@ import { BlockAnnotationsPanel } from './BlockAnnotationsPanel';
 import { BlockQuizModal } from './BlockQuizModal';
 import { useSummaryBlockMastery } from '@/app/hooks/queries/useSummaryBlockMastery';
 import { useCreateAnnotationMutation, useDeleteAnnotationMutation, useUpdateAnnotationMutation } from '@/app/hooks/queries/useAnnotationMutations';
+import { AnnotationProvider } from '@/app/context/AnnotationContext';
 import type { TextAnnotation } from '@/app/services/studentSummariesApi';
 
 // ── Props ─────────────────────────────────────────────────
@@ -194,64 +195,67 @@ export function SummaryViewer({ summaryId, blocks: prefetchedBlocks, onKeywordCl
         role="region"
         aria-label="Contenido del resumen"
       >
-        {sorted.map((block, idx) => {
-          const content = (
-            <motion.div
-              key={block.id}
-              data-block-id={block.id}
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: idx * 0.03 }}
-              aria-label={`Bloque ${block.type}`}
-              {...(layout === 'flow' ? { style: { marginBottom: 16 } } : {})}
-            >
-              <ViewerBlock
-                block={block}
-                isMobile={isMobile}
-                keywords={keywords}
-                masteryLevel={masteryLevels[block.id]}
-                summaryId={summaryId}
-                createAnnotationMutation={createAnnotationMutation}
-                deleteAnnotationMutation={deleteAnnotationMutation}
-                updateAnnotationMutation={updateAnnotationMutation}
-                annotations={annotations}
-                onImageClick={handleImageClick}
-                onKeywordClick={onKeywordClick}
-                onVideoPlay={(videoId) => setActiveVideoId(videoId)}
-                onBookmarkToggle={() => toggleBookmark(block.id)}
-                isBookmarked={isBookmarked(block.id)}
-                onNotesToggle={() => toggleAnnotations(block.id)}
-                onQuizTrigger={() => setQuizBlockId(block.id)}
-              />
-              {annotationsOpen[block.id] && (
-                <div className="mt-2">
-                  <BlockAnnotationsPanel blockId={block.id} summaryId={summaryId} />
-                </div>
-              )}
-            </motion.div>
-          );
+        <AnnotationProvider
+          summaryId={summaryId}
+          annotations={annotations}
+          createAnnotationMutation={createAnnotationMutation}
+          updateAnnotationMutation={updateAnnotationMutation}
+          deleteAnnotationMutation={deleteAnnotationMutation}
+        >
+          {sorted.map((block, idx) => {
+            const content = (
+              <motion.div
+                key={block.id}
+                data-block-id={block.id}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: idx * 0.03 }}
+                aria-label={`Bloque ${block.type}`}
+                {...(layout === 'flow' ? { style: { marginBottom: 16 } } : {})}
+              >
+                <ViewerBlock
+                  block={block}
+                  isMobile={isMobile}
+                  keywords={keywords}
+                  masteryLevel={masteryLevels[block.id]}
+                  onImageClick={handleImageClick}
+                  onKeywordClick={onKeywordClick}
+                  onVideoPlay={(videoId) => setActiveVideoId(videoId)}
+                  onBookmarkToggle={() => toggleBookmark(block.id)}
+                  isBookmarked={isBookmarked(block.id)}
+                  onNotesToggle={() => toggleAnnotations(block.id)}
+                  onQuizTrigger={() => setQuizBlockId(block.id)}
+                />
+                {annotationsOpen[block.id] && (
+                  <div className="mt-2">
+                    <BlockAnnotationsPanel blockId={block.id} summaryId={summaryId} />
+                  </div>
+                )}
+              </motion.div>
+            );
 
-          if (isMobile || layout === 'flow') {
-            return content;
-          }
+            if (isMobile || layout === 'flow') {
+              return content;
+            }
 
-          // Desktop: absolute positioned (canvas mode)
-          return (
-            <div
-              key={block.id}
-              className="absolute"
-              style={{
-                left: `${block.position_x || 0}px`,
-                top: `${block.position_y || 0}px`,
-                width: `${block.width || 300}px`,
-                // height auto for content blocks, fixed for images/videos
-                ...(block.type === 'divider' ? {} : {}),
-              }}
-            >
-              {content}
-            </div>
-          );
-        })}
+            // Desktop: absolute positioned (canvas mode)
+            return (
+              <div
+                key={block.id}
+                className="absolute"
+                style={{
+                  left: `${block.position_x || 0}px`,
+                  top: `${block.position_y || 0}px`,
+                  width: `${block.width || 300}px`,
+                  // height auto for content blocks, fixed for images/videos
+                  ...(block.type === 'divider' ? {} : {}),
+                }}
+              >
+                {content}
+              </div>
+            );
+          })}
+        </AnnotationProvider>
       </div>
 
       {/* ── Image Lightbox ───────────────────────────────── */}

--- a/src/app/components/student/ViewerBlock.tsx
+++ b/src/app/components/student/ViewerBlock.tsx
@@ -17,7 +17,7 @@ import type { HighlightColor } from './HighlightToolbar';
 import BookmarkButton from './BookmarkButton';
 import clsx from 'clsx';
 import type { SummaryBlock, SummaryKeyword } from '@/app/services/summariesApi';
-import type { TextAnnotation } from '@/app/services/studentSummariesApi';
+import { useAnnotations } from '@/app/context/AnnotationContext';
 import { sanitizeHtml } from '@/app/lib/sanitize';
 import { replaceKeywordPlaceholders } from './blocks/renderTextWithKeywords';
 import {
@@ -48,16 +48,9 @@ interface ViewerBlockProps {
   onNotesToggle?: () => void;
   /** Trigger quiz modal for this block */
   onQuizTrigger?: () => void;
-  /** Summary ID for text annotation persistence (highlighting) */
-  summaryId?: string;
-  /** Shared annotation mutation (lifted from parent to avoid N instances) */
-  createAnnotationMutation?: { mutate: Function; isPending?: boolean };
-  /** Shared delete mutation for removing individual annotations */
-  deleteAnnotationMutation?: { mutate: Function; isPending?: boolean };
-  /** Shared update mutation for editing annotation notes */
-  updateAnnotationMutation?: { mutate: Function; isPending?: boolean };
-  /** Text annotations for rendering highlights on this block */
-  annotations?: TextAnnotation[];
+  // NOTE: summaryId, annotations, and the three annotation mutations
+  // are no longer props — they come from <AnnotationProvider> via
+  // the `useAnnotations()` hook. See src/app/context/AnnotationContext.tsx.
 }
 
 // ── Callout icon map ──────────────────────────────────────
@@ -170,13 +163,19 @@ export const ViewerBlock = React.memo(function ViewerBlock({
   isBookmarked,
   onNotesToggle,
   onQuizTrigger,
-  summaryId,
-  createAnnotationMutation,
-  deleteAnnotationMutation,
-  updateAnnotationMutation,
-  annotations = [],
 }: ViewerBlockProps) {
   const c = block.content || {};
+
+  // ── Annotation context (null when no <AnnotationProvider> above) ──
+  // When null we render as a pure read-only block: no highlight
+  // toolbar, no footnotes, no note editor — identical behaviour to
+  // the old ViewerBlock when its annotation props were omitted.
+  const annotationCtx = useAnnotations();
+  const summaryId = annotationCtx?.summaryId;
+  const annotations = annotationCtx?.annotations ?? [];
+  const createAnnotationMutation = annotationCtx?.createAnnotationMutation;
+  const updateAnnotationMutation = annotationCtx?.updateAnnotationMutation;
+  const deleteAnnotationMutation = annotationCtx?.deleteAnnotationMutation;
 
   // Extract text for TTS (only for text-bearing blocks)
   const ttsText = extractBlockText(block);
@@ -288,7 +287,7 @@ export const ViewerBlock = React.memo(function ViewerBlock({
         block_id: block.id,
       },
       {
-        onSuccess: (created: any) => {
+        onSuccess: (created) => {
           window.getSelection()?.removeAllRanges();
           setToolbar(null);
           setSelectionRange(null);

--- a/src/app/context/AnnotationContext.tsx
+++ b/src/app/context/AnnotationContext.tsx
@@ -1,0 +1,99 @@
+// ============================================================
+// Axon — AnnotationContext (Student: text annotation mutations)
+//
+// Lifts the three annotation mutations (create / update / delete),
+// the `summaryId`, and the current `annotations` array out of
+// prop-drilling through ViewerBlock. SummaryViewer (or any other
+// consumer wanting shared mutation instances) wraps its subtree
+// with <AnnotationProvider> and ViewerBlock reads via
+// `useAnnotations()` — which returns `null` if no provider is
+// mounted, so rendering ViewerBlock standalone (tests, previews)
+// keeps working with zero annotation capability.
+// ============================================================
+import React, { createContext, useContext, useMemo } from 'react';
+import type {
+  useCreateAnnotationMutation,
+  useUpdateAnnotationMutation,
+  useDeleteAnnotationMutation,
+} from '@/app/hooks/queries/useAnnotationMutations';
+import type { TextAnnotation } from '@/app/services/studentSummariesApi';
+
+// ── Types ─────────────────────────────────────────────────
+// Pull the exact return types of each mutation hook so the
+// context is fully typed (no `Function`, no `any`). This gives
+// ViewerBlock real IntelliSense on `.mutate(...)` payloads.
+
+type CreateAnnotationMutation = ReturnType<typeof useCreateAnnotationMutation>;
+type UpdateAnnotationMutation = ReturnType<typeof useUpdateAnnotationMutation>;
+type DeleteAnnotationMutation = ReturnType<typeof useDeleteAnnotationMutation>;
+
+export interface AnnotationContextValue {
+  /** Summary the annotations belong to — required for create payloads. */
+  summaryId: string;
+  /** Current annotations for the summary (already-fetched by the parent). */
+  annotations: TextAnnotation[];
+  /** Shared create mutation (single instance for all blocks in the tree). */
+  createAnnotationMutation: CreateAnnotationMutation;
+  /** Shared update mutation for editing annotation notes / colors. */
+  updateAnnotationMutation: UpdateAnnotationMutation;
+  /** Shared delete mutation for removing individual annotations. */
+  deleteAnnotationMutation: DeleteAnnotationMutation;
+}
+
+const AnnotationContext = createContext<AnnotationContextValue | null>(null);
+
+// ── Provider ──────────────────────────────────────────────
+
+export interface AnnotationProviderProps {
+  summaryId: string;
+  annotations: TextAnnotation[];
+  createAnnotationMutation: CreateAnnotationMutation;
+  updateAnnotationMutation: UpdateAnnotationMutation;
+  deleteAnnotationMutation: DeleteAnnotationMutation;
+  children: React.ReactNode;
+}
+
+export function AnnotationProvider({
+  summaryId,
+  annotations,
+  createAnnotationMutation,
+  updateAnnotationMutation,
+  deleteAnnotationMutation,
+  children,
+}: AnnotationProviderProps) {
+  const value = useMemo<AnnotationContextValue>(
+    () => ({
+      summaryId,
+      annotations,
+      createAnnotationMutation,
+      updateAnnotationMutation,
+      deleteAnnotationMutation,
+    }),
+    [
+      summaryId,
+      annotations,
+      createAnnotationMutation,
+      updateAnnotationMutation,
+      deleteAnnotationMutation,
+    ],
+  );
+
+  return (
+    <AnnotationContext.Provider value={value}>
+      {children}
+    </AnnotationContext.Provider>
+  );
+}
+
+// ── Hook ──────────────────────────────────────────────────
+
+/**
+ * Read the annotation context. Returns `null` when no
+ * <AnnotationProvider> is mounted above — callers must treat
+ * this as "annotations are disabled" (render read-only, no
+ * highlight toolbar). This keeps ViewerBlock usable in isolated
+ * test / preview contexts without a provider.
+ */
+export function useAnnotations(): AnnotationContextValue | null {
+  return useContext(AnnotationContext);
+}


### PR DESCRIPTION
## Summary
Eliminates props drilling for annotation mutations by introducing `AnnotationContext` + `useAnnotations()` hook.

### Before → After
- `ViewerBlock` props: **14 → 9** (5 moved to context: `summaryId`, `annotations`, `createAnnotationMutation`, `updateAnnotationMutation`, `deleteAnnotationMutation`)
- Mutation instances per summary: 1 (unchanged — now via context)
- `Function` / `any` in ViewerBlock props: **3 → 0** (fully typed via `ReturnType<typeof useXMutation>`)

### Changes
- **NEW** `src/app/context/AnnotationContext.tsx` (99 LOC) — provider + `useAnnotations()` hook. Returns `null` when no provider above (preserves standalone render/test behavior — no mocking needed).
- `SummaryViewer.tsx` wraps the viewer loop in `<AnnotationProvider>`.
- `ViewerBlock.tsx` consumes context, dropped `(created: any)` cast.

## Test plan
- [x] 45/45 annotation-related tests pass (`ViewerBlock.integration.test.tsx`, `ViewerBlock.tts.test.tsx`, `useAnnotationMutations.test.ts`)
- [x] `vite build` succeeded (1m33s, full tsc via vite plugin, no type errors)
- [x] Public API unchanged (non-annotation props intact)
- [x] `EditableBlock.tsx` / `BlockEditor.tsx` (professor path) untouched — they never consumed these props

Part of issue #423 (split god components). 1/6 (StickyNotesPanel) done via PR #432. This is 2/6.

3 atomic commits: `b80237e3`, `e705c518`, `712600d7`.