### PR TITLE
fix(types): tighten Institution.settings and PlatformPlan.features (BH-ERR-026)

### DIFF
--- a/src/app/types/platform.ts
+++ b/src/app/types/platform.ts
@@ -27,7 +27,7 @@ export interface Institution {
   logo_url?: string | null;
   owner_id?: UUID;
   is_active?: boolean;
-  settings?: Record<string, any>;
+  settings?: Record<string, unknown>;
   created_at: ISODate;
   updated_at: ISODate;
   owner?: {
@@ -98,7 +98,7 @@ export interface PlatformPlan {
   max_students: number | null;
   max_courses: number | null;
   max_storage_mb: number | null;
-  features: Record<string, any>;
+  features: Record<string, unknown>;
   is_active: boolean;
   created_at: ISODate;
   updated_at: ISODate;


### PR DESCRIPTION
## Summary

Fixes **BH-ERR-026** from `KNOWN-BUGS.md` — `Institution.settings` and `PlatformPlan.features` were typed as `Record<string, any>`, which lets unsafe property access slip through silently. Tightened to `Record<string, unknown>`, which forces explicit narrowing at the access site.

## Diff (2 lines)

```diff
- settings?: Record<string, any>;
+ settings?: Record<string, unknown>;

- features: Record<string, any>;
+ features: Record<string, unknown>;
```

## Verification

1. **Consumer scan before edit**: `grep -rnE "(institution|inst|currentInstitution)\??\.settings(\.|\[)"` and the equivalent for `.features` returned **0 matches** across `src/app`. No code reads these properties via dot/bracket access today, so the tighter type cannot break any existing consumer.
2. **Build**: `npm run build` passes (`✓ built in 2m 13s`).

## Why `unknown` over a fully-typed shape

These fields are persisted as JSON columns in Supabase and have no contract enforced by the schema. An `unknown` type is the honest description: "there's data here, but you must verify it before reading." Fully typing the shape would require a separate spec PR with backend buy-in.

## Notes for reviewers

- Companion PR [`axon-docs#23`](https://github.com/Matraca130/axon-docs/pull/23) closed 9 stale ledger entries verified fixed in `main`. BH-ERR-026 was confirmed *still* live before this PR was opened (the lesson from cycle 1 was: always re-verify before fixing).
- Per cycle hygiene: branch named `fix/bh-err-NNN-<slug>`; one bug per PR.

## Test plan

- [x] `npm run build` passes locally
- [ ] CI green
- [ ] Reviewer sanity: confirm no production code reads `institution.settings.X` or `plan.features.Y` (intentional grep above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)