### PR TITLE
ci: add bug-hunter workflow (cron every 3h)

### DIFF
--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -1,0 +1,27 @@
+name: Bug Hunter
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+jobs:
+  hunt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install -g @anthropic-ai/claude-code
+      - name: Run Claude bug hunter
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
+            --dangerously-skip-permissions \
+            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*)"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bug-hunter.yml`
- Runs Claude Code via OAuth (Max plan token) every 3h
- Scans TS/React code, opens issues with `bug-hunter` label
- Max 5 new issues per run, skips duplicates

## Setup required before first run
- Set secret: `gh secret set CLAUDE_CODE_OAUTH_TOKEN` (token from `claude setup-token`)
- Label `bug-hunter` already created

## Test plan
- [ ] Secret configured
- [ ] Trigger manually: `gh workflow run bug-hunter.yml`
- [ ] Verify issues created with correct label
- [ ] Confirm cron fires at next 3h boundary

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>