### PR TITLE
fix(review-batch): retain partial failures for retry

### DIFF
--- a/src/app/hooks/__tests__/useReviewBatch.test.ts
+++ b/src/app/hooks/__tests__/useReviewBatch.test.ts
@@ -427,6 +427,55 @@ describe('submitBatch', () => {
 
     expect(localStorageMock.removeItem).toHaveBeenCalledWith(LS_KEY);
   });
+
+  it('keeps only failed items in localStorage when batch returns partial errors', async () => {
+    mockSubmitReviewBatch.mockResolvedValueOnce({
+      processed: 2,
+      reviews_created: 1,
+      fsrs_updated: 1,
+      bkt_updated: 1,
+      errors: [{ index: 1, step: 'bkt', message: 'subtopic missing' }],
+      results: [
+        {
+          item_id: 'card-1',
+          fsrs: {
+            stability: 5,
+            difficulty: 0.3,
+            due_at: '2026-04-01',
+            state: 'review',
+            reps: 1,
+            lapses: 0,
+            consecutive_lapses: 0,
+            is_leech: false,
+          },
+          bkt: { subtopic_id: 'sub-1', p_know: 0.7, max_p_know: 0.7, delta: 0.2 },
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useReviewBatch());
+
+    act(() => {
+      result.current.queueReview(makeParams({ card: makeCard('card-1', 'sub-1'), grade: 4 }));
+      result.current.queueReview(makeParams({ card: makeCard('card-2', 'sub-2'), grade: 3 }));
+    });
+
+    let submitResult!: BatchSubmitResult | null;
+    await act(async () => {
+      submitResult = await result.current.submitBatch('session-partial');
+    });
+
+    expect(submitResult).not.toBeNull();
+    expect(submitResult!.computedResults.get('card-1')?.bkt?.p_know).toBe(0.7);
+    expect(mockFallbackToIndividualPosts).not.toHaveBeenCalled();
+
+    const saved = JSON.parse(localStorageStore[LS_KEY]);
+    expect(saved.sessionId).toBe('session-partial');
+    expect(saved.items).toEqual([
+      expect.objectContaining({ item_id: 'card-2', subtopic_id: 'sub-2', grade: 3 }),
+    ]);
+    expect(localStorageMock.removeItem).not.toHaveBeenCalledWith(LS_KEY);
+  });
 });
 
 // ════════════════════════════════════════════════════════════
@@ -553,6 +602,37 @@ describe('localStorage persistence', () => {
     expect(retried).toBe(true);
     expect(mockSubmitReviewBatch).toHaveBeenCalledWith('session-retry', pending.items);
     expect(localStorageMock.removeItem).toHaveBeenCalledWith(LS_KEY);
+  });
+
+  it('retryPendingBatches keeps only failed items when retry returns partial errors', async () => {
+    const pending = {
+      sessionId: 'session-retry-partial',
+      items: [
+        { item_id: 'card-ok', instrument_type: 'flashcard', grade: 4 },
+        { item_id: 'card-fail', instrument_type: 'flashcard', grade: 2, subtopic_id: 'sub-fail' },
+      ],
+      savedAt: new Date().toISOString(),
+    };
+    localStorageStore[LS_KEY] = JSON.stringify(pending);
+
+    mockSubmitReviewBatch.mockResolvedValueOnce({
+      processed: 2,
+      reviews_created: 1,
+      fsrs_updated: 1,
+      bkt_updated: 0,
+      errors: [{ index: 1, step: 'review', message: 'duplicate session row' }],
+    });
+
+    const retried = await retryPendingBatches();
+
+    expect(retried).toBe(false);
+    expect(mockFallbackToIndividualPosts).not.toHaveBeenCalled();
+
+    const saved = JSON.parse(localStorageStore[LS_KEY]);
+    expect(saved.sessionId).toBe('session-retry-partial');
+    expect(saved.items).toEqual([
+      expect.objectContaining({ item_id: 'card-fail', subtopic_id: 'sub-fail', grade: 2 }),
+    ]);
   });
 
   it('retryPendingBatches falls back to individual if batch retry fails', async () => {

--- a/src/app/hooks/useReviewBatch.ts
+++ b/src/app/hooks/useReviewBatch.ts
@@ -108,6 +108,8 @@ interface PendingBatch {
   savedAt: string;
 }
 
+type BatchError = NonNullable<BatchReviewResponse['errors']>[number];
+
 function savePendingBatch(sessionId: string, items: BatchReviewItem[]): void {
   try {
     const pending: PendingBatch = { sessionId, items, savedAt: new Date().toISOString() };
@@ -132,6 +134,51 @@ function loadPendingBatch(): PendingBatch | null {
   } catch { clearPendingBatch(); return null; }
 }
 
+function collectFailedItems(
+  items: BatchReviewItem[],
+  errors?: BatchError[],
+): BatchReviewItem[] {
+  if (!errors?.length) return [];
+
+  const failedIndexes = new Set<number>();
+  for (const error of errors) {
+    if (Number.isInteger(error.index) && error.index >= 0 && error.index < items.length) {
+      failedIndexes.add(error.index);
+    }
+  }
+
+  return [...failedIndexes]
+    .sort((a, b) => a - b)
+    .map((index) => items[index])
+    .filter((item): item is BatchReviewItem => Boolean(item));
+}
+
+function persistPendingFailures(
+  sessionId: string,
+  items: BatchReviewItem[],
+  errors?: BatchError[],
+): BatchReviewItem[] {
+  if (!errors?.length) {
+    clearPendingBatch();
+    return [];
+  }
+
+  const failedItems = collectFailedItems(items, errors);
+  if (failedItems.length > 0) {
+    savePendingBatch(sessionId, failedItems);
+    return failedItems;
+  }
+
+  if (import.meta.env.DEV) {
+    console.warn(
+      '[ReviewBatch] Partial errors did not include valid indexes; keeping full batch for retry.',
+      errors,
+    );
+  }
+  savePendingBatch(sessionId, items);
+  return items;
+}
+
 export async function retryPendingBatches(): Promise<boolean> {
   const pending = loadPendingBatch();
   if (!pending || pending.items.length === 0) return false;
@@ -141,10 +188,21 @@ export async function retryPendingBatches(): Promise<boolean> {
   }
 
   try {
-    await sessionApi.submitReviewBatch(pending.sessionId, pending.items);
-    clearPendingBatch();
-    if (import.meta.env.DEV) console.log('[ReviewBatch] Pending batch retried successfully');
-    return true;
+    const response = await sessionApi.submitReviewBatch(pending.sessionId, pending.items);
+    const failedItems = persistPendingFailures(pending.sessionId, pending.items, response.errors);
+
+    if (failedItems.length === 0) {
+      if (import.meta.env.DEV) console.log('[ReviewBatch] Pending batch retried successfully');
+      return true;
+    }
+
+    if (import.meta.env.DEV) {
+      console.warn(
+        `[ReviewBatch] Pending batch retry still has ${failedItems.length} failed item(s); keeping them in localStorage`,
+        response.errors,
+      );
+    }
+    return false;
   } catch (batchErr) {
     try {
       await sessionApi.fallbackToIndividualPosts(pending.sessionId, pending.items);
@@ -238,7 +296,13 @@ export function useReviewBatch() {
         }
       }
 
-      clearPendingBatch();
+      const failedItems = persistPendingFailures(sessionId, batchItems, response.errors);
+      if (failedItems.length > 0 && import.meta.env.DEV) {
+        console.warn(
+          `[ReviewBatch] Keeping ${failedItems.length} failed item(s) in localStorage for retry`,
+          response.errors,
+        );
+      }
       batchQueueRef.current = [];
       return { response, computedResults };
     } catch (batchErr) {


### PR DESCRIPTION
## Summary
- Enhances `useReviewBatch` to retain partial failures for retry instead of silently dropping them
- Adds 80-line test suite for the new retry behavior

## Context
Branch found during unmerged-branch audit (2026-04-18). Created by Codex on 2026-04-15, never had a PR.

## Test plan
- [ ] Verify `useReviewBatch` test passes
- [ ] Confirm partial failures are retained and retryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)