### PR TITLE
refactor(professor): consolidate ModelManager state into useReducer

### DIFF
--- a/src/app/components/professor/ModelManager.tsx
+++ b/src/app/components/professor/ModelManager.tsx
@@ -10,7 +10,7 @@
 // Uses lib/model3d-api.ts for all operations.
 // ============================================================
 
-import React, { useState, useEffect, useCallback, memo } from 'react';
+import React, { useState, useEffect, useCallback, useReducer, memo } from 'react';
 import {
   Box, Pencil, Trash2, X, Save, Loader2, Upload,
   Eye, EyeOff, ChevronDown, ChevronUp, ExternalLink, View,
@@ -30,6 +30,10 @@ import {
 import type { Model3D, UploadProgress } from '@/app/lib/model3d-api';
 import { ModelUploadZone } from '@/app/components/professor/ModelUploadZone';
 import { useNavigate } from 'react-router';
+import {
+  modelManagerReducer,
+  initialModelManagerState,
+} from '@/app/components/professor/modelManagerReducer';
 
 // ── Props ─────────────────────────────────────────────────
 
@@ -44,26 +48,20 @@ interface ModelManagerProps {
 
 export function ModelManager({ topicId, topicName }: ModelManagerProps) {
   const navigate = useNavigate();
-  const [models, setModels] = useState<Model3D[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [showUpload, setShowUpload] = useState(false);
-  const [showManualForm, setShowManualForm] = useState(false);
-
-  // Upload state
-  const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null);
-  const [uploadTitle, setUploadTitle] = useState('');
+  const [state, dispatch] = useReducer(modelManagerReducer, initialModelManagerState);
+  const { models, loading, showUpload, showManualForm, uploadProgress, uploadTitle } = state;
 
   // ── Fetch ──
   const fetchModels = useCallback(async () => {
-    setLoading(true);
+    dispatch({ type: 'SET_LOADING', payload: true });
     try {
       const res = await getModels3D(topicId);
-      setModels(res?.items || []);
+      dispatch({ type: 'SET_MODELS', payload: res?.items || [] });
     } catch (err: unknown) {
       logger.error('ModelManager', 'fetch error:', err);
       toast.error('Error al cargar modelos 3D');
     } finally {
-      setLoading(false);
+      dispatch({ type: 'SET_LOADING', payload: false });
     }
   }, [topicId]);
 
@@ -74,7 +72,9 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
     const title = uploadTitle.trim() || file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
 
     try {
-      await uploadAndCreateModel(file, topicId, title, setUploadProgress);
+      await uploadAndCreateModel(file, topicId, title, (p) =>
+        dispatch({ type: 'SET_UPLOAD_PROGRESS', payload: p }),
+      );
       toast.success('Modelo 3D subido exitosamente');
       fetchModels();
     } catch (err: unknown) {
@@ -84,7 +84,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
   }, [topicId, uploadTitle, fetchModels]);
 
   const handleUploadReset = useCallback(() => {
-    setUploadProgress(null);
+    dispatch({ type: 'SET_UPLOAD_PROGRESS', payload: null });
   }, []);
 
   // ── Manual create (paste URL) ──
@@ -103,7 +103,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
         file_size_bytes: data.file_size_bytes,
       });
       toast.success('Modelo 3D creado');
-      setShowManualForm(false);
+      dispatch({ type: 'CLOSE_MANUAL_FORM' });
       fetchModels();
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Error al crear modelo');
@@ -123,16 +123,13 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
 
   // ── Delete ──
   const handleDelete = useCallback(async (id: string) => {
-    let deletedModel: Model3D | undefined;
-
-    // Optimistic: remove from UI + capture for rollback
-    setModels(prev => {
-      deletedModel = prev.find(m => m.id === id);
-      return prev.filter(m => m.id !== id);
-    });
+    // Optimistic: remove from UI; reducer captures the deleted model in state.lastDeleted.
+    dispatch({ type: 'OPTIMISTIC_DELETE', payload: { id } });
 
     try {
       await deleteModel3D(id);
+      // Deletion confirmed; discard rollback snapshot.
+      dispatch({ type: 'CLEAR_LAST_DELETED' });
       toast.success('Modelo eliminado', {
         action: {
           label: 'Deshacer',
@@ -149,9 +146,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
       });
     } catch (err: unknown) {
       // Rollback on network error
-      if (deletedModel) {
-        setModels(prev => [...prev, deletedModel!]);
-      }
+      dispatch({ type: 'ROLLBACK_DELETE' });
       toast.error(err instanceof Error ? err.message : 'Error al eliminar');
     }
   }, [fetchModels]);
@@ -179,7 +174,9 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
           </div>
           <div className="flex items-center gap-2">
             <button
-              onClick={() => { setShowManualForm(!showManualForm); setShowUpload(false); }}
+              onClick={() =>
+                dispatch({ type: showManualForm ? 'CLOSE_MANUAL_FORM' : 'OPEN_MANUAL_FORM' })
+              }
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
               title="Crear con URL manual"
             >
@@ -187,7 +184,9 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
               URL Manual
             </button>
             <button
-              onClick={() => { setShowUpload(!showUpload); setShowManualForm(false); }}
+              onClick={() =>
+                dispatch({ type: showUpload ? 'CLOSE_UPLOAD' : 'OPEN_UPLOAD' })
+              }
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-[#2a8c7a] hover:bg-[#244e47] rounded-lg transition-colors"
             >
               <Upload size={13} />
@@ -213,7 +212,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
                   Subir archivo 3D
                 </h3>
                 <button
-                  onClick={() => { setShowUpload(false); handleUploadReset(); }}
+                  onClick={() => dispatch({ type: 'CLOSE_UPLOAD' })}
                   className="text-gray-400 hover:text-gray-600"
                 >
                   <X size={16} />
@@ -226,7 +225,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
                 <input
                   type="text"
                   value={uploadTitle}
-                  onChange={(e) => setUploadTitle(e.target.value)}
+                  onChange={(e) => dispatch({ type: 'SET_UPLOAD_TITLE', payload: e.target.value })}
                   placeholder="Se usara el nombre del archivo si se deja vacio"
                   className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#2a8c7a]/20 focus:border-[#2a8c7a]"
                 />
@@ -254,7 +253,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
           >
             <ManualModelForm
               onSubmit={handleManualCreate}
-              onCancel={() => setShowManualForm(false)}
+              onCancel={() => dispatch({ type: 'CLOSE_MANUAL_FORM' })}
             />
           </motion.div>
         )}
@@ -278,7 +277,7 @@ export function ModelManager({ topicId, topicName }: ModelManagerProps) {
             Arrastra un archivo .glb o .gltf, o pega una URL directa.
           </p>
           <button
-            onClick={() => setShowUpload(true)}
+            onClick={() => dispatch({ type: 'OPEN_UPLOAD' })}
             className="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-white bg-[#2a8c7a] hover:bg-[#244e47] rounded-lg transition-colors"
           >
             <Upload size={14} />

--- a/src/app/components/professor/__tests__/modelManagerReducer.test.ts
+++ b/src/app/components/professor/__tests__/modelManagerReducer.test.ts
@@ -1,0 +1,165 @@
+// Unit tests for modelManagerReducer — pure reducer, no React.
+import { describe, it, expect } from 'vitest';
+import {
+  modelManagerReducer,
+  initialModelManagerState,
+  type ModelManagerState,
+} from '../modelManagerReducer';
+import type { Model3D, UploadProgress } from '@/app/lib/model3d-api';
+
+const makeModel = (id: string, title = `Model ${id}`): Model3D =>
+  ({
+    id,
+    topic_id: 'topic-1',
+    title,
+    file_url: `https://example.com/${id}.glb`,
+    file_format: 'glb',
+    file_size_bytes: 1024,
+    is_active: true,
+    order_index: 0,
+    created_at: new Date().toISOString(),
+  } as Model3D);
+
+describe('modelManagerReducer', () => {
+  it('has the documented initial state', () => {
+    expect(initialModelManagerState).toEqual({
+      models: [],
+      loading: true,
+      showUpload: false,
+      showManualForm: false,
+      uploadProgress: null,
+      uploadTitle: '',
+      lastDeleted: null,
+    });
+  });
+
+  it('SET_MODELS replaces the models array', () => {
+    const models = [makeModel('a'), makeModel('b')];
+    const next = modelManagerReducer(initialModelManagerState, {
+      type: 'SET_MODELS',
+      payload: models,
+    });
+    expect(next.models).toEqual(models);
+  });
+
+  it('SET_LOADING toggles loading', () => {
+    const next = modelManagerReducer(initialModelManagerState, {
+      type: 'SET_LOADING',
+      payload: false,
+    });
+    expect(next.loading).toBe(false);
+  });
+
+  it('OPEN_UPLOAD opens upload and closes manual form (mutually exclusive)', () => {
+    const state: ModelManagerState = {
+      ...initialModelManagerState,
+      showManualForm: true,
+    };
+    const next = modelManagerReducer(state, { type: 'OPEN_UPLOAD' });
+    expect(next.showUpload).toBe(true);
+    expect(next.showManualForm).toBe(false);
+  });
+
+  it('OPEN_MANUAL_FORM opens form and closes upload (mutually exclusive)', () => {
+    const state: ModelManagerState = {
+      ...initialModelManagerState,
+      showUpload: true,
+    };
+    const next = modelManagerReducer(state, { type: 'OPEN_MANUAL_FORM' });
+    expect(next.showManualForm).toBe(true);
+    expect(next.showUpload).toBe(false);
+  });
+
+  it('CLOSE_UPLOAD clears upload panel AND resets uploadProgress', () => {
+    const progress: UploadProgress = { phase: 'uploading', percent: 42, message: '...' };
+    const state: ModelManagerState = {
+      ...initialModelManagerState,
+      showUpload: true,
+      uploadProgress: progress,
+    };
+    const next = modelManagerReducer(state, { type: 'CLOSE_UPLOAD' });
+    expect(next.showUpload).toBe(false);
+    expect(next.uploadProgress).toBeNull();
+  });
+
+  it('CLOSE_MANUAL_FORM hides the manual form', () => {
+    const state: ModelManagerState = {
+      ...initialModelManagerState,
+      showManualForm: true,
+    };
+    const next = modelManagerReducer(state, { type: 'CLOSE_MANUAL_FORM' });
+    expect(next.showManualForm).toBe(false);
+  });
+
+  it('SET_UPLOAD_PROGRESS sets a progress snapshot', () => {
+    const progress: UploadProgress = { phase: 'validating', percent: 0, message: 'x' };
+    const next = modelManagerReducer(initialModelManagerState, {
+      type: 'SET_UPLOAD_PROGRESS',
+      payload: progress,
+    });
+    expect(next.uploadProgress).toEqual(progress);
+  });
+
+  it('SET_UPLOAD_TITLE stores the input value', () => {
+    const next = modelManagerReducer(initialModelManagerState, {
+      type: 'SET_UPLOAD_TITLE',
+      payload: 'Shoulder',
+    });
+    expect(next.uploadTitle).toBe('Shoulder');
+  });
+
+  describe('optimistic delete + rollback', () => {
+    const seed: ModelManagerState = {
+      ...initialModelManagerState,
+      models: [makeModel('a'), makeModel('b'), makeModel('c')],
+    };
+
+    it('OPTIMISTIC_DELETE removes model from list and stores it in lastDeleted', () => {
+      const next = modelManagerReducer(seed, {
+        type: 'OPTIMISTIC_DELETE',
+        payload: { id: 'b' },
+      });
+      expect(next.models.map((m) => m.id)).toEqual(['a', 'c']);
+      expect(next.lastDeleted?.id).toBe('b');
+    });
+
+    it('ROLLBACK_DELETE restores lastDeleted and clears the snapshot', () => {
+      const afterDelete = modelManagerReducer(seed, {
+        type: 'OPTIMISTIC_DELETE',
+        payload: { id: 'b' },
+      });
+      const restored = modelManagerReducer(afterDelete, { type: 'ROLLBACK_DELETE' });
+      expect(restored.models.map((m) => m.id).sort()).toEqual(['a', 'b', 'c']);
+      expect(restored.lastDeleted).toBeNull();
+    });
+
+    it('ROLLBACK_DELETE with nothing to restore is a no-op', () => {
+      const next = modelManagerReducer(seed, { type: 'ROLLBACK_DELETE' });
+      expect(next).toBe(seed);
+    });
+
+    it('CLEAR_LAST_DELETED drops the snapshot without touching models', () => {
+      const afterDelete = modelManagerReducer(seed, {
+        type: 'OPTIMISTIC_DELETE',
+        payload: { id: 'a' },
+      });
+      const cleared = modelManagerReducer(afterDelete, { type: 'CLEAR_LAST_DELETED' });
+      expect(cleared.lastDeleted).toBeNull();
+      expect(cleared.models).toEqual(afterDelete.models);
+    });
+
+    it('CLEAR_LAST_DELETED is a no-op when already null', () => {
+      const next = modelManagerReducer(seed, { type: 'CLEAR_LAST_DELETED' });
+      expect(next).toBe(seed);
+    });
+
+    it('OPTIMISTIC_DELETE of an unknown id leaves models untouched and lastDeleted null', () => {
+      const next = modelManagerReducer(seed, {
+        type: 'OPTIMISTIC_DELETE',
+        payload: { id: 'does-not-exist' },
+      });
+      expect(next.models).toEqual(seed.models);
+      expect(next.lastDeleted).toBeNull();
+    });
+  });
+});

--- a/src/app/components/professor/modelManagerReducer.ts
+++ b/src/app/components/professor/modelManagerReducer.ts
@@ -1,0 +1,123 @@
+// ============================================================
+// Axon — ModelManager Reducer
+//
+// Consolidates the 6 useState hooks of ModelManager into a single
+// typed reducer with a discriminated-union Action type.
+//
+// State consolidated:
+//   - models           (Model3D[])
+//   - loading          (boolean)
+//   - showUpload       (boolean)
+//   - showManualForm   (boolean)
+//   - uploadProgress   (UploadProgress | null)
+//   - uploadTitle      (string)
+//
+// Extra field introduced to make optimistic delete self-contained:
+//   - lastDeleted      (Model3D | null) — captured during OPTIMISTIC_DELETE,
+//                                         used by ROLLBACK_DELETE.
+//
+// Pure module — no side effects, no React imports. Safe to unit test.
+// ============================================================
+
+import type { Model3D, UploadProgress } from '@/app/lib/model3d-api';
+
+// ── State ─────────────────────────────────────────────────
+
+export interface ModelManagerState {
+  models: Model3D[];
+  loading: boolean;
+  showUpload: boolean;
+  showManualForm: boolean;
+  uploadProgress: UploadProgress | null;
+  uploadTitle: string;
+  /** Captured during optimistic delete so ROLLBACK_DELETE can restore it. */
+  lastDeleted: Model3D | null;
+}
+
+export const initialModelManagerState: ModelManagerState = {
+  models: [],
+  loading: true,
+  showUpload: false,
+  showManualForm: false,
+  uploadProgress: null,
+  uploadTitle: '',
+  lastDeleted: null,
+};
+
+// ── Actions (discriminated union) ─────────────────────────
+
+export type ModelManagerAction =
+  | { type: 'SET_MODELS'; payload: Model3D[] }
+  | { type: 'SET_LOADING'; payload: boolean }
+  | { type: 'OPEN_UPLOAD' }
+  | { type: 'OPEN_MANUAL_FORM' }
+  | { type: 'CLOSE_UPLOAD' }
+  | { type: 'CLOSE_MANUAL_FORM' }
+  | { type: 'SET_UPLOAD_PROGRESS'; payload: UploadProgress | null }
+  | { type: 'SET_UPLOAD_TITLE'; payload: string }
+  | { type: 'OPTIMISTIC_DELETE'; payload: { id: string } }
+  | { type: 'ROLLBACK_DELETE' }
+  | { type: 'CLEAR_LAST_DELETED' };
+
+// ── Reducer ───────────────────────────────────────────────
+
+export function modelManagerReducer(
+  state: ModelManagerState,
+  action: ModelManagerAction,
+): ModelManagerState {
+  switch (action.type) {
+    case 'SET_MODELS':
+      return { ...state, models: action.payload };
+
+    case 'SET_LOADING':
+      return { ...state, loading: action.payload };
+
+    case 'OPEN_UPLOAD':
+      // Mutually exclusive with manual form (matches previous inline logic).
+      return { ...state, showUpload: true, showManualForm: false };
+
+    case 'OPEN_MANUAL_FORM':
+      return { ...state, showManualForm: true, showUpload: false };
+
+    case 'CLOSE_UPLOAD':
+      // Resetting uploadProgress mirrors previous handleUploadReset() behaviour
+      // when the panel is dismissed via the X button.
+      return { ...state, showUpload: false, uploadProgress: null };
+
+    case 'CLOSE_MANUAL_FORM':
+      return { ...state, showManualForm: false };
+
+    case 'SET_UPLOAD_PROGRESS':
+      return { ...state, uploadProgress: action.payload };
+
+    case 'SET_UPLOAD_TITLE':
+      return { ...state, uploadTitle: action.payload };
+
+    case 'OPTIMISTIC_DELETE': {
+      const deleted = state.models.find((m) => m.id === action.payload.id) ?? null;
+      return {
+        ...state,
+        models: state.models.filter((m) => m.id !== action.payload.id),
+        lastDeleted: deleted,
+      };
+    }
+
+    case 'ROLLBACK_DELETE': {
+      if (!state.lastDeleted) return state;
+      return {
+        ...state,
+        models: [...state.models, state.lastDeleted],
+        lastDeleted: null,
+      };
+    }
+
+    case 'CLEAR_LAST_DELETED':
+      return state.lastDeleted === null ? state : { ...state, lastDeleted: null };
+
+    default: {
+      // Exhaustiveness check — if a new action is added, TS will complain here.
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Replaces 6 `useState` calls in `ModelManager.tsx` with a single `useReducer` backed by a typed discriminated union of 11 actions.

### State consolidated
| Before (6 useState) | After (reducer state) |
|---|---|
| `models: Model3D[]` | same |
| `loading: boolean` | same |
| `showUpload: boolean` | same (now mutually exclusive via reducer invariants) |
| `showManualForm: boolean` | same (mutually exclusive with upload) |
| `uploadProgress: UploadProgress \| null` | same |
| `uploadTitle: string` | same |
| *(mutable closure variable)* | **+ `lastDeleted: Model3D \| null`** — optimistic-delete rollback captured declaratively |

### Actions (discriminated union)
`SET_MODELS`, `SET_LOADING`, `OPEN_UPLOAD`, `OPEN_MANUAL_FORM`, `CLOSE_UPLOAD`, `CLOSE_MANUAL_FORM`, `SET_UPLOAD_PROGRESS`, `SET_UPLOAD_TITLE`, `OPTIMISTIC_DELETE`, `ROLLBACK_DELETE`, `CLEAR_LAST_DELETED`. Reducer uses exhaustiveness `never` check.

### Files
- **NEW** `modelManagerReducer.ts` (123 LOC) — pure reducer + action types
- **NEW** `__tests__/modelManagerReducer.test.ts` (165 LOC, 15 unit tests)
- **MODIFIED** `ModelManager.tsx` (666 → 665 LOC) — state wiring only

## Test plan
- [x] 15 new reducer unit tests pass (initial state, each action, optimistic-delete lifecycle, no-op rollback, mutually-exclusive panel invariants)
- [x] **90/90 professor test suite** pass
- [x] Public API (`ModelManager` props: `topicId`, `topicName`) unchanged
- [x] Mutually-exclusive upload/manual-form panels now enforced in reducer (was inline `setX(false)` chains)
- [x] Subcomponent state (`ModelCard`, `ManualModelForm`) intentionally left as `useState` — out of scope
- [ ] `vite build` blocked by unrelated esbuild goroutine panic in `DailyRecommendationCard.tsx`; `ModelManager.tsx` itself transforms cleanly

Part of issue #423 (split god components). 6/6.

Single atomic commit: `2c572c15`.