### PR TITLE
security: harden chart CSS, sticky note XSS, URL/CSP surface

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,6 +5,6 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https://xdnciktarvxyhkrokbng.supabase.co https://image.mux.com https://images.unsplash.com data: blob:; media-src 'self' https://stream.mux.com blob:; connect-src 'self' https://xdnciktarvxyhkrokbng.supabase.co wss://xdnciktarvxyhkrokbng.supabase.co https://api.openai.com wss://api.openai.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:;
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https://xdnciktarvxyhkrokbng.supabase.co https://image.mux.com https://images.unsplash.com data: blob:; media-src 'self' https://stream.mux.com blob:; connect-src 'self' https://xdnciktarvxyhkrokbng.supabase.co wss://xdnciktarvxyhkrokbng.supabase.co wss://api.openai.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:;
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(self), geolocation=()

--- a/src/app/components/student/StudentSettingsPage.tsx
+++ b/src/app/components/student/StudentSettingsPage.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion, AnimatePresence } from 'motion/react';
 import { headingStyle, components, animation } from '@/app/design-system';
+import { safeUrl } from '@/app/lib/urlValidator';
 import {
   Settings,
   Send,
@@ -333,7 +334,7 @@ function TelegramLinkFlow() {
                 {linkData.instructions || 'Abre nuestro bot de Telegram y envia este codigo para completar la vinculacion.'}
               </p>
               <a
-                href={linkData.botUrl}
+                href={safeUrl(linkData.botUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={`${components.buttonPrimary.base} ${components.buttonPrimary.sizes.md} inline-flex items-center gap-2`}

--- a/src/app/components/student/ViewerBlock.tsx
+++ b/src/app/components/student/ViewerBlock.tsx
@@ -19,6 +19,7 @@ import clsx from 'clsx';
 import type { SummaryBlock, SummaryKeyword } from '@/app/services/summariesApi';
 import { useAnnotations } from '@/app/context/AnnotationContext';
 import { sanitizeHtml } from '@/app/lib/sanitize';
+import { safeUrl } from '@/app/lib/urlValidator';
 import { replaceKeywordPlaceholders } from './blocks/renderTextWithKeywords';
 import {
   ProseBlock, KeyPointBlock, StagesBlock, ComparisonBlock,
@@ -574,8 +575,12 @@ export const ViewerBlock = React.memo(function ViewerBlock({
 
     // ── PDF ──────────────────────────────────────────────
     case 'pdf': {
-      const pdfUrl = c.url || c.src || '';
+      // safeUrl strips any non-http(s) payload (javascript:, data:, file:)
+      // that a compromised backend or block editor could stash in c.url.
+      // See issue #443.
+      const pdfUrl = safeUrl(c.url || c.src || '');
       const title = c.title || 'Documento PDF';
+      if (!pdfUrl) return null;
 
       if (isMobile) {
         return (

--- a/src/app/components/summary/stickyNotes/StickyNoteEditor.tsx
+++ b/src/app/components/summary/stickyNotes/StickyNoteEditor.tsx
@@ -18,6 +18,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import { sanitizeNoteHtml } from './noteHtml';
 
 export interface StickyNoteEditorProps {
   value: string;
@@ -42,7 +43,10 @@ export const StickyNoteEditor = forwardRef<HTMLDivElement, StickyNoteEditorProps
       const el = localRef.current;
       if (!el) return;
       if (value !== lastValueRef.current) {
-        el.innerHTML = value;
+        // Sanitize on read, not only on write. Guards against stored notes
+        // whose HTML predates the sanitize-on-write pass or was produced by
+        // a compromised backend. See issue #442.
+        el.innerHTML = sanitizeNoteHtml(value);
         lastValueRef.current = value;
       }
     }, [value]);
@@ -85,7 +89,7 @@ export const StickyNoteEditor = forwardRef<HTMLDivElement, StickyNoteEditorProps
       if (!value) return true;
       if (typeof document === 'undefined') return false;
       const tmp = document.createElement('div');
-      tmp.innerHTML = value;
+      tmp.innerHTML = sanitizeNoteHtml(value);
       return (tmp.textContent ?? '').trim() === '';
     }, [value]);
 

--- a/src/app/components/summary/stickyNotes/__tests__/noteHtml.test.ts
+++ b/src/app/components/summary/stickyNotes/__tests__/noteHtml.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeNoteHtml } from '../noteHtml';
+
+// Regression tests for issue #442 — sanitize-on-read contract for StickyNotes.
+// sanitizeNoteHtml() MUST strip any tag outside the allow-list ([u, br])
+// and flatten the XSS payloads listed in the issue acceptance criteria.
+describe('sanitizeNoteHtml — XSS hardening (issue #442)', () => {
+  it('strips <img onerror> without preserving the src/handler', () => {
+    const malicious = '<img src=x onerror=alert(1)>';
+    const out = sanitizeNoteHtml(malicious);
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('onerror');
+    expect(out).not.toContain('src=x');
+  });
+
+  it('strips <script> blocks entirely', () => {
+    const malicious = '<script>alert(1)</script>';
+    const out = sanitizeNoteHtml(malicious);
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('alert(1)');
+  });
+
+  it('preserves the allow-listed <u> and <br> tags', () => {
+    expect(sanitizeNoteHtml('<u>foo</u>')).toBe('<u>foo</u>');
+    expect(sanitizeNoteHtml('hi<br>there')).toBe('hi<br>there');
+  });
+
+  it('flattens <div> / <p> wrappers into trailing <br>s', () => {
+    expect(sanitizeNoteHtml('<div>line1</div><div>line2</div>')).toBe(
+      'line1<br>line2<br>',
+    );
+  });
+
+  it('escapes raw entity characters in text nodes', () => {
+    expect(sanitizeNoteHtml('<<x>>')).toContain('&lt;');
+    expect(sanitizeNoteHtml('&')).toBe('&amp;');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(sanitizeNoteHtml('')).toBe('');
+  });
+});

--- a/src/app/components/summary/stickyNotes/noteHtml.ts
+++ b/src/app/components/summary/stickyNotes/noteHtml.ts
@@ -34,6 +34,14 @@ export function ensureHtml(content: string): string {
   return isHtmlContent(content) ? content : plainTextToHtml(content);
 }
 
+// Tags whose entire subtree must be dropped — keeping their text content
+// would leak attacker-controlled strings (e.g. `<script>alert(1)</script>`
+// surviving as the text "alert(1)") and round-trip them into other readers
+// that might unsafely re-interpret them. See issue #442.
+const DROP_SUBTREE = new Set([
+  'script', 'style', 'iframe', 'object', 'embed', 'noscript', 'svg', 'math',
+]);
+
 // Strip everything except <u> and <br>. Block-ish elements (<div>, <p>) are
 // flattened into trailing <br>s so the user's visual line structure is kept
 // even when the browser inserts wrapper tags on Enter or paste.
@@ -49,6 +57,7 @@ export function sanitizeNoteHtml(html: string): string {
     if (node.nodeType !== Node.ELEMENT_NODE) return '';
     const el = node as Element;
     const tag = el.tagName.toLowerCase();
+    if (DROP_SUBTREE.has(tag)) return '';
     const inner = Array.from(node.childNodes).map(walk).join('');
     if (tag === 'u') return `<u>${inner}</u>`;
     if (tag === 'br') return '<br>';

--- a/src/app/components/ui/__tests__/chart.test.tsx
+++ b/src/app/components/ui/__tests__/chart.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChartContainer } from '../chart';
+
+// Single harmless child so ResponsiveContainer has content.
+function Noop() {
+  return <g />;
+}
+
+describe('ChartContainer <style> injection (issue #441)', () => {
+  it('emits clean CSS custom property when color value is safe', () => {
+    const { container } = render(
+      <ChartContainer id="safe" config={{ series1: { color: '#14b8a6' } }}>
+        <Noop />
+      </ChartContainer>,
+    );
+    const style = container.querySelector('style');
+    expect(style?.innerHTML).toContain('--color-series1: #14b8a6;');
+    expect(style?.innerHTML).not.toMatch(/body\s*\{/);
+  });
+
+  it('rejects CSS-injection payload and falls back to currentColor', () => {
+    const payload = 'red;} body{display:none}/*';
+    const { container } = render(
+      <ChartContainer id="attack" config={{ series1: { color: payload } }}>
+        <Noop />
+      </ChartContainer>,
+    );
+    const style = container.querySelector('style');
+    const css = style?.innerHTML ?? '';
+
+    // Fallback was emitted.
+    expect(css).toContain('--color-series1: currentColor;');
+
+    // None of the injection characters escaped the --color-series1 rule.
+    expect(css).not.toContain(payload);
+    expect(css).not.toMatch(/body\s*\{/);
+    expect(css).not.toContain('display:none');
+  });
+
+  it('permits CSS variable references', () => {
+    const { container } = render(
+      <ChartContainer id="var" config={{ series1: { color: 'var(--primary)' } }}>
+        <Noop />
+      </ChartContainer>,
+    );
+    expect(container.querySelector('style')?.innerHTML).toContain(
+      '--color-series1: var(--primary);',
+    );
+  });
+
+  it('permits functional color notations with commas and percentages', () => {
+    const { container } = render(
+      <ChartContainer
+        id="rgb"
+        config={{ series1: { color: 'hsl(180, 50%, 40%)' } }}
+      >
+        <Noop />
+      </ChartContainer>,
+    );
+    expect(container.querySelector('style')?.innerHTML).toContain(
+      '--color-series1: hsl(180, 50%, 40%);',
+    );
+  });
+});

--- a/src/app/components/ui/chart.tsx
+++ b/src/app/components/ui/chart.tsx
@@ -8,6 +8,12 @@ import { cn } from "./utils";
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
 
+// Allow-list for CSS color values written into the injected <style> tag.
+// Permits hex (#rgb, #rrggbb, #rrggbbaa), functional notations (rgb/hsl/oklch/var),
+// named colors, and CSS variable references. Rejects ';', '{', '}', '*', '/' —
+// the characters needed to break out of the rule and inject arbitrary CSS.
+const SAFE_CSS_COLOR = /^[#a-zA-Z0-9(),.%\s-]+$/;
+
 export type ChartConfig = {
   [k in string]: {
     label?: React.ReactNode;
@@ -87,10 +93,12 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
-    const color =
+    const rawColor =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    if (!rawColor) return null;
+    const color = SAFE_CSS_COLOR.test(rawColor) ? rawColor : "currentColor";
+    return `  --color-${key}: ${color};`;
   })
   .join("\n")}
 }

--- a/src/app/lib/__tests__/urlValidator.test.ts
+++ b/src/app/lib/__tests__/urlValidator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { safeUrl } from '../urlValidator';
+
+// Regression coverage for issue #443 — safeUrl must block any scheme
+// that can execute code when assigned to href/src, while allowing the
+// http(s) URLs that legitimately flow through ViewerBlock (PDFs) and
+// StudentSettingsPage (Telegram bot deep link).
+describe('safeUrl — scheme allow-list (issue #443)', () => {
+  it('accepts https URLs unchanged', () => {
+    const url = 'https://t.me/AxonBot?start=abc123';
+    expect(safeUrl(url)).toBe(url);
+  });
+
+  it('accepts http URLs unchanged', () => {
+    const url = 'http://localhost:3000/foo.pdf';
+    expect(safeUrl(url)).toBe(url);
+  });
+
+  it('accepts relative paths', () => {
+    expect(safeUrl('/assets/brochure.pdf')).toBe('/assets/brochure.pdf');
+    expect(safeUrl('brochure.pdf')).toBe('brochure.pdf');
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(safeUrl('javascript:alert(1)')).toBe('');
+    expect(safeUrl('JavaScript:alert(1)')).toBe('');
+    expect(safeUrl('  javascript:alert(1)  ')).toBe('');
+  });
+
+  it('rejects data: URLs', () => {
+    expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+  });
+
+  it('rejects file: URLs', () => {
+    expect(safeUrl('file:///etc/passwd')).toBe('');
+  });
+
+  it('rejects vbscript: URLs', () => {
+    expect(safeUrl('vbscript:msgbox(1)')).toBe('');
+  });
+
+  it('returns empty string for empty / falsy input', () => {
+    expect(safeUrl('')).toBe('');
+    expect(safeUrl('   ')).toBe('');
+    expect(safeUrl(null)).toBe('');
+    expect(safeUrl(undefined)).toBe('');
+    expect(safeUrl(42)).toBe('');
+  });
+
+  it('trims surrounding whitespace on accepted URLs', () => {
+    expect(safeUrl('  https://axon.app/  ')).toBe('https://axon.app/');
+  });
+});

--- a/src/app/lib/urlValidator.ts
+++ b/src/app/lib/urlValidator.ts
@@ -1,0 +1,33 @@
+// ============================================================
+// Axon — URL validator
+//
+// safeUrl() guards anchor/iframe/window.open targets that receive
+// backend-supplied URLs. Any non-http(s) scheme (javascript:, data:,
+// file:, vbscript:) is stripped to '' so the calling component renders
+// a non-functional link instead of executing the payload.
+//
+// See issue #443.
+// ============================================================
+
+const SAFE_SCHEMES = new Set(['http:', 'https:']);
+
+/**
+ * Returns the input unchanged if it's an http(s) absolute URL or a
+ * relative path; returns '' otherwise. Use for any href/src that comes
+ * from user-controlled or backend-stored data.
+ */
+export function safeUrl(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  try {
+    // Resolve against a dummy base so relative paths are accepted while
+    // dangerous explicit schemes (javascript:, data:, file:, vbscript:)
+    // parse to their own protocol and get rejected.
+    const resolved = new URL(trimmed, 'https://axon.invalid/');
+    if (!SAFE_SCHEMES.has(resolved.protocol)) return '';
+    return trimmed;
+  } catch {
+    return '';
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,3 +5,17 @@
 // Adds @testing-library/jest-dom matchers (toBeInTheDocument, etc.)
 // ============================================================
 import '@testing-library/jest-dom';
+
+// jsdom does not implement ResizeObserver. Recharts' ResponsiveContainer
+// instantiates one at mount, so any chart-under-test throws without this
+// stub. A no-op implementation is enough — we never assert on observed
+// sizes in unit tests.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub })
+    .ResizeObserver = ResizeObserverStub;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https://xdnciktarvxyhkrokbng.supabase.co https://image.mux.com https://images.unsplash.com data: blob:; media-src 'self' https://stream.mux.com blob:; connect-src 'self' https://xdnciktarvxyhkrokbng.supabase.co wss://xdnciktarvxyhkrokbng.supabase.co https://api.openai.com wss://api.openai.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:;" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https://xdnciktarvxyhkrokbng.supabase.co https://image.mux.com https://images.unsplash.com data: blob:; media-src 'self' https://stream.mux.com blob:; connect-src 'self' https://xdnciktarvxyhkrokbng.supabase.co wss://xdnciktarvxyhkrokbng.supabase.co wss://api.openai.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:;" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(self), geolocation=()" }
       ]


### PR DESCRIPTION
## Summary

Batch-1 frontend hardening covering three reported security issues.

- Closes #441 — chart CSS injection via unvalidated color strings in `<style>`
- Closes #442 — sticky-note XSS via stored HTML returning to `innerHTML`
- Closes #443 — unsafe URL schemes in student-facing anchors + CSP dead-entry cleanup

## Fixes

**#441 — Chart CSS injection** (`src/app/components/ui/chart.tsx`)
- Validate `rawColor` against `SAFE_CSS_COLOR = /^[#a-zA-Z0-9(),.%\s-]+$/` before inlining into the generated `<style>` block.
- On reject, fall back to `currentColor`. Prevents payloads like `red;} body{display:none}/*` from breaking out of the declaration.
- Regression tests: `src/app/components/ui/__tests__/chart.test.tsx` (4 cases).

**#442 — Sticky note XSS** (`src/app/components/summary/stickyNotes/`)
- `StickyNoteEditor.tsx`: call `sanitizeNoteHtml()` on `value` before assigning to `innerHTML` (sanitize-on-read, two sites).
- `noteHtml.ts`: add `DROP_SUBTREE` for `<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>`, `<noscript>`, `<svg>`, `<math>`. Previously the wrapper tag was stripped but the textContent survived, so `<script>alert(1)</script>` round-tripped as the literal text `alert(1)` — any downstream reader that re-interpreted the string would have a live XSS.
- Regression tests: `src/app/components/summary/stickyNotes/__tests__/noteHtml.test.ts` (6 cases).

**#443 — URL validation + CSP**
- New `src/app/lib/urlValidator.ts` exporting `safeUrl()`: resolves input via `new URL(input, 'https://axon.invalid/')` (dummy base so relative paths still work), then rejects anything whose resolved `protocol` is not `http:` or `https:`. Returns `''` on reject.
- Applied at two student-reachable anchor sites:
  - `ViewerBlock.tsx` — PDF case: `pdfUrl = safeUrl(c.url || c.src || '')`; if empty, `return null` (fail-closed — no empty iframe).
  - `StudentSettingsPage.tsx` — Telegram link: `href={safeUrl(linkData.botUrl)}`.
- CSP (`public/_headers`, `vercel.json`): removed `https://api.openai.com` from `connect-src`. Grep confirms the frontend never makes HTTPS requests to OpenAI.
- Tests: `src/app/lib/__tests__/urlValidator.test.ts` (8 cases: http/https/relative accepted; javascript/data/file/vbscript rejected with case + whitespace variations; non-string input rejected).

## Correction to #443 spec — `wss://api.openai.com` kept

The issue body suggests stripping **all** `api.openai.com` entries. That is too aggressive: `src/app/services/ai-service/as-realtime.ts:123` opens a WebSocket to `wss://api.openai.com/v1/realtime` for the Realtime voice feature. Removing the `wss://` entry would break that path in production with a silent CSP violation.

Only the unused `https://api.openai.com` was removed. The `wss://` entry stays.

## Scope additions

Two small changes outside the issue bodies, needed to make the acceptance tests pass:

- `noteHtml.ts` DROP_SUBTREE — the original #442 patch stripped hostile tags but left their textContent. One-liner fix keeps sanitizer fail-safe; it is what makes the regression test for `<script>` blocks actually green.
- `src/test/setup.ts` ResizeObserver stub — Recharts' `ResponsiveContainer` instantiates `ResizeObserver` at mount, which jsdom doesn't implement. A no-op stub lets the new chart tests (and any future chart-under-test) run. We never assert on observed sizes in unit tests, so no-op is sufficient.

## Test plan

- [x] `npm test -- --run` green (199 files / 3731 tests)
- [x] Each new test file exercises the relevant reject path and a positive-control accept path
- [x] Manual grep confirms no remaining `https://api.openai.com` references in `src/`
- [x] Manual grep confirms `wss://api.openai.com` present in `as-realtime.ts:123` and in CSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)