### PR TITLE
chore(cleanup): drop 2 deprecated symbols + migrate last caller (BH-ERR-009)

### DIFF
--- a/src/app/hooks/useAdaptiveSession.ts
+++ b/src/app/hooks/useAdaptiveSession.ts
@@ -75,7 +75,7 @@ import {
   type AdaptiveGenerationResult,
 } from '@/app/services/adaptiveGenerationApi';
 import { countCorrect } from '@/app/lib/session-stats';
-import { smRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
+import { uiRatingToFsrsGrade, type SmRating } from '@/app/lib/grade-mapper';
 import type { OptimisticCardUpdate, CardMasteryDelta } from './useFlashcardEngine';
 
 // ── Types ─────────────────────────────────────────────────
@@ -261,7 +261,7 @@ export function useAdaptiveSession(opts: UseAdaptiveSessionOpts) {
     // rating of 5 would reach the backend as grade=5 and get silently
     // clamped, corrupting FSRS stability/difficulty updates. Mirrors the
     // same fix applied in useFlashcardEngine on fix/flashcards-session-p0.
-    const fsrsGrade = smRatingToFsrsGrade(rating as SmRating);
+    const fsrsGrade = uiRatingToFsrsGrade(rating as SmRating);
 
     const result: QueueReviewResult = queueReview({
       card, grade: fsrsGrade, responseTimeMs, currentPKnow: sq?.p_know,

--- a/src/app/lib/grade-mapper.ts
+++ b/src/app/lib/grade-mapper.ts
@@ -115,13 +115,6 @@ export function uiRatingToFsrsGrade(rating: SmRating): FsrsGrade {
 }
 
 /**
- * @deprecated Use `uiRatingToFsrsGrade`. Kept as an alias to avoid
- * breaking external consumers during the SM-2 → UI rename.
- * Will be removed once all callers migrate.
- */
-export const smRatingToFsrsGrade = uiRatingToFsrsGrade;
-
-/**
  * Convert FSRS grade (1-4) to continuous float (0.0-1.0).
  * Used by the backend FSRS engine for stability/difficulty calculations.
  */

--- a/src/app/types/keywords.ts
+++ b/src/app/types/keywords.ts
@@ -37,26 +37,6 @@ export interface KeywordData {
 /** Record<normalizedKeyword, KeywordState> — canonical keyword collection type */
 export type KeywordCollection = Record<string, KeywordState>;
 
-// ── Mastery Config ───────────────────────────────────────────
-
-/**
- * @deprecated Use getDeltaColorClasses + getDeltaColorLabel from mastery-helpers.ts instead
- * Labels are canonical Spanish (es-AR). Portuguese labels (Nao sei, Mais ou menos, Sei bem) were removed in BH-ERR-021.
- */
-export const masteryConfig: Record<MasteryLevel, {
-  label: string;
-  color: string;
-  bg: string;
-  border: string;
-  description: string;
-}> = {
-  none:      { label: 'Nuevo',       color: 'text-gray-600',    bg: 'bg-gray-50',    border: 'border-gray-200',   description: 'Sin revisar' },
-  seen:      { label: 'Visto',       color: 'text-sky-400',     bg: 'bg-sky-50',     border: 'border-sky-200',    description: 'Visto una vez' },
-  learning:  { label: 'Aprendiendo', color: 'text-amber-600',   bg: 'bg-amber-50',   border: 'border-amber-200',  description: 'Conocimiento parcial' },
-  familiar:  { label: 'Familiar',    color: 'text-teal-600',    bg: 'bg-teal-50',    border: 'border-teal-200',   description: 'Buen dominio' },
-  mastered:  { label: 'Dominado',    color: 'text-emerald-600', bg: 'bg-emerald-50', border: 'border-emerald-200', description: 'Dominio consolidado' },
-};
-
 // ── Stub functions (previously in data/keywords.ts) ──────────
 
 export function findKeyword(_term: string): KeywordData | null {


### PR DESCRIPTION
## Summary

Fixes part of **BH-ERR-009** (`@deprecated` markers cleanup). Real count is 8 markers (not 19 as the ledger claims). Of those, 2 are safely removable today; the rest still have active callers and need coordinated changes.

## Removed

| Symbol | File | Why safe |
|---|---|---|
| `smRatingToFsrsGrade` | `src/app/lib/grade-mapper.ts` | Pure alias of `uiRatingToFsrsGrade`. Single caller migrated in this PR. |
| `masteryConfig` (const) | `src/app/types/keywords.ts` | Not imported by anyone. `useKeywordMastery.ts` has its own local `masteryConfig` built from the canonical Delta scale. |

## Migrated

| File | Change |
|---|---|
| `src/app/hooks/useAdaptiveSession.ts:78,264` | `smRatingToFsrsGrade` → `uiRatingToFsrsGrade` (same `SmRating` signature, behavior identical) |

## Out of scope (still have active callers)

- `FlashcardDeck.courseColor` prop — still passed by `AdaptiveFlashcardView.tsx:231` and consumed by `FlashcardHubScreen.tsx:325/336`, `FlashcardSectionScreen.tsx`, `FlashcardSessionScreen.tsx`, `FlashcardSummaryScreen.tsx`
- `computeSectionProgress` in `studyhub-helpers.ts` — exercised by `e2e-study-hub-flow.test.tsx`
- Other `@deprecated` markers on type aliases / interface fields

These require migrating consumers and updating tests, which is a different scope.

## Verification

- `npm run build` passes (`✓ built in 8m 19s`)
- Net: -27 lines, +2 lines
- Cycle-5 lesson: my initial grep `"ratingToFsrsGrade\b"` returned no matches but the build caught the live caller — added the migration in the same PR

## Test plan

- [x] `npm run build` passes locally
- [ ] CI green
- [ ] Reviewer sanity: `useAdaptiveSession.ts` rating flow works in adaptive flashcard mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)