### PR TITLE
fix(security): frontend auth session hardening

### DIFF
--- a/src/__tests__/e2e-auth-flow.test.tsx
+++ b/src/__tests__/e2e-auth-flow.test.tsx
@@ -469,7 +469,6 @@ describe('E2E Auth Flow', () => {
     });
 
     expect(result.current.user).toBeNull();
-    expect(result.current.accessToken).toBeNull();
     expect(result.current.institutions).toHaveLength(0);
     expect(result.current.selectedInstitution).toBeNull();
     expect(result.current.status).toBe('unauthenticated');
@@ -615,7 +614,6 @@ describe('E2E Auth Flow', () => {
 
     expect(result.current.status).toBe('unauthenticated');
     expect(result.current.user).toBeNull();
-    expect(result.current.accessToken).toBeNull();
     expect(result.current.institutions).toHaveLength(0);
     expect(result.current.selectedInstitution).toBeNull();
     expect(result.current.role).toBeNull();

--- a/src/__tests__/e2e-content-routing.test.tsx
+++ b/src/__tests__/e2e-content-routing.test.tsx
@@ -52,7 +52,6 @@ vi.mock('@/app/services/contentTreeApi', () => ({
 
 const mockAuthValue = {
   user: { id: 'u1', email: 'test@test.com', full_name: 'Test' },
-  accessToken: 'tok',
   institutions: [],
   selectedInstitution: { id: 'inst-1', name: 'Test Inst', role: 'professor' as const, membership_id: 'm1' },
   role: 'professor' as string | null,

--- a/src/__tests__/e2e-context-providers.test.tsx
+++ b/src/__tests__/e2e-context-providers.test.tsx
@@ -146,7 +146,6 @@ function setupAuthenticatedUser() {
   mockUseAuth.mockReturnValue({
     user: MOCK_USER,
     status: 'authenticated',
-    accessToken: 'mock-jwt-token',
     institutions: [],
     selectedInstitution: null,
     role: 'student',
@@ -159,7 +158,6 @@ function setupUnauthenticatedUser() {
   mockUseAuth.mockReturnValue({
     user: null,
     status: 'unauthenticated',
-    accessToken: null,
     institutions: [],
     selectedInstitution: null,
     role: null,
@@ -172,7 +170,6 @@ function setupLoadingAuth() {
   mockUseAuth.mockReturnValue({
     user: null,
     status: 'loading',
-    accessToken: null,
     institutions: [],
     selectedInstitution: null,
     role: null,

--- a/src/__tests__/e2e-layout-navigation.test.tsx
+++ b/src/__tests__/e2e-layout-navigation.test.tsx
@@ -244,7 +244,6 @@ vi.mock('@/app/context/AuthContext', () => ({
   AuthProvider: ({ children }: any) => children,
   useAuth: () => ({
     user: MOCK_USER,
-    accessToken: 'test-jwt',
     institutions: [MOCK_INSTITUTION],
     selectedInstitution: MOCK_INSTITUTION,
     role: 'student',

--- a/src/app/components/auth/LoginPage.tsx
+++ b/src/app/components/auth/LoginPage.tsx
@@ -53,12 +53,17 @@ export function LoginPage() {
       } else {
         if (!name.trim()) { setError('El nombre es obligatorio'); setLoading(false); return; }
         if (password.length < 8) { setError('La contraseña debe tener al menos 8 caracteres'); setLoading(false); return; }
+        if (!/[A-Z]/.test(password) || !/[a-z]/.test(password) || !/[0-9]/.test(password)) {
+          setError('La contrasena debe incluir mayusculas, minusculas y numeros');
+          setLoading(false);
+          return;
+        }
         const res = await signup(email, password, name);
         if (!res.success) {
           setError(res.error || 'Error al crear cuenta');
         } else {
-          setSuccess('Cuenta creada exitosamente');
-          navigate('/', { replace: true });
+          setSuccess('Revisa tu email para confirmar tu cuenta. Luego podras iniciar sesion.');
+          setMode('signin');
         }
       }
     } catch (err: any) {

--- a/src/app/components/shared/ErrorBoundary.tsx
+++ b/src/app/components/shared/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { supabase } from '@/app/lib/supabase';
 
 // ─── Types ────────────────────────────────────────────────────────
 export interface ErrorBoundaryProps {
@@ -74,6 +75,7 @@ function PageFallback({
         </button>
         <button
           onClick={() => {
+            supabase.auth.signOut().catch(() => {});
             localStorage.removeItem('axon_active_membership');
             localStorage.removeItem('axon_access_token');
             localStorage.removeItem('axon_user');

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -10,7 +10,7 @@
 //   6. Route by role.
 //
 // State:
-//   { user, accessToken, institutions, selectedInstitution, role, loading, authError }
+//   { user, institutions, selectedInstitution, role, loading, authError }
 //
 // The role is NOT in the JWT. It comes from GET /institutions.
 // A user can be professor in one institution and student in another.
@@ -82,7 +82,6 @@ export interface Membership {
 interface AuthContextType {
   // New clean names
   user: AuthUser | null;
-  accessToken: string | null;
   institutions: UserInstitution[];
   selectedInstitution: UserInstitution | null;
   role: string | null;
@@ -300,12 +299,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
+  // ── Cross-tab session synchronization ───────────────────
+  // If user logs out in another tab, the 'storage' event fires here.
+  // Detect removal of axon_access_token and clear local auth state.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'axon_access_token' && e.newValue === null) {
+        setUser(null);
+        setAccessTokenState(null);
+        setSelectedInstitution(null);
+        setInstitutions([]);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
   // ── Login ─────────────────────────────────────────────
   const login = useCallback(async (email: string, password: string) => {
     try {
       const { data, error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) {
-        console.error('[Auth] signIn error:', error.message);
+        if (import.meta.env.DEV) console.error('[Auth] signIn error:', error.message);
         return { success: false, error: error.message };
       }
       const token = data.session?.access_token;
@@ -321,7 +336,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return { success: true };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error('[Auth] Login error:', err);
+      if (import.meta.env.DEV) console.error('[Auth] Login error:', err);
       return { success: false, error: msg };
     }
   }, [loadSession]);
@@ -346,7 +361,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         json = JSON.parse(text);
       } catch {
-        console.error('[Auth] /signup non-JSON response:', text.substring(0, 300));
+        if (import.meta.env.DEV) console.error('[Auth] /signup non-JSON response:', text.substring(0, 300));
         return { success: false, error: 'Server returned invalid response' };
       }
       if (!res.ok || json?.error) {
@@ -367,7 +382,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return { success: true };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error('[Auth] Signup error:', err);
+      if (import.meta.env.DEV) console.error('[Auth] Signup error:', err);
       return { success: false, error: msg };
     }
   }, [loadSession]);
@@ -445,7 +460,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AuthContextType>(() => ({
     // New clean names
     user,
-    accessToken,
     institutions,
     selectedInstitution,
     role,
@@ -465,7 +479,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     signUp: signUpCompat,
     signOut: logout,
   }), [
-    user, accessToken, institutions, selectedInstitution, role, loading, authError,
+    user, institutions, selectedInstitution, role, loading, authError,
     login, signup, logout, selectInstitution,
     status, memberships, activeMembership, setActiveMembership, signUpCompat,
   ]);

--- a/src/app/context/__tests__/AuthContext.test.tsx
+++ b/src/app/context/__tests__/AuthContext.test.tsx
@@ -282,7 +282,6 @@ describe('AuthContext', () => {
 
     expect(result.current.status).toBe('unauthenticated');
     expect(result.current.user).toBeNull();
-    expect(result.current.accessToken).toBeNull();
     expect(result.current.institutions).toHaveLength(0);
     expect(result.current.selectedInstitution).toBeNull();
   });
@@ -476,7 +475,6 @@ describe('AuthContext', () => {
 
     expect(mockSignOut).toHaveBeenCalled();
     expect(result.current.user).toBeNull();
-    expect(result.current.accessToken).toBeNull();
     expect(result.current.institutions).toHaveLength(0);
     expect(result.current.selectedInstitution).toBeNull();
     expect(result.current.authError).toBeNull();

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -56,6 +56,7 @@ let _handlingUnauthorized = false;
 function handleUnauthorized(): void {
   if (_handlingUnauthorized) return;
   _handlingUnauthorized = true;
+  setTimeout(() => { _handlingUnauthorized = false; }, 3000);
 
   // Clear module-level token
   _accessToken = null;

--- a/src/app/services/apiConfig.ts
+++ b/src/app/services/apiConfig.ts
@@ -18,10 +18,8 @@ export const publicAnonKey = ANON_KEY;
 
 // ── Auth tokens ───────────────────────────────────────
 
-const TOKEN_KEY = 'axon_access_token';
-
 export function getRealToken(): string | null {
-  return getAccessToken() || localStorage.getItem(TOKEN_KEY);
+  return getAccessToken();
 }
 
 export function getAnonKey(): string {

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -63,7 +63,6 @@ export function createMockInstitution(
 
 interface AuthContextOverrides {
   user?: AuthUser | null;
-  accessToken?: string | null;
   institutions?: UserInstitution[];
   selectedInstitution?: UserInstitution | null;
   role?: 'owner' | 'admin' | 'professor' | 'student' | null;
@@ -82,7 +81,6 @@ function buildAuthValue(overrides: AuthContextOverrides = {}) {
   return {
     // New clean names
     user,
-    accessToken: overrides.accessToken !== undefined ? overrides.accessToken : 'mock-jwt-token',
     institutions: overrides.institutions ?? (selectedInstitution ? [selectedInstitution] : []),
     selectedInstitution,
     role,


### PR DESCRIPTION
## Summary

Frontend security fixes from auth session audit (2026-04-18). 7 findings resolved:

- **MEDIUM**: 401 handler flag resets after 3s debounce (was permanently locked)
- **MEDIUM**: ErrorBoundary calls `supabase.auth.signOut()` before cleanup
- **LOW**: Production console.error guarded with `import.meta.env.DEV`
- **LOW**: Cross-tab session sync via `storage` event listener
- **LOW**: `getRealToken()` stale localStorage fallback removed
- **LOW**: Password requires uppercase + lowercase + digit
- **INFO**: `accessToken` removed from AuthContext (unused)
- Signup flow updated for email confirmation (shows "check email" message)

## Test plan

- [ ] Login flow works normally
- [ ] Signup shows "revisa tu email" message (no auto-redirect)
- [ ] Logout in Tab A clears session in Tab B
- [ ] ErrorBoundary "Volver al inicio" fully clears session
- [ ] Password validation rejects weak passwords on signup