### PR TITLE
refactor(content): slim StudentSummaryReader to 209 LOC composition shell

### DIFF
--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -1,9 +1,9 @@
 // Axon — StudentSummaryReader (read-only summary with student features)
 // Refactored (Phase C.1): state/effects extracted to useStudentSummaryReader hook.
 import React from 'react';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion } from 'motion/react';
 import {
-  Layers, Tag, Video as VideoIcon,
+  Tag, Video as VideoIcon,
   StickyNote, Minimize2,
 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
@@ -15,18 +15,9 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/ta
 import type { Summary } from '@/app/services/summariesApi';
 import type { ReadingState } from '@/app/services/studentSummariesApi';
 import { VideoPlayer } from '@/app/components/student/VideoPlayer';
-import {
-  PageNavigation,
-  CompletionCard,
-  XpToast,
-  proseClasses,
-} from '@/app/components/design-kit';
-import { KeywordHighlighterInline } from '@/app/components/student/KeywordHighlighterInline';
+import { XpToast } from '@/app/components/design-kit';
 import { SummaryReaderToolbar } from '@/app/components/student/SummaryReaderToolbar';
-
-// ── Extracted helpers (Phase B.1) ─────────────────────────
-import { renderPlainLine } from '@/app/lib/summary-content-helpers';
-import { sanitizeHtml } from '@/app/lib/sanitize';
+import { SummaryReaderBody } from '@/app/components/student/SummaryReaderBody';
 
 // ── Extracted atoms (Phase B.2) ───────────────────────────
 import { TabBadge } from '@/app/components/student/reader-atoms';
@@ -34,7 +25,6 @@ import { TabBadge } from '@/app/components/student/reader-atoms';
 // ── Extracted tab components (Phase B.4-B.5) ──────────────
 import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotationsTab';
 import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
-import { ReaderChunksTab } from '@/app/components/student/ReaderChunksTab';
 import { StudyTimer } from '@/app/components/student/StudyTimer';
 
 // ── Extracted state hook (Phase C.1) ──────────────────────
@@ -174,91 +164,26 @@ export function StudentSummaryReader({
         {s.showTimer && <StudyTimer onClose={() => s.setShowTimer(false)} />}
 
         {/* ── Main content area (white card) ── */}
-        <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-b-[20px] border-2 border-t-0 border-zinc-200 dark:border-[#2d2e34] shadow-sm overflow-hidden">
-
-          {/* ── Reading mode fallback when no content_markdown ── */}
-          {s.viewMode === 'reading' && !summary?.content_markdown && (
-            <p style={{ color: '#888', textAlign: 'center', padding: '2rem' }}>
-              Este resumen no tiene contenido en formato texto. Cambiando a modo enriquecido...
-            </p>
-          )}
-
-          {/* ── Reading mode: plain markdown ── */}
-          {s.viewMode === 'reading' && summary.content_markdown && (
-            <div
-              className="px-6 sm:px-8 py-8"
-              style={{
-                fontSize: `${s.readingSettings.fontSize}px`,
-                lineHeight: s.readingSettings.lineHeight,
-                fontFamily: s.readingSettings.fontFamily,
-              }}
-            >
-              <AnimatePresence mode="wait">
-                <motion.div
-                  key={s.safePage}
-                  initial={{ opacity: 0, x: 8 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: -8 }}
-                  transition={{ duration: 0.15 }}
-                >
-                  {s.isHtmlContent ? (
-                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={s.handleNavigateKeywordWrapped}>
-                      <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(s.htmlPages[s.safePage] || '') }} />
-                    </KeywordHighlighterInline>
-                  ) : (
-                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={s.handleNavigateKeywordWrapped}>
-                      <div className="axon-prose max-w-none">
-                        {s.textPages[s.safePage]?.map((line, i) => renderPlainLine(line, i))}
-                      </div>
-                    </KeywordHighlighterInline>
-                  )}
-                </motion.div>
-              </AnimatePresence>
-
-              {/* Pagination */}
-              {s.totalPages > 1 && (
-                <PageNavigation
-                  currentPage={s.safePage}
-                  totalPages={s.totalPages}
-                  onPrev={() => s.setContentPage(Math.max(0, s.safePage - 1))}
-                  onNext={() => s.setContentPage(Math.min(s.totalPages - 1, s.safePage + 1))}
-                  onPageClick={(i) => s.setContentPage(i)}
-                />
-              )}
-            </div>
-          )}
-
-          {/* ── Enriched mode: structured blocks ── */}
-          {s.viewMode === 'enriched' && (
-            <div className="py-4">
-              <ReaderChunksTab
-                summaryId={summary.id}
-                chunks={s.chunks}
-                chunksLoading={s.chunksLoading}
-                hasBlocks={s.hasBlocks}
-                blocksLoading={s.blocksLoading}
-                onNavigateKeyword={s.handleNavigateKeywordWrapped}
-                readingSettings={s.readingSettings}
-                keywords={s.keywords}
-                annotations={s.textAnnotations}
-              />
-            </div>
-          )}
-
-          {/* Completion card when read */}
-          {s.isCompleted && (
-            <div className="px-6 sm:px-8 pb-6">
-              <CompletionCard
-                title="Resumen completado!"
-                subtitle={`Has leido "${summary.title || 'este resumen'}"`}
-                xpEarned={15}
-                actions={[
-                  { label: `Flashcards`, icon: Layers, onClick: () => s.setActiveTab('keywords'), variant: 'secondary' },
-                ]}
-              />
-            </div>
-          )}
-        </div>
+        <SummaryReaderBody
+          summary={summary}
+          viewMode={s.viewMode}
+          readingSettings={s.readingSettings}
+          isHtmlContent={s.isHtmlContent}
+          htmlPages={s.htmlPages}
+          textPages={s.textPages}
+          safePage={s.safePage}
+          totalPages={s.totalPages}
+          setContentPage={s.setContentPage}
+          onNavigateKeyword={s.handleNavigateKeywordWrapped}
+          chunks={s.chunks}
+          chunksLoading={s.chunksLoading}
+          hasBlocks={s.hasBlocks}
+          blocksLoading={s.blocksLoading}
+          keywords={s.keywords}
+          annotations={s.textAnnotations}
+          isCompleted={s.isCompleted}
+          onGoToKeywordsTab={() => s.setActiveTab('keywords')}
+        />
 
         {/* ── Secondary tabs: Keywords, Videos, Notes (below content) ── */}
         <div className="mt-6">

--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -2,32 +2,19 @@
 // Refactored (Phase C.1): state/effects extracted to useStudentSummaryReader hook.
 import React from 'react';
 import { motion } from 'motion/react';
-import {
-  Tag, Video as VideoIcon,
-  StickyNote, Minimize2,
-} from 'lucide-react';
+import { Minimize2 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
 import { SidebarOutline } from '@/app/components/student/SidebarOutline';
 import { StickyNotesPanel } from '@/app/components/summary/StickyNotesPanel';
 import { MasteryLegend } from '@/app/components/student/MasteryLegend';
 import { SearchBar } from '@/app/components/student/SearchBar';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/tabs';
 import type { Summary } from '@/app/services/summariesApi';
 import type { ReadingState } from '@/app/services/studentSummariesApi';
-import { VideoPlayer } from '@/app/components/student/VideoPlayer';
 import { XpToast } from '@/app/components/design-kit';
 import { SummaryReaderToolbar } from '@/app/components/student/SummaryReaderToolbar';
 import { SummaryReaderBody } from '@/app/components/student/SummaryReaderBody';
-
-// ── Extracted atoms (Phase B.2) ───────────────────────────
-import { TabBadge } from '@/app/components/student/reader-atoms';
-
-// ── Extracted tab components (Phase B.4-B.5) ──────────────
-import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotationsTab';
-import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
+import { SummaryReaderBottomTabs } from '@/app/components/student/SummaryReaderBottomTabs';
 import { StudyTimer } from '@/app/components/student/StudyTimer';
-
-// ── Extracted state hook (Phase C.1) ──────────────────────
 import { useStudentSummaryReader } from '@/app/hooks/useStudentSummaryReader';
 
 // ── Props ─────────────────────────────────────────────────
@@ -186,63 +173,30 @@ export function StudentSummaryReader({
         />
 
         {/* ── Secondary tabs: Keywords, Videos, Notes (below content) ── */}
-        <div className="mt-6">
-          <Tabs value={s.activeTab} onValueChange={s.setActiveTab}>
-            <TabsList className="mb-4 bg-white dark:bg-[#1e1f25] border border-zinc-200 dark:border-[#2d2e34] rounded-xl p-1">
-              <TabsTrigger value="keywords" className="gap-1.5 rounded-lg">
-                <Tag className="w-3.5 h-3.5" />
-                <span lang="en">Keywords</span>
-                {!s.keywordsLoading && <TabBadge count={s.keywords.length} active={s.activeTab === 'keywords'} />}
-              </TabsTrigger>
-              <TabsTrigger value="videos" className="gap-1.5 rounded-lg">
-                <VideoIcon className="w-3.5 h-3.5" />
-                <span lang="en">Videos</span>
-                {!s.videosLoading && <TabBadge count={s.videosCount} active={s.activeTab === 'videos'} />}
-              </TabsTrigger>
-              <TabsTrigger value="annotations" className="gap-1.5 rounded-lg">
-                <StickyNote className="w-3.5 h-3.5" />
-                Mis Notas
-                {!s.annotationsLoading && s.textAnnotations.length > 0 && <TabBadge count={s.textAnnotations.length} active={s.activeTab === 'annotations'} />}
-              </TabsTrigger>
-            </TabsList>
-
-            {/* ── KEYWORDS TAB ── */}
-            <TabsContent value="keywords">
-              <ReaderKeywordsTab
-                keywords={s.keywords}
-                keywordsLoading={s.keywordsLoading}
-                expandedKeyword={s.expandedKeyword}
-                onToggleExpand={s.toggleKeywordExpand}
-                subtopics={s.subtopics}
-                subtopicsLoading={s.subtopicsLoading}
-                kwNotes={s.kwNotes}
-                kwNotesLoading={s.kwNotesLoading}
-                onCreateKwNote={s.handleCreateKwNote}
-                onUpdateKwNote={s.handleUpdateKwNote}
-                onDeleteKwNote={s.handleDeleteKwNote}
-                savingKwNote={s.savingKwNote}
-              />
-            </TabsContent>
-
-            {/* ── VIDEOS TAB ── */}
-            <TabsContent value="videos">
-              <div className="bg-white dark:bg-[#1e1f25] rounded-2xl border border-zinc-200 dark:border-[#2d2e34] overflow-hidden">
-                <VideoPlayer summaryId={summary.id} />
-              </div>
-            </TabsContent>
-
-            {/* ── ANNOTATIONS TAB ── */}
-            <TabsContent value="annotations">
-              <ReaderAnnotationsTab
-                annotations={s.textAnnotations}
-                annotationsLoading={s.annotationsLoading}
-                onCreateAnnotation={s.handleCreateAnnotation}
-                onDeleteAnnotation={s.handleDeleteAnnotation}
-                savingAnnotation={s.savingAnnotation}
-              />
-            </TabsContent>
-          </Tabs>
-        </div>
+        <SummaryReaderBottomTabs
+          summaryId={summary.id}
+          activeTab={s.activeTab}
+          onActiveTabChange={s.setActiveTab}
+          keywords={s.keywords}
+          keywordsLoading={s.keywordsLoading}
+          expandedKeyword={s.expandedKeyword}
+          onToggleExpand={s.toggleKeywordExpand}
+          subtopics={s.subtopics}
+          subtopicsLoading={s.subtopicsLoading}
+          kwNotes={s.kwNotes}
+          kwNotesLoading={s.kwNotesLoading}
+          onCreateKwNote={s.handleCreateKwNote}
+          onUpdateKwNote={s.handleUpdateKwNote}
+          onDeleteKwNote={s.handleDeleteKwNote}
+          savingKwNote={s.savingKwNote}
+          videosLoading={s.videosLoading}
+          videosCount={s.videosCount}
+          textAnnotations={s.textAnnotations}
+          annotationsLoading={s.annotationsLoading}
+          onCreateAnnotation={s.handleCreateAnnotation}
+          onDeleteAnnotation={s.handleDeleteAnnotation}
+          savingAnnotation={s.savingAnnotation}
+        />
         </div>{/* end flex-1 content wrapper */}
       </div>{/* end flex layout */}
     </motion.div>

--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -3,10 +3,8 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
-  ChevronLeft, Layers, Tag, Video as VideoIcon,
-  CheckCircle2, Clock, Loader2,
-  StickyNote, Search as SearchIcon,
-  Timer, Settings, PanelLeftOpen, Minimize2,
+  Layers, Tag, Video as VideoIcon,
+  StickyNote, Minimize2,
 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
 import { SidebarOutline } from '@/app/components/student/SidebarOutline';
@@ -24,8 +22,7 @@ import {
   proseClasses,
 } from '@/app/components/design-kit';
 import { KeywordHighlighterInline } from '@/app/components/student/KeywordHighlighterInline';
-import { ThemeToggle } from '@/app/components/student/ThemeToggle';
-import { colors } from '@/app/design-system';
+import { SummaryReaderToolbar } from '@/app/components/student/SummaryReaderToolbar';
 
 // ── Extracted helpers (Phase B.1) ─────────────────────────
 import { renderPlainLine } from '@/app/lib/summary-content-helpers';
@@ -39,7 +36,6 @@ import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotations
 import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
 import { ReaderChunksTab } from '@/app/components/student/ReaderChunksTab';
 import { StudyTimer } from '@/app/components/student/StudyTimer';
-import ReadingSettingsPanel from '@/app/components/student/ReadingSettingsPanel';
 
 // ── Extracted state hook (Phase C.1) ──────────────────────
 import { useStudentSummaryReader } from '@/app/hooks/useStudentSummaryReader';
@@ -73,21 +69,6 @@ export function StudentSummaryReader({
     onNavigateKeyword,
     initialTab,
   });
-
-  // ── Shared toolbar button style ──
-  const toolbarBtnStyle: React.CSSProperties = {
-    background: 'none',
-    border: 'none',
-    padding: 10,
-    cursor: 'pointer',
-    color: colors.reader.iconDefault,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: 44,
-    minHeight: 44,
-    borderRadius: 6,
-  };
 
   return (
     <>
@@ -166,142 +147,27 @@ export function StudentSummaryReader({
 
         {/* ── Compact header toolbar with title ── */}
         {!s.readingSettings.focusMode && (
-        <header
-          role="banner"
-          aria-label="Barra de herramientas del resumen"
-          className="flex items-center justify-between"
-          style={{
-            background: s.isDark ? colors.reader.headerBgDark : colors.reader.headerBg,
-            padding: '10px 20px',
-            position: 'sticky',
-            top: 0,
-            zIndex: 100,
-            borderBottom: s.isDark ? '1px solid #2d2e34' : '1px solid transparent',
-            borderRadius: '12px 12px 0 0',
-          }}
-        >
-          {/* Left side: back + title */}
-          <div className="flex items-center min-w-0" style={{ gap: 10 }}>
-            <button
-              onClick={onBack}
-              aria-label="Volver a resúmenes"
-              style={{ ...toolbarBtnStyle, flexShrink: 0 }}
-            >
-              <ChevronLeft size={20} />
-            </button>
-            <div className="min-w-0">
-              <h1
-                className="truncate"
-                style={{
-                  fontSize: 15,
-                  fontWeight: 700,
-                  color: '#fff',
-                  fontFamily: 'Georgia, serif',
-                  lineHeight: 1.2,
-                  margin: 0,
-                }}
-              >
-                {summary.title || 'Sin título'}
-              </h1>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span style={{ color: colors.reader.iconSubtle, fontSize: 11 }}>
-                  {new Date(summary.created_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' })}
-                </span>
-                {readingState?.time_spent_seconds != null && readingState.time_spent_seconds > 0 && (
-                  <span className="flex items-center gap-1" style={{ color: colors.reader.iconSubtle, fontSize: 11 }}>
-                    <Clock className="w-3 h-3" />
-                    {Math.round(readingState.time_spent_seconds / 60)} min
-                  </span>
-                )}
-                {s.isCompleted && (
-                  <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ fontSize: 10, fontWeight: 600, background: 'rgba(16,185,129,0.2)', color: colors.reader.iconActive }}>
-                    <CheckCircle2 className="w-2.5 h-2.5" /> Leído
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Right side: tool icons */}
-          <div className="flex items-center" style={{ gap: 6 }}>
-            {/* Mark complete */}
-            <button
-              onClick={s.isCompleted ? s.handleUnmarkCompleted : s.handleMarkCompleted}
-              disabled={s.markingRead}
-              title={s.isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
-              aria-label={s.isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
-              style={{
-                background: s.isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
-                border: 'none',
-                padding: 6,
-                cursor: 'pointer',
-                color: s.isCompleted ? colors.reader.iconActive : colors.reader.iconDefault,
-                display: 'flex',
-                borderRadius: 6,
-              }}
-            >
-              {s.markingRead ? <Loader2 size={16} className="animate-spin" /> : <CheckCircle2 size={16} />}
-            </button>
-
-            {/* Search toggle */}
-            <button
-              onClick={() => s.setSearchOpen((v) => !v)}
-              title="Buscar (Ctrl+F)"
-              aria-label="Buscar"
-              style={{ ...toolbarBtnStyle, background: s.searchOpen ? 'rgba(42,140,122,0.15)' : 'none', color: s.searchOpen ? '#2a8c7a' : colors.reader.iconDefault }}
-            >
-              <SearchIcon size={16} />
-            </button>
-
-            {/* Timer toggle */}
-            <button
-              onClick={() => s.setShowTimer((prev) => !prev)}
-              title="Temporizador de estudio"
-              aria-label={s.showTimer ? 'Cerrar timer' : 'Abrir timer'}
-              style={{ ...toolbarBtnStyle, background: s.showTimer ? 'rgba(42,140,122,0.15)' : 'none', color: s.showTimer ? '#2a8c7a' : colors.reader.iconDefault }}
-            >
-              <Timer size={16} />
-            </button>
-
-            {/* Separator */}
-            <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
-
-            {/* Theme toggle */}
-            <ThemeToggle isDark={s.isDark} onToggle={s.toggleTheme} />
-
-            {/* Settings toggle */}
-            <div className="relative">
-              <button
-                onClick={() => s.setShowSettings((prev) => !prev)}
-                title="Configuración de lectura"
-                aria-label={s.showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
-                style={{ ...toolbarBtnStyle, background: s.showSettings ? 'rgba(42,140,122,0.15)' : 'none', color: s.showSettings ? '#2a8c7a' : colors.reader.iconDefault }}
-              >
-                <Settings size={16} />
-              </button>
-              {s.showSettings && (
-                <ReadingSettingsPanel
-                  settings={s.readingSettings}
-                  onChange={s.updateReadingSettings}
-                  onClose={() => s.setShowSettings(false)}
-                />
-              )}
-            </div>
-
-            {/* Separator */}
-            <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
-
-            {/* Sidebar toggle */}
-            <button
-              onClick={() => s.setSidebarCollapsed((v) => !v)}
-              title="Outline"
-              aria-label={s.sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
-              style={{ ...toolbarBtnStyle, background: !s.sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none', color: !s.sidebarCollapsed ? '#2a8c7a' : colors.reader.iconDefault }}
-            >
-              <PanelLeftOpen size={16} />
-            </button>
-          </div>
-        </header>
+          <SummaryReaderToolbar
+            summary={summary}
+            readingState={readingState}
+            isDark={s.isDark}
+            isCompleted={s.isCompleted}
+            markingRead={s.markingRead}
+            searchOpen={s.searchOpen}
+            showTimer={s.showTimer}
+            showSettings={s.showSettings}
+            sidebarCollapsed={s.sidebarCollapsed}
+            readingSettings={s.readingSettings}
+            onBack={onBack}
+            onToggleRead={s.isCompleted ? s.handleUnmarkCompleted : s.handleMarkCompleted}
+            onToggleSearch={() => s.setSearchOpen((v) => !v)}
+            onToggleTimer={() => s.setShowTimer((prev) => !prev)}
+            onToggleTheme={s.toggleTheme}
+            onToggleSettings={() => s.setShowSettings((prev) => !prev)}
+            onCloseSettings={() => s.setShowSettings(false)}
+            onToggleSidebar={() => s.setSidebarCollapsed((v) => !v)}
+            onUpdateReadingSettings={s.updateReadingSettings}
+          />
         )}
 
         {/* ── Study Timer (fixed position, self-managed) ── */}

--- a/src/app/components/content/StudentSummaryReader.tsx
+++ b/src/app/components/content/StudentSummaryReader.tsx
@@ -1,11 +1,11 @@
 // Axon — StudentSummaryReader (read-only summary with student features)
-// Refactored (Phase B): mutations hook, helpers, tab sub-components, keyword page nav hook.
-import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+// Refactored (Phase C.1): state/effects extracted to useStudentSummaryReader hook.
+import React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   ChevronLeft, Layers, Tag, Video as VideoIcon,
   CheckCircle2, Clock, Loader2,
-  StickyNote, BookOpen, Search as SearchIcon,
+  StickyNote, Search as SearchIcon,
   Timer, Settings, PanelLeftOpen, Minimize2,
 } from 'lucide-react';
 import { ReadingProgress } from '@/app/components/student/ReadingProgress';
@@ -17,47 +17,32 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/ta
 import type { Summary } from '@/app/services/summariesApi';
 import type { ReadingState } from '@/app/services/studentSummariesApi';
 import { VideoPlayer } from '@/app/components/student/VideoPlayer';
-import { useSummaryReaderQueries } from '@/app/hooks/queries/useSummaryReaderQueries';
-import { useKeywordDetailQueries } from '@/app/hooks/queries/useKeywordDetailQueries';
-import { useSummaryReaderMutations } from '@/app/hooks/queries/useSummaryReaderMutations';
-import { useSummaryBlockMastery } from '@/app/hooks/queries/useSummaryBlockMastery';
 import {
   PageNavigation,
   CompletionCard,
   XpToast,
-  focusRing,
   proseClasses,
 } from '@/app/components/design-kit';
 import { KeywordHighlighterInline } from '@/app/components/student/KeywordHighlighterInline';
-import { useReadingTimeTracker } from '@/app/hooks/useReadingTimeTracker';
-import { useScrollPositionSave } from '@/app/hooks/useScrollPositionSave';
-import { useScrollPositionRestore } from '@/app/hooks/useScrollPositionRestore';
-import { useVideoListQuery } from '@/app/hooks/queries/useVideoPlayerQueries';
-import { useThemeToggle } from '@/app/hooks/useThemeToggle';
 import { ThemeToggle } from '@/app/components/student/ThemeToggle';
 import { colors } from '@/app/design-system';
 
 // ── Extracted helpers (Phase B.1) ─────────────────────────
-import {
-  CONTENT_PAGE_SIZE,
-  enrichHtmlWithImages,
-  paginateHtml,
-  paginateLines,
-  renderPlainLine,
-} from '@/app/lib/summary-content-helpers';
+import { renderPlainLine } from '@/app/lib/summary-content-helpers';
 import { sanitizeHtml } from '@/app/lib/sanitize';
 
 // ── Extracted atoms (Phase B.2) ───────────────────────────
-import { ListSkeleton, TabBadge } from '@/app/components/student/reader-atoms';
+import { TabBadge } from '@/app/components/student/reader-atoms';
 
 // ── Extracted tab components (Phase B.4-B.5) ──────────────
 import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotationsTab';
 import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
 import { ReaderChunksTab } from '@/app/components/student/ReaderChunksTab';
 import { StudyTimer } from '@/app/components/student/StudyTimer';
-import ReadingSettingsPanel, { useReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
-import { useSummaryBlocksQuery } from '@/app/hooks/queries/useSummaryBlocksQuery';
-import { useKeywordPageNavigation } from '@/app/hooks/useKeywordPageNavigation';
+import ReadingSettingsPanel from '@/app/components/student/ReadingSettingsPanel';
+
+// ── Extracted state hook (Phase C.1) ──────────────────────
+import { useStudentSummaryReader } from '@/app/hooks/useStudentSummaryReader';
 
 // ── Props ─────────────────────────────────────────────────
 interface StudentSummaryReaderProps {
@@ -81,249 +66,13 @@ export function StudentSummaryReader({
   onNavigateKeyword,
   initialTab,
 }: StudentSummaryReaderProps) {
-  const [activeTab, setActiveTab] = useState(initialTab || 'keywords');
-  const readerRef = useRef<HTMLDivElement>(null);
-  const { isDark, toggle: toggleTheme } = useThemeToggle(readerRef);
-  const [showTimer, setShowTimer] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
-  const { settings: readingSettings, update: updateReadingSettings } = useReadingSettings();
-
-  // ── Wave 1: Sidebar, search, reading progress ─────────
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth < 1280 : true
-  );
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
-
-  // ── Scroll position restore (must be before state init) ──
-  const { initialViewMode, initialContentPage, restoreScroll } = useScrollPositionRestore(
-    summary.id,
-    readingState?.scroll_position ?? null,
-  );
-
-  /** View mode: 'enriched' shows structured blocks, 'reading' shows plain markdown */
-  const [viewMode, setViewMode] = useState<'enriched' | 'reading'>(initialViewMode ?? 'enriched');
-
-  // Auto-switch to enriched if reading mode selected but no content_markdown
-  useEffect(() => {
-    if (viewMode === 'reading' && !summary?.content_markdown) {
-      const timer = setTimeout(() => setViewMode('enriched'), 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [viewMode, summary?.content_markdown]);
-
-  // ── Content pagination ──────────────────────────────────
-  const [contentPage, setContentPage] = useState(initialContentPage ?? 0);
-
-  // ── React Query: 4 initial fetches ──────────────────────
-  const {
-    chunks, chunksLoading,
-    keywords, keywordsLoading,
-    textAnnotations, annotationsLoading,
-    hasBlocks, blocksLoading,
-    invalidateAnnotations,
-  } = useSummaryReaderQueries(summary.id);
-
-  // ── Blocks for sidebar outline (shared cache — no extra fetch) ──
-  const { data: sidebarBlocks = [] } = useSummaryBlocksQuery(summary.id);
-
-  // ── Block mastery levels (Delta scale) ──
-  const { data: masteryLevels = {} } = useSummaryBlockMastery(summary.id);
-
-  // ── Scroll-spy: track which block is currently visible ──
-  useEffect(() => {
-    if (!sidebarBlocks.length) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setActiveBlockId(entry.target.getAttribute('data-block-id'));
-          }
-        }
-      },
-      { rootMargin: '-20% 0px -60% 0px', threshold: 0 },
-    );
-    const elements = document.querySelectorAll('[data-block-id]');
-    elements.forEach((el) => observer.observe(el));
-    return () => observer.disconnect();
-  }, [sidebarBlocks, activeTab]);
-
-  // ── Suppress browser native scroll restoration ──
-  useEffect(() => {
-    if ('scrollRestoration' in history) {
-      history.scrollRestoration = 'manual';
-    }
-    return () => {
-      if ('scrollRestoration' in history) {
-        history.scrollRestoration = 'auto';
-      }
-    };
-  }, []);
-
-  // ── Restore scroll position after content loads ──
-  useEffect(() => {
-    if (!blocksLoading && !chunksLoading) {
-      restoreScroll(readerRef);
-    }
-  }, [blocksLoading, chunksLoading, restoreScroll]);
-
-  // ── Sidebar block click → scroll into view ──
-  const handleSidebarBlockClick = useCallback((blockId: string) => {
-    const scrollToBlock = () => {
-      requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-block-id="${blockId}"]`);
-        if (el) {
-          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          setActiveBlockId(blockId);
-        }
-      });
-    };
-
-    if (viewMode === 'reading') {
-      setViewMode('enriched');
-      // Double rAF ensures React has flushed the DOM update
-      requestAnimationFrame(() => scrollToBlock());
-      return;
-    }
-    scrollToBlock();
-  }, [viewMode]);
-
-  // ── Search: count matches in blocks ──
-  const searchResultCount = useMemo(() => {
-    if (!searchQuery.trim()) return 0;
-    const q = searchQuery.toLowerCase();
-    return sidebarBlocks.filter((b) => {
-      const c = b.content || {};
-      const text = [c.title, c.text, c.label, c.html, c.description]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
-      return text.includes(q);
-    }).length;
-  }, [searchQuery, sidebarBlocks]);
-
-  // ── Keyboard shortcuts (Ctrl+F, Ctrl+Shift+F, Escape) ──
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'F') {
-        e.preventDefault();
-        updateReadingSettings({ ...readingSettings, focusMode: !readingSettings.focusMode });
-        return;
-      }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
-        e.preventDefault();
-        setSearchOpen(true);
-      }
-      if (e.key === 'Escape') {
-        if (readingSettings.focusMode) {
-          updateReadingSettings({ ...readingSettings, focusMode: false });
-          return;
-        }
-        setSearchOpen(false);
-        setSearchQuery('');
-        setShowSettings(false);
-        setShowTimer(false);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [readingSettings, updateReadingSettings]);
-
-  // ── Memoized pagination + keyword-to-page map ───────────
-  const { isHtmlContent, htmlPages, textPages, totalPages } = useMemo(() => {
-    if (!summary.content_markdown) {
-      return { isHtmlContent: false, htmlPages: [] as string[], textPages: [] as string[][], totalPages: 0 };
-    }
-    const isHtml = /<[a-z][\s\S]*>/i.test(summary.content_markdown);
-    const enriched = isHtml ? enrichHtmlWithImages(summary.content_markdown) : '';
-    const html = isHtml ? paginateHtml(enriched, CONTENT_PAGE_SIZE) : [];
-    const text = !isHtml ? paginateLines(summary.content_markdown, 45) : [];
-    return {
-      isHtmlContent: isHtml,
-      htmlPages: html,
-      textPages: text,
-      totalPages: isHtml ? html.length : text.length,
-    };
-  }, [summary.content_markdown]);
-
-  const safePage = Math.min(contentPage, Math.max(0, totalPages - 1));
-
-  // MEJORA-P1: Cross-page keyword navigation (extracted hook)
-  const { handleNavigateKeyword: handleNavigateKeywordWrapped } = useKeywordPageNavigation({
-    summaryId: summary.id,
-    keywords,
-    isHtmlContent,
-    htmlPages,
-    textPages,
-    totalPages,
-    safePage,
-    contentPage,
-    setContentPage,
-    onNavigateKeyword,
-  });
-
-  // ── Keywords: React Query on-demand (cache per keywordId) ──
-  const [expandedKeyword, setExpandedKeyword] = useState<string | null>(null);
-  const {
-    subtopics, subtopicsLoading,
-    kwNotes, kwNotesLoading,
-    invalidateKwNotes,
-  } = useKeywordDetailQueries(expandedKeyword);
-
-  // ── Videos ──────────────────────────────────────────────
-  const { data: videos, isLoading: videosLoading } = useVideoListQuery(summary.id);
-  const videosCount = videos?.length || 0;
-
-  // ── Scroll position save ────────────────────────────────
-  const { getScrollPercentage } = useScrollPositionSave(
-    summary.id,
-    activeBlockId,
-    viewMode,
-    contentPage,
-  );
-
-  // ── Reading time tracking (+ scroll position piggyback) ─
-  const { snapshotForExternalSave } = useReadingTimeTracker(
-    summary.id,
-    readingState?.time_spent_seconds ?? 0,
-    () => getScrollPercentage(readerRef),
-  );
-
-  // ── Mutations hook (Phase B.3) ──────────────────────────
-  // Replaces 7 inline useMutation + 6 handlers + 3 derived flags + showXpToast
-  const {
-    handleMarkCompleted,
-    handleUnmarkCompleted,
-    handleCreateAnnotation,
-    handleDeleteAnnotation,
-    handleCreateKwNote,
-    handleUpdateKwNote,
-    handleDeleteKwNote,
-    markingRead,
-    savingAnnotation,
-    savingKwNote,
-    showXpToast,
-  } = useSummaryReaderMutations({
-    summaryId: summary.id,
-    topicId: summary.topic_id,
-    snapshotForExternalSave,
+  const s = useStudentSummaryReader({
+    summary,
+    readingState,
     onReadingStateChanged,
-    invalidateAnnotations,
-    invalidateKwNotes,
-    // Form state reset callbacks — sub-components handle their own form state
-    onAnnotationCreated: () => {},
-    onKwNoteCreated: () => {},
-    onKwNoteUpdated: () => {},
+    onNavigateKeyword,
+    initialTab,
   });
-
-  const toggleKeywordExpand = (keywordId: string) => {
-    if (expandedKeyword === keywordId) { setExpandedKeyword(null); } else {
-      setExpandedKeyword(keywordId);
-    }
-  };
-
-  const isCompleted = readingState?.completed === true;
 
   // ── Shared toolbar button style ──
   const toolbarBtnStyle: React.CSSProperties = {
@@ -343,10 +92,10 @@ export function StudentSummaryReader({
   return (
     <>
     <motion.div
-      ref={readerRef}
+      ref={s.readerRef}
       initial={{ opacity: 0, x: 10 }}
       animate={{ opacity: 1, x: 0 }}
-      className={`axon-reader overflow-y-auto ${isDark ? 'bg-[#111215]' : 'bg-[#F0F2F5]'}`}
+      className={`axon-reader overflow-y-auto ${s.isDark ? 'bg-[#111215]' : 'bg-[#F0F2F5]'}`}
       style={{ minHeight: '100vh' }}
     >
       {/* ── Skip to content link (a11y) ── */}
@@ -359,25 +108,25 @@ export function StudentSummaryReader({
       </a>
 
       {/* ── Reading progress bar (Wave 1) ── */}
-      <ReadingProgress containerRef={readerRef} />
+      <ReadingProgress containerRef={s.readerRef} />
 
       {/* XP Toast */}
-      <XpToast amount={15} show={showXpToast} />
+      <XpToast amount={15} show={s.showXpToast} />
 
       {/* ── Search bar (Wave 1) ── */}
-      {searchOpen && (
+      {s.searchOpen && (
         <SearchBar
-          query={searchQuery}
-          onQueryChange={setSearchQuery}
-          resultCount={searchResultCount}
-          onClose={() => { setSearchOpen(false); setSearchQuery(''); }}
+          query={s.searchQuery}
+          onQueryChange={s.setSearchQuery}
+          resultCount={s.searchResultCount}
+          onClose={() => { s.setSearchOpen(false); s.setSearchQuery(''); }}
         />
       )}
 
       {/* ── Focus mode floating exit button ── */}
-      {readingSettings.focusMode && (
+      {s.readingSettings.focusMode && (
         <button
-          onClick={() => updateReadingSettings({ ...readingSettings, focusMode: false })}
+          onClick={() => s.updateReadingSettings({ ...s.readingSettings, focusMode: false })}
           title="Salir de modo enfocado (Esc)"
           aria-label="Salir de modo enfocado"
           className="fixed top-5 right-5 z-[500] flex items-center gap-2 px-4 py-2 rounded-full bg-teal-500 hover:bg-teal-600 text-white shadow-lg hover:shadow-xl transition-all"
@@ -388,25 +137,24 @@ export function StudentSummaryReader({
         </button>
       )}
 
-      <div className="flex mx-auto p-6 sm:p-8 gap-6" style={{ maxWidth: readingSettings.focusMode ? 768 : 1100 }}>
+      <div className="flex mx-auto p-6 sm:p-8 gap-6" style={{ maxWidth: s.readingSettings.focusMode ? 768 : 1100 }}>
         {/* ── Sidebar outline (Wave 1) — hidden in focus mode ── */}
-        {/* Wrapper is relative so expanded sidebar overlays from its own position */}
-        {!readingSettings.focusMode && sidebarBlocks.length > 0 && (
+        {!s.readingSettings.focusMode && s.sidebarBlocks.length > 0 && (
           <div className="relative" style={{ width: 52, flexShrink: 0 }}>
             <SidebarOutline
-              blocks={sidebarBlocks}
-              activeBlockId={activeBlockId}
-              onBlockClick={handleSidebarBlockClick}
-              collapsed={sidebarCollapsed}
-              onToggleCollapse={() => setSidebarCollapsed((v) => !v)}
-              masteryLevels={masteryLevels}
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
+              blocks={s.sidebarBlocks}
+              activeBlockId={s.activeBlockId}
+              onBlockClick={s.handleSidebarBlockClick}
+              collapsed={s.sidebarCollapsed}
+              onToggleCollapse={() => s.setSidebarCollapsed((v) => !v)}
+              masteryLevels={s.masteryLevels}
+              viewMode={s.viewMode}
+              onViewModeChange={s.setViewMode}
               masteryLegend={
-                Object.keys(masteryLevels).length > 0 ? (
+                Object.keys(s.masteryLevels).length > 0 ? (
                   <MasteryLegend
-                    masteryLevels={masteryLevels}
-                    totalBlocks={sidebarBlocks.length}
+                    masteryLevels={s.masteryLevels}
+                    totalBlocks={s.sidebarBlocks.length}
                   />
                 ) : undefined
               }
@@ -414,21 +162,21 @@ export function StudentSummaryReader({
           </div>
         )}
 
-        <div id="reader-main-content" tabIndex={-1} className={`flex-1 min-w-0 transition-all duration-200 ${readingSettings.focusMode ? 'mx-auto' : ''}`} style={{ maxWidth: readingSettings.focusMode ? 680 : 800 }}>
+        <div id="reader-main-content" tabIndex={-1} className={`flex-1 min-w-0 transition-all duration-200 ${s.readingSettings.focusMode ? 'mx-auto' : ''}`} style={{ maxWidth: s.readingSettings.focusMode ? 680 : 800 }}>
 
         {/* ── Compact header toolbar with title ── */}
-        {!readingSettings.focusMode && (
+        {!s.readingSettings.focusMode && (
         <header
           role="banner"
           aria-label="Barra de herramientas del resumen"
           className="flex items-center justify-between"
           style={{
-            background: isDark ? colors.reader.headerBgDark : colors.reader.headerBg,
+            background: s.isDark ? colors.reader.headerBgDark : colors.reader.headerBg,
             padding: '10px 20px',
             position: 'sticky',
             top: 0,
             zIndex: 100,
-            borderBottom: isDark ? '1px solid #2d2e34' : '1px solid transparent',
+            borderBottom: s.isDark ? '1px solid #2d2e34' : '1px solid transparent',
             borderRadius: '12px 12px 0 0',
           }}
         >
@@ -465,7 +213,7 @@ export function StudentSummaryReader({
                     {Math.round(readingState.time_spent_seconds / 60)} min
                   </span>
                 )}
-                {isCompleted && (
+                {s.isCompleted && (
                   <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ fontSize: 10, fontWeight: 600, background: 'rgba(16,185,129,0.2)', color: colors.reader.iconActive }}>
                     <CheckCircle2 className="w-2.5 h-2.5" /> Leído
                   </span>
@@ -478,39 +226,39 @@ export function StudentSummaryReader({
           <div className="flex items-center" style={{ gap: 6 }}>
             {/* Mark complete */}
             <button
-              onClick={isCompleted ? handleUnmarkCompleted : handleMarkCompleted}
-              disabled={markingRead}
-              title={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
-              aria-label={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
+              onClick={s.isCompleted ? s.handleUnmarkCompleted : s.handleMarkCompleted}
+              disabled={s.markingRead}
+              title={s.isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
+              aria-label={s.isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
               style={{
-                background: isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
+                background: s.isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
                 border: 'none',
                 padding: 6,
                 cursor: 'pointer',
-                color: isCompleted ? colors.reader.iconActive : colors.reader.iconDefault,
+                color: s.isCompleted ? colors.reader.iconActive : colors.reader.iconDefault,
                 display: 'flex',
                 borderRadius: 6,
               }}
             >
-              {markingRead ? <Loader2 size={16} className="animate-spin" /> : <CheckCircle2 size={16} />}
+              {s.markingRead ? <Loader2 size={16} className="animate-spin" /> : <CheckCircle2 size={16} />}
             </button>
 
             {/* Search toggle */}
             <button
-              onClick={() => setSearchOpen((v) => !v)}
+              onClick={() => s.setSearchOpen((v) => !v)}
               title="Buscar (Ctrl+F)"
               aria-label="Buscar"
-              style={{ ...toolbarBtnStyle, background: searchOpen ? 'rgba(42,140,122,0.15)' : 'none', color: searchOpen ? '#2a8c7a' : colors.reader.iconDefault }}
+              style={{ ...toolbarBtnStyle, background: s.searchOpen ? 'rgba(42,140,122,0.15)' : 'none', color: s.searchOpen ? '#2a8c7a' : colors.reader.iconDefault }}
             >
               <SearchIcon size={16} />
             </button>
 
             {/* Timer toggle */}
             <button
-              onClick={() => setShowTimer((prev) => !prev)}
+              onClick={() => s.setShowTimer((prev) => !prev)}
               title="Temporizador de estudio"
-              aria-label={showTimer ? 'Cerrar timer' : 'Abrir timer'}
-              style={{ ...toolbarBtnStyle, background: showTimer ? 'rgba(42,140,122,0.15)' : 'none', color: showTimer ? '#2a8c7a' : colors.reader.iconDefault }}
+              aria-label={s.showTimer ? 'Cerrar timer' : 'Abrir timer'}
+              style={{ ...toolbarBtnStyle, background: s.showTimer ? 'rgba(42,140,122,0.15)' : 'none', color: s.showTimer ? '#2a8c7a' : colors.reader.iconDefault }}
             >
               <Timer size={16} />
             </button>
@@ -519,23 +267,23 @@ export function StudentSummaryReader({
             <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
 
             {/* Theme toggle */}
-            <ThemeToggle isDark={isDark} onToggle={toggleTheme} />
+            <ThemeToggle isDark={s.isDark} onToggle={s.toggleTheme} />
 
             {/* Settings toggle */}
             <div className="relative">
               <button
-                onClick={() => setShowSettings((prev) => !prev)}
+                onClick={() => s.setShowSettings((prev) => !prev)}
                 title="Configuración de lectura"
-                aria-label={showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
-                style={{ ...toolbarBtnStyle, background: showSettings ? 'rgba(42,140,122,0.15)' : 'none', color: showSettings ? '#2a8c7a' : colors.reader.iconDefault }}
+                aria-label={s.showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
+                style={{ ...toolbarBtnStyle, background: s.showSettings ? 'rgba(42,140,122,0.15)' : 'none', color: s.showSettings ? '#2a8c7a' : colors.reader.iconDefault }}
               >
                 <Settings size={16} />
               </button>
-              {showSettings && (
+              {s.showSettings && (
                 <ReadingSettingsPanel
-                  settings={readingSettings}
-                  onChange={updateReadingSettings}
-                  onClose={() => setShowSettings(false)}
+                  settings={s.readingSettings}
+                  onChange={s.updateReadingSettings}
+                  onClose={() => s.setShowSettings(false)}
                 />
               )}
             </div>
@@ -545,10 +293,10 @@ export function StudentSummaryReader({
 
             {/* Sidebar toggle */}
             <button
-              onClick={() => setSidebarCollapsed((v) => !v)}
+              onClick={() => s.setSidebarCollapsed((v) => !v)}
               title="Outline"
-              aria-label={sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
-              style={{ ...toolbarBtnStyle, background: !sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none', color: !sidebarCollapsed ? '#2a8c7a' : colors.reader.iconDefault }}
+              aria-label={s.sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
+              style={{ ...toolbarBtnStyle, background: !s.sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none', color: !s.sidebarCollapsed ? '#2a8c7a' : colors.reader.iconDefault }}
             >
               <PanelLeftOpen size={16} />
             </button>
@@ -557,44 +305,44 @@ export function StudentSummaryReader({
         )}
 
         {/* ── Study Timer (fixed position, self-managed) ── */}
-        {showTimer && <StudyTimer onClose={() => setShowTimer(false)} />}
+        {s.showTimer && <StudyTimer onClose={() => s.setShowTimer(false)} />}
 
         {/* ── Main content area (white card) ── */}
         <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-b-[20px] border-2 border-t-0 border-zinc-200 dark:border-[#2d2e34] shadow-sm overflow-hidden">
 
           {/* ── Reading mode fallback when no content_markdown ── */}
-          {viewMode === 'reading' && !summary?.content_markdown && (
+          {s.viewMode === 'reading' && !summary?.content_markdown && (
             <p style={{ color: '#888', textAlign: 'center', padding: '2rem' }}>
               Este resumen no tiene contenido en formato texto. Cambiando a modo enriquecido...
             </p>
           )}
 
           {/* ── Reading mode: plain markdown ── */}
-          {viewMode === 'reading' && summary.content_markdown && (
+          {s.viewMode === 'reading' && summary.content_markdown && (
             <div
               className="px-6 sm:px-8 py-8"
               style={{
-                fontSize: `${readingSettings.fontSize}px`,
-                lineHeight: readingSettings.lineHeight,
-                fontFamily: readingSettings.fontFamily,
+                fontSize: `${s.readingSettings.fontSize}px`,
+                lineHeight: s.readingSettings.lineHeight,
+                fontFamily: s.readingSettings.fontFamily,
               }}
             >
               <AnimatePresence mode="wait">
                 <motion.div
-                  key={safePage}
+                  key={s.safePage}
                   initial={{ opacity: 0, x: 8 }}
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -8 }}
                   transition={{ duration: 0.15 }}
                 >
-                  {isHtmlContent ? (
-                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
-                      <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(htmlPages[safePage] || '') }} />
+                  {s.isHtmlContent ? (
+                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={s.handleNavigateKeywordWrapped}>
+                      <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(s.htmlPages[s.safePage] || '') }} />
                     </KeywordHighlighterInline>
                   ) : (
-                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={handleNavigateKeywordWrapped}>
+                    <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={s.handleNavigateKeywordWrapped}>
                       <div className="axon-prose max-w-none">
-                        {textPages[safePage]?.map((line, i) => renderPlainLine(line, i))}
+                        {s.textPages[s.safePage]?.map((line, i) => renderPlainLine(line, i))}
                       </div>
                     </KeywordHighlighterInline>
                   )}
@@ -602,44 +350,44 @@ export function StudentSummaryReader({
               </AnimatePresence>
 
               {/* Pagination */}
-              {totalPages > 1 && (
+              {s.totalPages > 1 && (
                 <PageNavigation
-                  currentPage={safePage}
-                  totalPages={totalPages}
-                  onPrev={() => setContentPage(Math.max(0, safePage - 1))}
-                  onNext={() => setContentPage(Math.min(totalPages - 1, safePage + 1))}
-                  onPageClick={(i) => setContentPage(i)}
+                  currentPage={s.safePage}
+                  totalPages={s.totalPages}
+                  onPrev={() => s.setContentPage(Math.max(0, s.safePage - 1))}
+                  onNext={() => s.setContentPage(Math.min(s.totalPages - 1, s.safePage + 1))}
+                  onPageClick={(i) => s.setContentPage(i)}
                 />
               )}
             </div>
           )}
 
           {/* ── Enriched mode: structured blocks ── */}
-          {viewMode === 'enriched' && (
+          {s.viewMode === 'enriched' && (
             <div className="py-4">
               <ReaderChunksTab
                 summaryId={summary.id}
-                chunks={chunks}
-                chunksLoading={chunksLoading}
-                hasBlocks={hasBlocks}
-                blocksLoading={blocksLoading}
-                onNavigateKeyword={handleNavigateKeywordWrapped}
-                readingSettings={readingSettings}
-                keywords={keywords}
-                annotations={textAnnotations}
+                chunks={s.chunks}
+                chunksLoading={s.chunksLoading}
+                hasBlocks={s.hasBlocks}
+                blocksLoading={s.blocksLoading}
+                onNavigateKeyword={s.handleNavigateKeywordWrapped}
+                readingSettings={s.readingSettings}
+                keywords={s.keywords}
+                annotations={s.textAnnotations}
               />
             </div>
           )}
 
           {/* Completion card when read */}
-          {isCompleted && (
+          {s.isCompleted && (
             <div className="px-6 sm:px-8 pb-6">
               <CompletionCard
                 title="Resumen completado!"
                 subtitle={`Has leido "${summary.title || 'este resumen'}"`}
                 xpEarned={15}
                 actions={[
-                  { label: `Flashcards`, icon: Layers, onClick: () => setActiveTab('keywords'), variant: 'secondary' },
+                  { label: `Flashcards`, icon: Layers, onClick: () => s.setActiveTab('keywords'), variant: 'secondary' },
                 ]}
               />
             </div>
@@ -648,40 +396,40 @@ export function StudentSummaryReader({
 
         {/* ── Secondary tabs: Keywords, Videos, Notes (below content) ── */}
         <div className="mt-6">
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <Tabs value={s.activeTab} onValueChange={s.setActiveTab}>
             <TabsList className="mb-4 bg-white dark:bg-[#1e1f25] border border-zinc-200 dark:border-[#2d2e34] rounded-xl p-1">
               <TabsTrigger value="keywords" className="gap-1.5 rounded-lg">
                 <Tag className="w-3.5 h-3.5" />
                 <span lang="en">Keywords</span>
-                {!keywordsLoading && <TabBadge count={keywords.length} active={activeTab === 'keywords'} />}
+                {!s.keywordsLoading && <TabBadge count={s.keywords.length} active={s.activeTab === 'keywords'} />}
               </TabsTrigger>
               <TabsTrigger value="videos" className="gap-1.5 rounded-lg">
                 <VideoIcon className="w-3.5 h-3.5" />
                 <span lang="en">Videos</span>
-                {!videosLoading && <TabBadge count={videosCount} active={activeTab === 'videos'} />}
+                {!s.videosLoading && <TabBadge count={s.videosCount} active={s.activeTab === 'videos'} />}
               </TabsTrigger>
               <TabsTrigger value="annotations" className="gap-1.5 rounded-lg">
                 <StickyNote className="w-3.5 h-3.5" />
                 Mis Notas
-                {!annotationsLoading && textAnnotations.length > 0 && <TabBadge count={textAnnotations.length} active={activeTab === 'annotations'} />}
+                {!s.annotationsLoading && s.textAnnotations.length > 0 && <TabBadge count={s.textAnnotations.length} active={s.activeTab === 'annotations'} />}
               </TabsTrigger>
             </TabsList>
 
             {/* ── KEYWORDS TAB ── */}
             <TabsContent value="keywords">
               <ReaderKeywordsTab
-                keywords={keywords}
-                keywordsLoading={keywordsLoading}
-                expandedKeyword={expandedKeyword}
-                onToggleExpand={toggleKeywordExpand}
-                subtopics={subtopics}
-                subtopicsLoading={subtopicsLoading}
-                kwNotes={kwNotes}
-                kwNotesLoading={kwNotesLoading}
-                onCreateKwNote={handleCreateKwNote}
-                onUpdateKwNote={handleUpdateKwNote}
-                onDeleteKwNote={handleDeleteKwNote}
-                savingKwNote={savingKwNote}
+                keywords={s.keywords}
+                keywordsLoading={s.keywordsLoading}
+                expandedKeyword={s.expandedKeyword}
+                onToggleExpand={s.toggleKeywordExpand}
+                subtopics={s.subtopics}
+                subtopicsLoading={s.subtopicsLoading}
+                kwNotes={s.kwNotes}
+                kwNotesLoading={s.kwNotesLoading}
+                onCreateKwNote={s.handleCreateKwNote}
+                onUpdateKwNote={s.handleUpdateKwNote}
+                onDeleteKwNote={s.handleDeleteKwNote}
+                savingKwNote={s.savingKwNote}
               />
             </TabsContent>
 
@@ -695,11 +443,11 @@ export function StudentSummaryReader({
             {/* ── ANNOTATIONS TAB ── */}
             <TabsContent value="annotations">
               <ReaderAnnotationsTab
-                annotations={textAnnotations}
-                annotationsLoading={annotationsLoading}
-                onCreateAnnotation={handleCreateAnnotation}
-                onDeleteAnnotation={handleDeleteAnnotation}
-                savingAnnotation={savingAnnotation}
+                annotations={s.textAnnotations}
+                annotationsLoading={s.annotationsLoading}
+                onCreateAnnotation={s.handleCreateAnnotation}
+                onDeleteAnnotation={s.handleDeleteAnnotation}
+                savingAnnotation={s.savingAnnotation}
               />
             </TabsContent>
           </Tabs>

--- a/src/app/components/student/SummaryReaderBody.tsx
+++ b/src/app/components/student/SummaryReaderBody.tsx
@@ -1,0 +1,150 @@
+// Axon — SummaryReaderBody
+// Extracted from StudentSummaryReader.tsx (Phase C.3).
+// Renders the white content card: reading mode (paginated plain/HTML),
+// enriched mode (structured blocks) and the completion card.
+import React from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { Layers } from 'lucide-react';
+import type { Summary } from '@/app/services/summariesApi';
+import {
+  PageNavigation,
+  CompletionCard,
+  proseClasses,
+} from '@/app/components/design-kit';
+import { KeywordHighlighterInline } from '@/app/components/student/KeywordHighlighterInline';
+import { ReaderChunksTab } from '@/app/components/student/ReaderChunksTab';
+import { renderPlainLine } from '@/app/lib/summary-content-helpers';
+import { sanitizeHtml } from '@/app/lib/sanitize';
+import type { ReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
+
+interface SummaryReaderBodyProps {
+  summary: Summary;
+  viewMode: 'enriched' | 'reading';
+  readingSettings: ReadingSettings;
+  // Reading-mode pagination
+  isHtmlContent: boolean;
+  htmlPages: string[];
+  textPages: string[][];
+  safePage: number;
+  totalPages: number;
+  setContentPage: (page: number) => void;
+  onNavigateKeyword: (keywordId: string, summaryId: string) => void;
+  // Enriched-mode data
+  chunks: React.ComponentProps<typeof ReaderChunksTab>['chunks'];
+  chunksLoading: boolean;
+  hasBlocks: boolean;
+  blocksLoading: boolean;
+  keywords: React.ComponentProps<typeof ReaderChunksTab>['keywords'];
+  annotations: React.ComponentProps<typeof ReaderChunksTab>['annotations'];
+  // Completion
+  isCompleted: boolean;
+  onGoToKeywordsTab: () => void;
+}
+
+export function SummaryReaderBody({
+  summary,
+  viewMode,
+  readingSettings,
+  isHtmlContent,
+  htmlPages,
+  textPages,
+  safePage,
+  totalPages,
+  setContentPage,
+  onNavigateKeyword,
+  chunks,
+  chunksLoading,
+  hasBlocks,
+  blocksLoading,
+  keywords,
+  annotations,
+  isCompleted,
+  onGoToKeywordsTab,
+}: SummaryReaderBodyProps) {
+  return (
+    <div className="reader-card bg-white dark:bg-[#1e1f25] rounded-b-[20px] border-2 border-t-0 border-zinc-200 dark:border-[#2d2e34] shadow-sm overflow-hidden">
+      {/* ── Reading mode fallback when no content_markdown ── */}
+      {viewMode === 'reading' && !summary?.content_markdown && (
+        <p style={{ color: '#888', textAlign: 'center', padding: '2rem' }}>
+          Este resumen no tiene contenido en formato texto. Cambiando a modo enriquecido...
+        </p>
+      )}
+
+      {/* ── Reading mode: plain markdown ── */}
+      {viewMode === 'reading' && summary.content_markdown && (
+        <div
+          className="px-6 sm:px-8 py-8"
+          style={{
+            fontSize: `${readingSettings.fontSize}px`,
+            lineHeight: readingSettings.lineHeight,
+            fontFamily: readingSettings.fontFamily,
+          }}
+        >
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={safePage}
+              initial={{ opacity: 0, x: 8 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -8 }}
+              transition={{ duration: 0.15 }}
+            >
+              {isHtmlContent ? (
+                <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={onNavigateKeyword}>
+                  <div className={proseClasses} dangerouslySetInnerHTML={{ __html: sanitizeHtml(htmlPages[safePage] || '') }} />
+                </KeywordHighlighterInline>
+              ) : (
+                <KeywordHighlighterInline summaryId={summary.id} onNavigateKeyword={onNavigateKeyword}>
+                  <div className="axon-prose max-w-none">
+                    {textPages[safePage]?.map((line, i) => renderPlainLine(line, i))}
+                  </div>
+                </KeywordHighlighterInline>
+              )}
+            </motion.div>
+          </AnimatePresence>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <PageNavigation
+              currentPage={safePage}
+              totalPages={totalPages}
+              onPrev={() => setContentPage(Math.max(0, safePage - 1))}
+              onNext={() => setContentPage(Math.min(totalPages - 1, safePage + 1))}
+              onPageClick={(i) => setContentPage(i)}
+            />
+          )}
+        </div>
+      )}
+
+      {/* ── Enriched mode: structured blocks ── */}
+      {viewMode === 'enriched' && (
+        <div className="py-4">
+          <ReaderChunksTab
+            summaryId={summary.id}
+            chunks={chunks}
+            chunksLoading={chunksLoading}
+            hasBlocks={hasBlocks}
+            blocksLoading={blocksLoading}
+            onNavigateKeyword={onNavigateKeyword}
+            readingSettings={readingSettings}
+            keywords={keywords}
+            annotations={annotations}
+          />
+        </div>
+      )}
+
+      {/* Completion card when read */}
+      {isCompleted && (
+        <div className="px-6 sm:px-8 pb-6">
+          <CompletionCard
+            title="Resumen completado!"
+            subtitle={`Has leido "${summary.title || 'este resumen'}"`}
+            xpEarned={15}
+            actions={[
+              { label: `Flashcards`, icon: Layers, onClick: onGoToKeywordsTab, variant: 'secondary' },
+            ]}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/student/SummaryReaderBottomTabs.tsx
+++ b/src/app/components/student/SummaryReaderBottomTabs.tsx
@@ -1,0 +1,123 @@
+// Axon — SummaryReaderBottomTabs
+// Extracted from StudentSummaryReader.tsx (Phase C.4).
+// Secondary tabs below the main content: Keywords, Videos, and Mis Notas.
+import React from 'react';
+import { Tag, Video as VideoIcon, StickyNote } from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/tabs';
+import { VideoPlayer } from '@/app/components/student/VideoPlayer';
+import { TabBadge } from '@/app/components/student/reader-atoms';
+import { ReaderKeywordsTab } from '@/app/components/student/ReaderKeywordsTab';
+import { ReaderAnnotationsTab } from '@/app/components/student/ReaderAnnotationsTab';
+
+type KeywordsTabProps = React.ComponentProps<typeof ReaderKeywordsTab>;
+type AnnotationsTabProps = React.ComponentProps<typeof ReaderAnnotationsTab>;
+
+interface SummaryReaderBottomTabsProps {
+  summaryId: string;
+  activeTab: string;
+  onActiveTabChange: (tab: string) => void;
+  // Keyword tab
+  keywords: KeywordsTabProps['keywords'];
+  keywordsLoading: boolean;
+  expandedKeyword: KeywordsTabProps['expandedKeyword'];
+  onToggleExpand: KeywordsTabProps['onToggleExpand'];
+  subtopics: KeywordsTabProps['subtopics'];
+  subtopicsLoading: boolean;
+  kwNotes: KeywordsTabProps['kwNotes'];
+  kwNotesLoading: boolean;
+  onCreateKwNote: KeywordsTabProps['onCreateKwNote'];
+  onUpdateKwNote: KeywordsTabProps['onUpdateKwNote'];
+  onDeleteKwNote: KeywordsTabProps['onDeleteKwNote'];
+  savingKwNote: boolean;
+  // Videos
+  videosLoading: boolean;
+  videosCount: number;
+  // Annotations tab
+  textAnnotations: AnnotationsTabProps['annotations'];
+  annotationsLoading: boolean;
+  onCreateAnnotation: AnnotationsTabProps['onCreateAnnotation'];
+  onDeleteAnnotation: AnnotationsTabProps['onDeleteAnnotation'];
+  savingAnnotation: boolean;
+}
+
+export function SummaryReaderBottomTabs({
+  summaryId,
+  activeTab,
+  onActiveTabChange,
+  keywords,
+  keywordsLoading,
+  expandedKeyword,
+  onToggleExpand,
+  subtopics,
+  subtopicsLoading,
+  kwNotes,
+  kwNotesLoading,
+  onCreateKwNote,
+  onUpdateKwNote,
+  onDeleteKwNote,
+  savingKwNote,
+  videosLoading,
+  videosCount,
+  textAnnotations,
+  annotationsLoading,
+  onCreateAnnotation,
+  onDeleteAnnotation,
+  savingAnnotation,
+}: SummaryReaderBottomTabsProps) {
+  return (
+    <div className="mt-6">
+      <Tabs value={activeTab} onValueChange={onActiveTabChange}>
+        <TabsList className="mb-4 bg-white dark:bg-[#1e1f25] border border-zinc-200 dark:border-[#2d2e34] rounded-xl p-1">
+          <TabsTrigger value="keywords" className="gap-1.5 rounded-lg">
+            <Tag className="w-3.5 h-3.5" />
+            <span lang="en">Keywords</span>
+            {!keywordsLoading && <TabBadge count={keywords.length} active={activeTab === 'keywords'} />}
+          </TabsTrigger>
+          <TabsTrigger value="videos" className="gap-1.5 rounded-lg">
+            <VideoIcon className="w-3.5 h-3.5" />
+            <span lang="en">Videos</span>
+            {!videosLoading && <TabBadge count={videosCount} active={activeTab === 'videos'} />}
+          </TabsTrigger>
+          <TabsTrigger value="annotations" className="gap-1.5 rounded-lg">
+            <StickyNote className="w-3.5 h-3.5" />
+            Mis Notas
+            {!annotationsLoading && textAnnotations.length > 0 && <TabBadge count={textAnnotations.length} active={activeTab === 'annotations'} />}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="keywords">
+          <ReaderKeywordsTab
+            keywords={keywords}
+            keywordsLoading={keywordsLoading}
+            expandedKeyword={expandedKeyword}
+            onToggleExpand={onToggleExpand}
+            subtopics={subtopics}
+            subtopicsLoading={subtopicsLoading}
+            kwNotes={kwNotes}
+            kwNotesLoading={kwNotesLoading}
+            onCreateKwNote={onCreateKwNote}
+            onUpdateKwNote={onUpdateKwNote}
+            onDeleteKwNote={onDeleteKwNote}
+            savingKwNote={savingKwNote}
+          />
+        </TabsContent>
+
+        <TabsContent value="videos">
+          <div className="bg-white dark:bg-[#1e1f25] rounded-2xl border border-zinc-200 dark:border-[#2d2e34] overflow-hidden">
+            <VideoPlayer summaryId={summaryId} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="annotations">
+          <ReaderAnnotationsTab
+            annotations={textAnnotations}
+            annotationsLoading={annotationsLoading}
+            onCreateAnnotation={onCreateAnnotation}
+            onDeleteAnnotation={onDeleteAnnotation}
+            savingAnnotation={savingAnnotation}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/components/student/SummaryReaderToolbar.tsx
+++ b/src/app/components/student/SummaryReaderToolbar.tsx
@@ -1,0 +1,211 @@
+// Axon — SummaryReaderToolbar
+// Extracted from StudentSummaryReader.tsx (Phase C.2).
+// Sticky header with title, metadata and tool icons (mark read, search,
+// timer, theme, settings, sidebar toggle).
+import React from 'react';
+import {
+  ChevronLeft, CheckCircle2, Clock, Loader2,
+  Search as SearchIcon, Timer, Settings, PanelLeftOpen,
+} from 'lucide-react';
+import type { Summary } from '@/app/services/summariesApi';
+import type { ReadingState } from '@/app/services/studentSummariesApi';
+import { ThemeToggle } from '@/app/components/student/ThemeToggle';
+import ReadingSettingsPanel, { type ReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
+import { colors } from '@/app/design-system';
+
+interface SummaryReaderToolbarProps {
+  summary: Summary;
+  readingState: ReadingState | null;
+  isDark: boolean;
+  isCompleted: boolean;
+  markingRead: boolean;
+  searchOpen: boolean;
+  showTimer: boolean;
+  showSettings: boolean;
+  sidebarCollapsed: boolean;
+  readingSettings: ReadingSettings;
+  onBack: () => void;
+  onToggleRead: () => void;
+  onToggleSearch: () => void;
+  onToggleTimer: () => void;
+  onToggleTheme: () => void;
+  onToggleSettings: () => void;
+  onCloseSettings: () => void;
+  onToggleSidebar: () => void;
+  onUpdateReadingSettings: (s: ReadingSettings) => void;
+}
+
+const toolbarBtnStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  padding: 10,
+  cursor: 'pointer',
+  color: colors.reader.iconDefault,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 44,
+  minHeight: 44,
+  borderRadius: 6,
+};
+
+export function SummaryReaderToolbar({
+  summary,
+  readingState,
+  isDark,
+  isCompleted,
+  markingRead,
+  searchOpen,
+  showTimer,
+  showSettings,
+  sidebarCollapsed,
+  readingSettings,
+  onBack,
+  onToggleRead,
+  onToggleSearch,
+  onToggleTimer,
+  onToggleTheme,
+  onToggleSettings,
+  onCloseSettings,
+  onToggleSidebar,
+  onUpdateReadingSettings,
+}: SummaryReaderToolbarProps) {
+  return (
+    <header
+      role="banner"
+      aria-label="Barra de herramientas del resumen"
+      className="flex items-center justify-between"
+      style={{
+        background: isDark ? colors.reader.headerBgDark : colors.reader.headerBg,
+        padding: '10px 20px',
+        position: 'sticky',
+        top: 0,
+        zIndex: 100,
+        borderBottom: isDark ? '1px solid #2d2e34' : '1px solid transparent',
+        borderRadius: '12px 12px 0 0',
+      }}
+    >
+      {/* Left side: back + title */}
+      <div className="flex items-center min-w-0" style={{ gap: 10 }}>
+        <button
+          onClick={onBack}
+          aria-label="Volver a resúmenes"
+          style={{ ...toolbarBtnStyle, flexShrink: 0 }}
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div className="min-w-0">
+          <h1
+            className="truncate"
+            style={{
+              fontSize: 15,
+              fontWeight: 700,
+              color: '#fff',
+              fontFamily: 'Georgia, serif',
+              lineHeight: 1.2,
+              margin: 0,
+            }}
+          >
+            {summary.title || 'Sin título'}
+          </h1>
+          <div className="flex items-center gap-2 mt-0.5">
+            <span style={{ color: colors.reader.iconSubtle, fontSize: 11 }}>
+              {new Date(summary.created_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' })}
+            </span>
+            {readingState?.time_spent_seconds != null && readingState.time_spent_seconds > 0 && (
+              <span className="flex items-center gap-1" style={{ color: colors.reader.iconSubtle, fontSize: 11 }}>
+                <Clock className="w-3 h-3" />
+                {Math.round(readingState.time_spent_seconds / 60)} min
+              </span>
+            )}
+            {isCompleted && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ fontSize: 10, fontWeight: 600, background: 'rgba(16,185,129,0.2)', color: colors.reader.iconActive }}>
+                <CheckCircle2 className="w-2.5 h-2.5" /> Leído
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Right side: tool icons */}
+      <div className="flex items-center" style={{ gap: 6 }}>
+        {/* Mark complete */}
+        <button
+          onClick={onToggleRead}
+          disabled={markingRead}
+          title={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
+          aria-label={isCompleted ? 'Marcar no leído' : 'Marcar como leído'}
+          style={{
+            background: isCompleted ? 'rgba(16,185,129,0.2)' : 'none',
+            border: 'none',
+            padding: 6,
+            cursor: 'pointer',
+            color: isCompleted ? colors.reader.iconActive : colors.reader.iconDefault,
+            display: 'flex',
+            borderRadius: 6,
+          }}
+        >
+          {markingRead ? <Loader2 size={16} className="animate-spin" /> : <CheckCircle2 size={16} />}
+        </button>
+
+        {/* Search toggle */}
+        <button
+          onClick={onToggleSearch}
+          title="Buscar (Ctrl+F)"
+          aria-label="Buscar"
+          style={{ ...toolbarBtnStyle, background: searchOpen ? 'rgba(42,140,122,0.15)' : 'none', color: searchOpen ? '#2a8c7a' : colors.reader.iconDefault }}
+        >
+          <SearchIcon size={16} />
+        </button>
+
+        {/* Timer toggle */}
+        <button
+          onClick={onToggleTimer}
+          title="Temporizador de estudio"
+          aria-label={showTimer ? 'Cerrar timer' : 'Abrir timer'}
+          style={{ ...toolbarBtnStyle, background: showTimer ? 'rgba(42,140,122,0.15)' : 'none', color: showTimer ? '#2a8c7a' : colors.reader.iconDefault }}
+        >
+          <Timer size={16} />
+        </button>
+
+        {/* Separator */}
+        <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
+
+        {/* Theme toggle */}
+        <ThemeToggle isDark={isDark} onToggle={onToggleTheme} />
+
+        {/* Settings toggle */}
+        <div className="relative">
+          <button
+            onClick={onToggleSettings}
+            title="Configuración de lectura"
+            aria-label={showSettings ? 'Cerrar configuración' : 'Configuración de lectura'}
+            style={{ ...toolbarBtnStyle, background: showSettings ? 'rgba(42,140,122,0.15)' : 'none', color: showSettings ? '#2a8c7a' : colors.reader.iconDefault }}
+          >
+            <Settings size={16} />
+          </button>
+          {showSettings && (
+            <ReadingSettingsPanel
+              settings={readingSettings}
+              onChange={onUpdateReadingSettings}
+              onClose={onCloseSettings}
+            />
+          )}
+        </div>
+
+        {/* Separator */}
+        <div role="separator" aria-hidden="true" style={{ width: 1, height: 20, background: '#6b9e95', margin: '0 4px' }} />
+
+        {/* Sidebar toggle */}
+        <button
+          onClick={onToggleSidebar}
+          title="Outline"
+          aria-label={sidebarCollapsed ? 'Mostrar panel de estructura' : 'Ocultar panel de estructura'}
+          style={{ ...toolbarBtnStyle, background: !sidebarCollapsed ? 'rgba(42,140,122,0.15)' : 'none', color: !sidebarCollapsed ? '#2a8c7a' : colors.reader.iconDefault }}
+        >
+          <PanelLeftOpen size={16} />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/app/hooks/useStudentSummaryReader.ts
+++ b/src/app/hooks/useStudentSummaryReader.ts
@@ -1,0 +1,339 @@
+// Axon — useStudentSummaryReader
+// Extracted from StudentSummaryReader.tsx (refactor split).
+// Centralizes state, effects, queries, mutations, and derived values for the reader shell.
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import type { Summary } from '@/app/services/summariesApi';
+import type { ReadingState } from '@/app/services/studentSummariesApi';
+import { useSummaryReaderQueries } from '@/app/hooks/queries/useSummaryReaderQueries';
+import { useKeywordDetailQueries } from '@/app/hooks/queries/useKeywordDetailQueries';
+import { useSummaryReaderMutations } from '@/app/hooks/queries/useSummaryReaderMutations';
+import { useSummaryBlockMastery } from '@/app/hooks/queries/useSummaryBlockMastery';
+import { useReadingTimeTracker } from '@/app/hooks/useReadingTimeTracker';
+import { useScrollPositionSave } from '@/app/hooks/useScrollPositionSave';
+import { useScrollPositionRestore } from '@/app/hooks/useScrollPositionRestore';
+import { useVideoListQuery } from '@/app/hooks/queries/useVideoPlayerQueries';
+import { useThemeToggle } from '@/app/hooks/useThemeToggle';
+import { useReadingSettings } from '@/app/components/student/ReadingSettingsPanel';
+import { useSummaryBlocksQuery } from '@/app/hooks/queries/useSummaryBlocksQuery';
+import { useKeywordPageNavigation } from '@/app/hooks/useKeywordPageNavigation';
+import {
+  CONTENT_PAGE_SIZE,
+  enrichHtmlWithImages,
+  paginateHtml,
+  paginateLines,
+} from '@/app/lib/summary-content-helpers';
+
+interface UseStudentSummaryReaderArgs {
+  summary: Summary;
+  readingState: ReadingState | null;
+  onReadingStateChanged: (rs: ReadingState) => void;
+  onNavigateKeyword?: (keywordId: string, summaryId: string) => void;
+  initialTab?: string;
+}
+
+export function useStudentSummaryReader({
+  summary,
+  readingState,
+  onReadingStateChanged,
+  onNavigateKeyword,
+  initialTab,
+}: UseStudentSummaryReaderArgs) {
+  // ── Tabs + refs ─────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState(initialTab || 'keywords');
+  const readerRef = useRef<HTMLDivElement>(null);
+  const { isDark, toggle: toggleTheme } = useThemeToggle(readerRef);
+  const [showTimer, setShowTimer] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const { settings: readingSettings, update: updateReadingSettings } = useReadingSettings();
+
+  // ── Wave 1: Sidebar, search, reading progress ─────────
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 1280 : true
+  );
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+
+  // ── Scroll position restore (must be before state init) ──
+  const { initialViewMode, initialContentPage, restoreScroll } = useScrollPositionRestore(
+    summary.id,
+    readingState?.scroll_position ?? null,
+  );
+
+  /** View mode: 'enriched' shows structured blocks, 'reading' shows plain markdown */
+  const [viewMode, setViewMode] = useState<'enriched' | 'reading'>(initialViewMode ?? 'enriched');
+
+  // Auto-switch to enriched if reading mode selected but no content_markdown
+  useEffect(() => {
+    if (viewMode === 'reading' && !summary?.content_markdown) {
+      const timer = setTimeout(() => setViewMode('enriched'), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [viewMode, summary?.content_markdown]);
+
+  // ── Content pagination ──────────────────────────────────
+  const [contentPage, setContentPage] = useState(initialContentPage ?? 0);
+
+  // ── React Query: 4 initial fetches ──────────────────────
+  const {
+    chunks, chunksLoading,
+    keywords, keywordsLoading,
+    textAnnotations, annotationsLoading,
+    hasBlocks, blocksLoading,
+    invalidateAnnotations,
+  } = useSummaryReaderQueries(summary.id);
+
+  // ── Blocks for sidebar outline (shared cache — no extra fetch) ──
+  const { data: sidebarBlocks = [] } = useSummaryBlocksQuery(summary.id);
+
+  // ── Block mastery levels (Delta scale) ──
+  const { data: masteryLevels = {} } = useSummaryBlockMastery(summary.id);
+
+  // ── Scroll-spy: track which block is currently visible ──
+  useEffect(() => {
+    if (!sidebarBlocks.length) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveBlockId(entry.target.getAttribute('data-block-id'));
+          }
+        }
+      },
+      { rootMargin: '-20% 0px -60% 0px', threshold: 0 },
+    );
+    const elements = document.querySelectorAll('[data-block-id]');
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [sidebarBlocks, activeTab]);
+
+  // ── Suppress browser native scroll restoration ──
+  useEffect(() => {
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = 'manual';
+    }
+    return () => {
+      if ('scrollRestoration' in history) {
+        history.scrollRestoration = 'auto';
+      }
+    };
+  }, []);
+
+  // ── Restore scroll position after content loads ──
+  useEffect(() => {
+    if (!blocksLoading && !chunksLoading) {
+      restoreScroll(readerRef);
+    }
+  }, [blocksLoading, chunksLoading, restoreScroll]);
+
+  // ── Sidebar block click → scroll into view ──
+  const handleSidebarBlockClick = useCallback((blockId: string) => {
+    const scrollToBlock = () => {
+      requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-block-id="${blockId}"]`);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          setActiveBlockId(blockId);
+        }
+      });
+    };
+
+    if (viewMode === 'reading') {
+      setViewMode('enriched');
+      // Double rAF ensures React has flushed the DOM update
+      requestAnimationFrame(() => scrollToBlock());
+      return;
+    }
+    scrollToBlock();
+  }, [viewMode]);
+
+  // ── Search: count matches in blocks ──
+  const searchResultCount = useMemo(() => {
+    if (!searchQuery.trim()) return 0;
+    const q = searchQuery.toLowerCase();
+    return sidebarBlocks.filter((b) => {
+      const c = b.content || {};
+      const text = [c.title, c.text, c.label, c.html, c.description]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return text.includes(q);
+    }).length;
+  }, [searchQuery, sidebarBlocks]);
+
+  // ── Keyboard shortcuts (Ctrl+F, Ctrl+Shift+F, Escape) ──
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'F') {
+        e.preventDefault();
+        updateReadingSettings({ ...readingSettings, focusMode: !readingSettings.focusMode });
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+      if (e.key === 'Escape') {
+        if (readingSettings.focusMode) {
+          updateReadingSettings({ ...readingSettings, focusMode: false });
+          return;
+        }
+        setSearchOpen(false);
+        setSearchQuery('');
+        setShowSettings(false);
+        setShowTimer(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [readingSettings, updateReadingSettings]);
+
+  // ── Memoized pagination + keyword-to-page map ───────────
+  const { isHtmlContent, htmlPages, textPages, totalPages } = useMemo(() => {
+    if (!summary.content_markdown) {
+      return { isHtmlContent: false, htmlPages: [] as string[], textPages: [] as string[][], totalPages: 0 };
+    }
+    const isHtml = /<[a-z][\s\S]*>/i.test(summary.content_markdown);
+    const enriched = isHtml ? enrichHtmlWithImages(summary.content_markdown) : '';
+    const html = isHtml ? paginateHtml(enriched, CONTENT_PAGE_SIZE) : [];
+    const text = !isHtml ? paginateLines(summary.content_markdown, 45) : [];
+    return {
+      isHtmlContent: isHtml,
+      htmlPages: html,
+      textPages: text,
+      totalPages: isHtml ? html.length : text.length,
+    };
+  }, [summary.content_markdown]);
+
+  const safePage = Math.min(contentPage, Math.max(0, totalPages - 1));
+
+  // MEJORA-P1: Cross-page keyword navigation (extracted hook)
+  const { handleNavigateKeyword: handleNavigateKeywordWrapped } = useKeywordPageNavigation({
+    summaryId: summary.id,
+    keywords,
+    isHtmlContent,
+    htmlPages,
+    textPages,
+    totalPages,
+    safePage,
+    contentPage,
+    setContentPage,
+    onNavigateKeyword,
+  });
+
+  // ── Keywords: React Query on-demand (cache per keywordId) ──
+  const [expandedKeyword, setExpandedKeyword] = useState<string | null>(null);
+  const {
+    subtopics, subtopicsLoading,
+    kwNotes, kwNotesLoading,
+    invalidateKwNotes,
+  } = useKeywordDetailQueries(expandedKeyword);
+
+  // ── Videos ──────────────────────────────────────────────
+  const { data: videos, isLoading: videosLoading } = useVideoListQuery(summary.id);
+  const videosCount = videos?.length || 0;
+
+  // ── Scroll position save ────────────────────────────────
+  const { getScrollPercentage } = useScrollPositionSave(
+    summary.id,
+    activeBlockId,
+    viewMode,
+    contentPage,
+  );
+
+  // ── Reading time tracking (+ scroll position piggyback) ─
+  const { snapshotForExternalSave } = useReadingTimeTracker(
+    summary.id,
+    readingState?.time_spent_seconds ?? 0,
+    () => getScrollPercentage(readerRef),
+  );
+
+  // ── Mutations hook (Phase B.3) ──────────────────────────
+  const {
+    handleMarkCompleted,
+    handleUnmarkCompleted,
+    handleCreateAnnotation,
+    handleDeleteAnnotation,
+    handleCreateKwNote,
+    handleUpdateKwNote,
+    handleDeleteKwNote,
+    markingRead,
+    savingAnnotation,
+    savingKwNote,
+    showXpToast,
+  } = useSummaryReaderMutations({
+    summaryId: summary.id,
+    topicId: summary.topic_id,
+    snapshotForExternalSave,
+    onReadingStateChanged,
+    invalidateAnnotations,
+    invalidateKwNotes,
+    onAnnotationCreated: () => {},
+    onKwNoteCreated: () => {},
+    onKwNoteUpdated: () => {},
+  });
+
+  const toggleKeywordExpand = useCallback((keywordId: string) => {
+    setExpandedKeyword((prev) => (prev === keywordId ? null : keywordId));
+  }, []);
+
+  const isCompleted = readingState?.completed === true;
+
+  return {
+    // refs
+    readerRef,
+    // theme
+    isDark, toggleTheme,
+    // tabs
+    activeTab, setActiveTab,
+    // panels
+    showTimer, setShowTimer,
+    showSettings, setShowSettings,
+    // reading settings
+    readingSettings, updateReadingSettings,
+    // sidebar + search
+    sidebarCollapsed, setSidebarCollapsed,
+    searchOpen, setSearchOpen,
+    searchQuery, setSearchQuery,
+    searchResultCount,
+    activeBlockId,
+    // view mode + pagination
+    viewMode, setViewMode,
+    contentPage, setContentPage,
+    safePage, totalPages,
+    isHtmlContent, htmlPages, textPages,
+    // queries: content
+    chunks, chunksLoading,
+    keywords, keywordsLoading,
+    textAnnotations, annotationsLoading,
+    hasBlocks, blocksLoading,
+    sidebarBlocks,
+    masteryLevels,
+    // videos
+    videos, videosLoading, videosCount,
+    // keyword detail
+    expandedKeyword, toggleKeywordExpand,
+    subtopics, subtopicsLoading,
+    kwNotes, kwNotesLoading,
+    // keyword nav
+    handleNavigateKeywordWrapped,
+    // sidebar click
+    handleSidebarBlockClick,
+    // mutations
+    handleMarkCompleted,
+    handleUnmarkCompleted,
+    handleCreateAnnotation,
+    handleDeleteAnnotation,
+    handleCreateKwNote,
+    handleUpdateKwNote,
+    handleDeleteKwNote,
+    markingRead,
+    savingAnnotation,
+    savingKwNote,
+    showXpToast,
+    // completion
+    isCompleted,
+  };
+}
+
+export type UseStudentSummaryReaderReturn = ReturnType<typeof useStudentSummaryReader>;


### PR DESCRIPTION
## Summary
Phase C extraction of `StudentSummaryReader.tsx` (previous phases already extracted queries/mutations/tab bodies). This PR finishes the shell by pulling out the main hook, toolbar, body, and bottom tabs.

### LOC
- `StudentSummaryReader.tsx`: **716 → 209** (-71%)

### New files
| File | LOC | Purpose |
|---|---|---|
| `src/app/hooks/useStudentSummaryReader.ts` | 339 | State, effects, queries, mutations, derived values |
| `src/app/components/student/SummaryReaderToolbar.tsx` | 211 | Sticky header w/ title + tool icons |
| `src/app/components/student/SummaryReaderBody.tsx` | 150 | Reading mode / enriched mode / completion card |
| `src/app/components/student/SummaryReaderBottomTabs.tsx` | 123 | Keywords / Videos / Mis Notas |

### Commits (atomic, each builds clean)
1. `eb38c60e` — extract `useStudentSummaryReader` hook (716 → 464)
2. `f06e82ca` — extract `SummaryReaderToolbar` (464 → 330)
3. `5790fb1d` — extract `SummaryReaderBody` (330 → 255)
4. `04a3e96f` — extract `SummaryReaderBottomTabs` (255 → 209)

## Test plan
- [x] `npm run build` passes clean after each commit
- [x] Public API preserved: `StudentSummaryReader` props unchanged
- [x] `StickyNotesPanel` import (from merged PR #432) untouched
- [x] `SidebarOutline` wrapper intentionally left in shell — already its own component
- [x] Vitest: no regressions introduced (baseline has pre-existing repo-wide failures unrelated to reader)

Part of issue #423 (split god components). 4/6.