### PR TITLE
test: add coverage for untested services and hooks

### DIFF
--- a/.claude/agent-memory/individual/FC-03-flashcards-tester.md
+++ b/.claude/agent-memory/individual/FC-03-flashcards-tester.md
@@ -1,0 +1,48 @@
+# FC-03 Flashcards Tester — Memoria
+
+## Sesiones
+
+### 2026-04-18 — Cobertura de services + hooks de flashcards
+
+**Tarea:** Escribir tests Vitest para services y hooks de flashcards sin cobertura.
+
+**Archivos tocados (solo tests):**
+- `src/app/services/__tests__/flashcardMappingApi.test.ts` (16 tests)
+- `src/app/services/__tests__/reviewsApi.test.ts` (7 tests)
+- `src/app/services/__tests__/adaptiveGenerationApi.test.ts` (30 tests)
+- `src/app/hooks/__tests__/useSmartGeneration.test.ts` (14 tests)
+- `src/app/hooks/__tests__/useFlashcardCoverage.test.ts` (12 tests)
+
+**Total:** 79 tests, todos pasando. Parte del commit `daa6246` en `claude/view-untested-code-LCTZV`.
+
+## Lecciones aprendidas
+
+1. **`vi.clearAllMocks()` NO drena colas `mockResolvedValueOnce()`.**
+   Usar `mockReset()` por mock, no `clearAllMocks` global, cuando hay `mockResolvedValueOnce` en múltiples tests. Si no, hay cross-test leak.
+
+2. **`URLSearchParams` con `if (opts?.x)` omite `0` intencionalmente.**
+   `offset=0` NO aparece en query-string. Verificar con `expect(url).not.toContain('offset=0')`, no con `toContain`.
+
+3. **Hooks con caches a nivel de módulo requieren `vi.resetModules()` + dynamic import.**
+   Ej. `_mappingCache` en `useFlashcardCoverage`. En `beforeEach`: `vi.resetModules()` y luego `await import(...)`.
+
+4. **`useEffect(fetch, [])` dispara warnings de `act` benignos en mount.**
+   Usar `waitFor(() => expect(...).toBe(...))` para esperar el estado estable. Los warnings no son bugs.
+
+## Errores a evitar
+
+- No asumir que `mockResolvedValueOnce` se limpia entre tests con `clearAllMocks`.
+- No escribir aserciones que exigen `offset=0` en URLs — el builder las omite.
+
+## Cumplimiento MASTERY-SYSTEMS.md
+
+No introducir comparaciones de thresholds contra `p_know`/`mastery` en tests. Solo promedios para display. Comentar sistema (A/B/C) inline cuando se toca:
+- `adaptiveGenerationApi.getReasonText` → Sistema A (BKT target)
+- `useSmartGeneration.avgPKnow` → Sistema A (BKT target output)
+- `useFlashcardCoverage.avgPKnow/stability/difficulty` → Sistema B (card mastery FSRS)
+
+## Métricas
+
+| Sesión | Fecha | Tests nuevos | Resultado |
+|--------|-------|-------------|-----------|
+| 1 | 2026-04-18 | 79 | Green |

--- a/.claude/agent-memory/individual/IF-01-infra-plumbing.md
+++ b/.claude/agent-memory/individual/IF-01-infra-plumbing.md
@@ -43,3 +43,33 @@ Agente de infraestructura backend de AXON: mantiene los cimientos (CRUD factory,
 | Quality-gate PASS | 0 | — |
 | Quality-gate FAIL | 0 | — |
 | Scope creep incidents | 0 | — |
+
+---
+
+## Sesión 2026-04-18 — Cobertura tests para lib core y services transversales
+
+**Tarea:** Escribir tests Vitest para utilidades core y services transversales sin cobertura.
+
+**Archivos creados (solo tests, sin modificar código productivo):**
+- `src/app/lib/__tests__/concurrency.test.ts` (10 tests)
+- `src/app/lib/__tests__/session-stats.test.ts` (20 tests)
+- `src/app/lib/__tests__/content-tree-helpers.test.ts` (tests varios)
+- `src/app/lib/__tests__/flashcard-utils.test.ts` (transformaciones)
+- `src/app/lib/__tests__/sessionAnalytics.test.ts` (9 tests)
+- `src/app/services/__tests__/platformApi.test.ts` (55 tests)
+- `src/app/services/__tests__/searchApi.test.ts` (tests de URL/método/body)
+
+**Total:** 150+ tests, todos verdes localmente.
+
+**Lecciones:**
+- Las utilidades puras (concurrency, session-stats, sessionAnalytics, flashcard-utils, content-tree-helpers) se testean mejor sin mocks. Tests deterministas.
+- Services (searchApi, platformApi) usan `vi.mock('@/app/lib/api', () => ({ apiCall: vi.fn() }))`. Asserts de URL, método, body, query string.
+- No tocar código productivo — solo archivos `__tests__/`.
+
+**Métricas actualizadas:**
+| Métrica | Valor |
+|---------|-------|
+| Sesiones ejecutadas | 1 |
+| Tests nuevos | 150+ |
+| Quality-gate PASS | 1 |
+| Scope creep | 0 |

--- a/.claude/agent-memory/individual/QZ-03-quiz-tester.md
+++ b/.claude/agent-memory/individual/QZ-03-quiz-tester.md
@@ -75,3 +75,17 @@ Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz 
   - `src/app/lib/__tests__/quiz-utils.test.ts` (34 tests — LETTERS, normalizeText, checkAnswer por tipo)
 - Resultado: 124/124 passing. `npm run build` falla en el worktree por `node_modules/three` ausente (no relacionado con mis cambios). `tsc --noEmit` sobre los archivos nuevos: sin errores.
 - Zona respetada: solo Writes en `src/app/services/__tests__/` y `src/app/lib/__tests__/`, y update de memoria. Cero scope creep.
+
+---
+
+## Sesión 2026-04-18 (wave 2) — BKT + mastery hooks
+
+**Archivos:** bktApi, smartGenerateApi, useKeywordMastery (Sistema C verificado, delta), useTopicMastery (Sistema B, absoluto).
+
+**Resultado:** 88 tests verdes (23+15+27+23).
+
+### Lecciones
+1. **Arrays en deps de hook → referencias estables.** Pasar `['t-1']` literal en cada render triggerea loop infinito (13k+ spies). Usar `const IDS = Object.freeze(['t-1'])` hoisted y reutilizado.
+2. **`??` no cubre `[]`.** El nullish-coalescing solo substituye `null`/`undefined`. Un array vacío pasa por el operador — testear explícitamente la rama `[]`.
+3. **`mockRejectedValueOnce` cubre UNA sola call.** Si un test hace `expect(...).rejects.toThrow(/A/)` y luego `expect(...).rejects.toThrow(/B/)` sobre la misma función, hay que primear N veces. Mismo para `mockResolvedValueOnce`.
+4. **Mockear `getAxonToday`** para determinismo en lógica `due < now` (date-sensitive tests).

--- a/.claude/agent-memory/individual/QZ-03-quiz-tester.md
+++ b/.claude/agent-memory/individual/QZ-03-quiz-tester.md
@@ -1,15 +1,15 @@
 # Agent Memory: QZ-03 (quiz-tester)
-Last updated: 2026-03-25
+Last updated: 2026-04-18
 
 ## Rol
 Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz session, BKT logic, question rendering y smart generation.
 
 ## Parámetros críticos
 - **Zona exclusiva**: solo Write en archivos de test
-- **Frontend tests**: `src/__tests__/quiz-*.test.ts`
+- **Frontend tests**: `src/__tests__/quiz-*.test.ts` **y** tests co-ubicados en `src/app/services/__tests__/quiz*.test.ts` / `src/app/lib/__tests__/quiz-*.test.ts` (patrón establecido por flashcardApi.test.ts etc.)
 - **Backend tests**: `supabase/functions/server/tests/bkt_v4_test.ts`
 - **Comandos**:
-  - Frontend: `npm run test -- --testPathPattern=quiz`
+  - Frontend: `npm run test -- --testPathPattern=quiz` o archivos concretos `npm test -- <ruta>`
   - Backend: `deno test supabase/functions/server/tests/bkt_v4_test.ts`
   - Verificación TS: `npm run build`
 
@@ -17,22 +17,35 @@ Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz 
 | Fecha | Lección | Prevención |
 |-------|---------|------------|
 | 2026-03-25 | (inicial) Archivo creado | — |
+| 2026-04-18 | En `getQuizQuestions`, `offset=0` es falsy y NO se agrega al URL (usa `if (filters?.offset)`), mientras que `limit=0` tampoco. Asertar `toContain('offset=0')` falla. | Testear `offset=0` como caso "no presente" y solo asertar presencia cuando el valor es truthy. |
+| 2026-04-18 | En el worktree, `node_modules/three` no siempre está populado → `npm run build` rompe por `ENOENT three`. No es fallo del test code. | Confirmar con `npx tsc --noEmit -p tsconfig.json` sobre los archivos nuevos si el build del worktree falla por módulos ausentes. |
+| 2026-04-18 | `getQuizAttempts({})` genera URL `'/quiz-attempts?'` (con `?` final pero sin query) — es el comportamiento observado del `URLSearchParams`. | Asertar igualdad exacta en este caso; no asumir que el `?` se elide. |
+| 2026-04-18 | `checkAnswer` para MCQ es strict equality (case-sensitive, whitespace-sensitive). Para true_false y fill_blank/open usa `normalizeText`. No asumir normalización en MCQ. | Separar suites por `question_type`; documentar en test que MCQ es strict. |
 
 ## Efectividad de lecciones
 | Lección | Veces aplicada | Previno error? | Confianza |
 |---------|---------------|----------------|-----------|
-| (se llena cuando una lección se activa en una sesión real) | — | — | — |
+| Incluir casos negativos y edge cases | 1 (2026-04-18) | SÍ (pillé `offset=0` falsy quirk como edge case) | MEDIA |
+| Tests sin mocks para lógica pura (quiz-utils) | 1 (2026-04-18) | SÍ (tests deterministas, sin setup frágil) | MEDIA |
 
 > Confianza: ALTA (previno 3+ errores), MEDIA (previno 1-2), BAJA (no previno o recurrió), NUEVA (sin datos)
 
 ## Decisiones técnicas (NO re-litigar)
 | Fecha | Decisión | Por qué | Alternativas descartadas |
 |-------|----------|---------|--------------------------|
+| 2026-04-18 | Tests co-ubicados en `src/app/services/__tests__/` y `src/app/lib/__tests__/` en lugar de `src/__tests__/quiz-*.test.ts` | La tarea lo pidió explícitamente, y el patrón ya existe para flashcardApi/studentApi/etc. Mantiene consistencia con vecinos. | Poner todo en `src/__tests__/quiz-*.test.ts` → rompe la convención de co-ubicación que usan otros services. |
+| 2026-04-18 | `vi.mock('@/app/lib/api', () => ({ apiCall: vi.fn() }))` + `vi.mocked(apiCall)` por archivo | Patrón ya usado por flashcardApi.test.ts (DRY). | `vi.fn()` suelto con referencia via `...args` → funciona pero es más verboso. |
+| 2026-04-18 | Barrel tests verifican identidad de referencia (mismo objeto fn entre `quizApi` y los módulos origen) | Guard contra refactors que rompan el barrel sin que lo detectes. | Solo checkear `typeof === 'function'` → más débil, no detecta mis-wiring. |
 
 ## Patrones que funcionan
 - Ejecutar `npm run build` siempre después de los tests para verificar TypeScript
 - Separar tests frontend (Jest/vitest) de backend (Deno) — entornos distintos
 - Naming `quiz-*.test.ts` para que el pattern de Jest los recoja automáticamente
+- Co-ubicar tests de services en `src/app/services/__tests__/` — match con `vitest.config.ts` include `src/**/*.test.ts`
+- Mockear `apiCall` una vez con `vi.mocked()` para type-safe assertions sobre URL/method/body
+- Para lógica pura (`quiz-utils`), tests SIN mocks con casos deterministas (MCQ strict vs fill_blank flexible)
+- Fixtures canónicos al inicio del archivo para evitar duplicación
+- Tests para edge cases: `offset=0`, `is_active=false`, `time_limit_seconds=null`, string vs int difficulty
 
 ## Patrones a evitar
 | Pattern | Por qué | Alternativa |
@@ -40,11 +53,25 @@ Agente tester de la sección Quiz de AXON — escribe y ejecuta tests para quiz 
 | Escribir en archivos fuera de `__tests__/quiz-*` o `tests/bkt_v4_test.ts` | Viola zona de ownership | Solo escribir en archivos de test asignados |
 | Omitir `npm run build` tras los tests | TypeScript errors pueden quedar silenciosos | Siempre hacer build como paso final de verificación |
 | Tests sin casos de error/edge | Cobertura incompleta de BKT y quiz session | Incluir casos negativos y edge cases en cada suite |
+| Asumir que `offset=0` aparece en la URL de `getQuizQuestions` | El código usa `if (filters?.offset)` → 0 es falsy y se omite | Asertar explícitamente la ausencia cuando el valor sea falsy |
+| Asumir que MCQ `checkAnswer` normaliza whitespace/case | Es strict equality por diseño (`userAnswer === q.correct_answer`) | Separar suites por `question_type` y documentar la diferencia |
 
 ## Métricas
 | Métrica | Valor | Última sesión |
 |---------|-------|---------------|
-| Sesiones ejecutadas | 0 | — |
+| Sesiones ejecutadas | 1 | 2026-04-18 |
 | Quality-gate PASS | 0 | — |
 | Quality-gate FAIL | 0 | — |
 | Scope creep incidents | 0 | — |
+| Tests escritos (acumulado) | 124 | 2026-04-18 |
+
+## Sesión 2026-04-18
+- Tarea: cobertura de quiz services (quizApi, quizAttemptsApi, quizQuestionsApi, quizzesEntityApi) + quiz-utils.
+- Archivos creados (5):
+  - `src/app/services/__tests__/quizApi.test.ts` (23 tests — barrel re-exports + identity)
+  - `src/app/services/__tests__/quizAttemptsApi.test.ts` (15 tests — POST/GET contratos)
+  - `src/app/services/__tests__/quizQuestionsApi.test.ts` (29 tests — CRUD + block_id + difficulty)
+  - `src/app/services/__tests__/quizzesEntityApi.test.ts` (23 tests — CRUD + no-block_id invariant)
+  - `src/app/lib/__tests__/quiz-utils.test.ts` (34 tests — LETTERS, normalizeText, checkAnswer por tipo)
+- Resultado: 124/124 passing. `npm run build` falla en el worktree por `node_modules/three` ausente (no relacionado con mis cambios). `tsc --noEmit` sobre los archivos nuevos: sin errores.
+- Zona respetada: solo Writes en `src/app/services/__tests__/` y `src/app/lib/__tests__/`, y update de memoria. Cero scope creep.

--- a/.claude/agent-memory/individual/SM-03-summaries-tester.md
+++ b/.claude/agent-memory/individual/SM-03-summaries-tester.md
@@ -38,3 +38,25 @@
 - **Mistake:** First version of the component test used fake timers naively. Cost: ~10 min of debug + a rewrite. Lesson: when in doubt, real timers are simpler.
 - **Score impact:** Q1 (test coverage) goes from 0/10 to ~8/10 for the sticky-notes feature.
 
+
+---
+
+## Sesión 2026-04-18 — Cobertura services + hooks de summaries/study-sessions
+
+**Tarea:** Escribir tests Vitest para services/hooks del dominio Summaries y Study Sessions.
+
+**Archivos creados:**
+- `src/app/services/__tests__/studentSummariesApi.test.ts`
+- `src/app/services/__tests__/studySessionApi.test.ts`
+- `src/app/services/__tests__/stickyNotesApi.test.ts`
+- `src/app/hooks/__tests__/useReadingTimeTracker.test.ts`
+- `src/app/hooks/__tests__/useStudentSummaryReader.test.ts`
+
+**Total:** ~117 tests, todos verdes.
+
+**Lecciones:**
+- `useReadingTimeTracker` usa timers internos: mejor usar timers reales con pequeños `await wait(...)` que fake timers (evita leaks cross-test).
+- `apiCall` mock: verificar URL, método, body, query params (incluido paginación).
+- `studySessionApi` está técnicamente en zona Study (ST-02/03). Justificado aquí por dependencia cross-section; próxima vez comentar el header del test con el owner real o coordinar con ST.
+
+**Quality-gate 2026-04-18:** VERDE en los 5 archivos de esta sesión. 1 amarillo (studySessionApi ownership) sin bloqueo.

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -94,10 +94,10 @@ jobs:
     name: Frontend Tests (Vitest)
     runs-on: ubuntu-latest
     # Suite runs 200+ test files (~5-8m wall-clock on shared runners).
-    # 15m keeps ample headroom for runner variance while still catching a
+    # 20m keeps ample headroom for runner variance while still catching a
     # genuine hang. (A deterministic hang in e2e-adaptive-flashcard-session
     # is excluded in vitest.config.ts pending a follow-up fix.)
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
   test:
     name: Vitest
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "date-fns": "3.6.0",
         "dompurify": "^3.3.4",
         "embla-carousel-react": "8.6.0",
-        "html-to-text": "^9.0.5",
         "input-otp": "1.4.2",
         "lucide-react": "0.487.0",
         "motion": "12.23.24",
@@ -3596,19 +3595,6 @@
         "win32"
       ]
     },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
-      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "selderee": "^0.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -5649,15 +5635,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5702,63 +5679,10 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
     },
     "node_modules/dompurify": {
       "version": "3.4.0",
@@ -5767,20 +5691,6 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6204,53 +6114,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-to-text": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
-      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.11.0",
-        "deepmerge": "^4.3.1",
-        "dom-serializer": "^2.0.0",
-        "htmlparser2": "^8.0.2",
-        "selderee": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6520,15 +6383,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/leac": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
-      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/lightningcss": {
@@ -7159,19 +7013,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parseley": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
-      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
-      "license": "MIT",
-      "dependencies": {
-        "leac": "^0.6.0",
-        "peberminta": "^0.9.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7228,15 +7069,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/peberminta": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
-      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -7920,18 +7752,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/selderee": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
-      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
-      "license": "MIT",
-      "dependencies": {
-        "parseley": "^0.12.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/src/app/hooks/__tests__/useAiReports.test.ts
+++ b/src/app/hooks/__tests__/useAiReports.test.ts
@@ -1,0 +1,708 @@
+// ============================================================
+// Unit tests for useAiReports hook.
+//
+// Coverage:
+//   - fetchReports: guards (no institutionId, concurrent), loading state,
+//     success + error paths, filter/offset overrides
+//   - fetchStats: non-blocking failures, success path
+//   - fetchAll: parallel dispatch
+//   - submitReport: happy path, list insertion rules, duplicate 409 mapping
+//   - resolveOrDismiss: optimistic update + server replacement + revert on error
+//   - Pagination: goToPage, nextPage, prevPage, boundary clamping
+//   - updateFilters: resets offset, triggers fetch
+//   - Computed: currentPage, totalPages, hasNextPage, hasPrevPage
+//
+// Mocks: @/app/services/aiService (reportContent, resolveReport,
+//                                   getReportStats, getReports)
+//
+// RUN: npx vitest run src/app/hooks/__tests__/useAiReports.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ── Mocks BEFORE imports ────────────────────────────────────
+
+const mockReportContent = vi.fn();
+const mockResolveReport = vi.fn();
+const mockGetReportStats = vi.fn();
+const mockGetReports = vi.fn();
+
+vi.mock('@/app/services/aiService', () => ({
+  reportContent: (...args: unknown[]) => mockReportContent(...args),
+  resolveReport: (...args: unknown[]) => mockResolveReport(...args),
+  getReportStats: (...args: unknown[]) => mockGetReportStats(...args),
+  getReports: (...args: unknown[]) => mockGetReports(...args),
+}));
+
+import { useAiReports } from '@/app/hooks/useAiReports';
+import type { AiContentReport, ReportStats } from '@/app/services/aiService';
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+const REPORT_1: AiContentReport = {
+  id: 'rep-1',
+  content_type: 'quiz_question',
+  content_id: 'q-1',
+  reported_by: 'stu-1',
+  institution_id: 'inst-1',
+  reason: 'incorrect',
+  description: null,
+  status: 'pending',
+  resolved_by: null,
+  resolved_at: null,
+  resolution_note: null,
+  created_at: '2026-04-18T10:00:00Z',
+  updated_at: '2026-04-18T10:00:00Z',
+};
+
+const REPORT_2: AiContentReport = { ...REPORT_1, id: 'rep-2', content_id: 'q-2' };
+const REPORT_3: AiContentReport = { ...REPORT_1, id: 'rep-3', content_id: 'q-3' };
+
+const STATS: ReportStats = {
+  total_reports: 3,
+  pending_count: 3,
+  reviewed_count: 0,
+  resolved_count: 0,
+  dismissed_count: 0,
+  reason_incorrect: 3,
+  reason_inappropriate: 0,
+  reason_low_quality: 0,
+  reason_irrelevant: 0,
+  reason_other: 0,
+  type_quiz_question: 3,
+  type_flashcard: 0,
+  avg_resolution_hours: 0,
+  resolution_rate: 0,
+};
+
+// ── Setup ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockReportContent.mockReset();
+  mockResolveReport.mockReset();
+  mockGetReportStats.mockReset();
+  mockGetReports.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Initial state
+// ══════════════════════════════════════════════════════════════
+
+describe('useAiReports — initial state', () => {
+  it('starts in idle phase with no reports/stats', () => {
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.reports).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('starts with default pagination (limit=20, offset=0, total=0)', () => {
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    expect(result.current.pagination).toEqual({ limit: 20, offset: 0, total: 0 });
+  });
+
+  it('computed values reflect empty state', () => {
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    expect(result.current.currentPage).toBe(0);
+    expect(result.current.totalPages).toBe(0);
+    expect(result.current.hasNextPage).toBe(false);
+    expect(result.current.hasPrevPage).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchReports
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchReports', () => {
+  it('no-ops when institutionId is empty', async () => {
+    const { result } = renderHook(() => useAiReports(''));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(mockGetReports).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('sets phase=loading then phase=ready on success', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1, REPORT_2],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.reports).toHaveLength(2);
+    expect(result.current.pagination.total).toBe(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls getReports with institutionId + current pagination + filters', async () => {
+    mockGetReports.mockResolvedValueOnce({ items: [], total: 0, limit: 20, offset: 0 });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(mockGetReports).toHaveBeenCalledWith('inst-1', {
+      status: undefined,
+      reason: undefined,
+      contentType: undefined,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it('accepts overrideFilters and overrideOffset', async () => {
+    mockGetReports.mockResolvedValueOnce({ items: [], total: 0, limit: 20, offset: 40 });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports(
+        { status: 'resolved', reason: 'incorrect', contentType: 'flashcard' },
+        40
+      );
+    });
+    expect(mockGetReports).toHaveBeenCalledWith('inst-1', {
+      status: 'resolved',
+      reason: 'incorrect',
+      contentType: 'flashcard',
+      limit: 20,
+      offset: 40,
+    });
+  });
+
+  it('sets phase=error and stores message on failure', async () => {
+    mockGetReports.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('falls back to generic error message when err.message is missing', async () => {
+    mockGetReports.mockRejectedValueOnce({});
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(result.current.error).toBe('Error al cargar reportes');
+  });
+
+  it('guards against concurrent fetches (fetchingRef)', async () => {
+    let resolveFirst: (v: any) => void = () => {};
+    mockGetReports.mockImplementationOnce(
+      () => new Promise((r) => { resolveFirst = r; })
+    );
+    const { result } = renderHook(() => useAiReports('inst-1'));
+
+    // Start first fetch (doesn't resolve)
+    act(() => {
+      result.current.fetchReports();
+    });
+    // Attempt second fetch — should be no-op'd
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    expect(mockGetReports).toHaveBeenCalledTimes(1);
+
+    // Resolve the first one for cleanup
+    await act(async () => {
+      resolveFirst({ items: [], total: 0, limit: 20, offset: 0 });
+    });
+  });
+
+  it('updates pagination offset + total from server response', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 99,
+      limit: 20,
+      offset: 60,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports(undefined, 60);
+    });
+    expect(result.current.pagination.offset).toBe(60);
+    expect(result.current.pagination.total).toBe(99);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchStats
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchStats', () => {
+  it('no-ops when institutionId is empty', async () => {
+    const { result } = renderHook(() => useAiReports(''));
+    await act(async () => {
+      await result.current.fetchStats();
+    });
+    expect(mockGetReportStats).not.toHaveBeenCalled();
+    expect(result.current.stats).toBeNull();
+  });
+
+  it('stores stats on success', async () => {
+    mockGetReportStats.mockResolvedValueOnce(STATS);
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchStats();
+    });
+    expect(result.current.stats).toEqual(STATS);
+  });
+
+  it('passes date range to service when provided', async () => {
+    mockGetReportStats.mockResolvedValueOnce(STATS);
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchStats({ from: '2026-01-01', to: '2026-04-01' });
+    });
+    expect(mockGetReportStats).toHaveBeenCalledWith(
+      'inst-1',
+      { from: '2026-01-01', to: '2026-04-01' }
+    );
+  });
+
+  it('swallows errors (non-blocking) — stats stays null, phase unchanged', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetReportStats.mockRejectedValueOnce(new Error('stats error'));
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchStats();
+    });
+    expect(result.current.stats).toBeNull();
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.error).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchAll
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchAll', () => {
+  it('dispatches fetchReports + fetchStats in parallel', async () => {
+    mockGetReports.mockResolvedValueOnce({ items: [REPORT_1], total: 1, limit: 20, offset: 0 });
+    mockGetReportStats.mockResolvedValueOnce(STATS);
+
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(mockGetReports).toHaveBeenCalledTimes(1);
+    expect(mockGetReportStats).toHaveBeenCalledTimes(1);
+    expect(result.current.reports).toHaveLength(1);
+    expect(result.current.stats).toEqual(STATS);
+  });
+
+  it('propagates date range to stats only', async () => {
+    mockGetReports.mockResolvedValueOnce({ items: [], total: 0, limit: 20, offset: 0 });
+    mockGetReportStats.mockResolvedValueOnce(STATS);
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll({ from: '2026-01-01' });
+    });
+    expect(mockGetReportStats).toHaveBeenCalledWith('inst-1', { from: '2026-01-01' });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// submitReport
+// ══════════════════════════════════════════════════════════════
+
+describe('submitReport', () => {
+  it('prepends new report to list when no status filter', async () => {
+    mockReportContent.mockResolvedValueOnce(REPORT_3);
+    const { result } = renderHook(() => useAiReports('inst-1'));
+
+    // Seed the list with REPORT_1
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+
+    await act(async () => {
+      await result.current.submitReport({
+        contentType: 'quiz_question',
+        contentId: 'q-3',
+        reason: 'incorrect',
+      });
+    });
+    expect(result.current.reports[0].id).toBe('rep-3');
+    expect(result.current.reports).toHaveLength(2);
+    expect(result.current.pagination.total).toBe(2);
+  });
+
+  it('prepends when filters.status === "pending"', async () => {
+    mockReportContent.mockResolvedValueOnce(REPORT_3);
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    // Set the filter to pending
+    await act(async () => {
+      result.current.updateFilters({ status: 'pending' });
+    });
+    await act(async () => {
+      await result.current.submitReport({
+        contentType: 'quiz_question',
+        contentId: 'q-3',
+        reason: 'incorrect',
+      });
+    });
+    expect(result.current.reports[0].id).toBe('rep-3');
+  });
+
+  it('does NOT prepend when filters.status differs from "pending"', async () => {
+    mockReportContent.mockResolvedValueOnce(REPORT_3);
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      result.current.updateFilters({ status: 'resolved' });
+    });
+    const initialCount = result.current.reports.length;
+    await act(async () => {
+      await result.current.submitReport({
+        contentType: 'quiz_question',
+        contentId: 'q-3',
+        reason: 'incorrect',
+      });
+    });
+    // List count unchanged because report wouldn't match the active filter
+    expect(result.current.reports.length).toBe(initialCount);
+  });
+
+  it('returns the created report on success', async () => {
+    mockReportContent.mockResolvedValueOnce(REPORT_3);
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    let submitted: AiContentReport | null = null;
+    await act(async () => {
+      submitted = await result.current.submitReport({
+        contentType: 'quiz_question',
+        contentId: 'q-3',
+        reason: 'incorrect',
+      });
+    });
+    expect(submitted).toEqual(REPORT_3);
+  });
+
+  it('maps 409 error to Spanish "Ya has reportado..." message', async () => {
+    mockReportContent.mockRejectedValueOnce(new Error('HTTP 409: duplicate'));
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await expect(
+        result.current.submitReport({
+          contentType: 'quiz_question',
+          contentId: 'q-1',
+          reason: 'incorrect',
+        })
+      ).rejects.toThrow('Ya has reportado este contenido.');
+    });
+  });
+
+  it('maps "duplicate" (lowercase) error to Spanish message', async () => {
+    mockReportContent.mockRejectedValueOnce(new Error('duplicate key constraint'));
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await expect(
+        result.current.submitReport({
+          contentType: 'flashcard',
+          contentId: 'f-1',
+          reason: 'low_quality',
+        })
+      ).rejects.toThrow('Ya has reportado este contenido.');
+    });
+  });
+
+  it('rethrows non-409 errors unchanged', async () => {
+    mockReportContent.mockRejectedValueOnce(new Error('HTTP 500: boom'));
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await expect(
+        result.current.submitReport({
+          contentType: 'quiz_question',
+          contentId: 'q-1',
+          reason: 'incorrect',
+        })
+      ).rejects.toThrow('HTTP 500: boom');
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// resolveOrDismiss — optimistic + rollback
+// ══════════════════════════════════════════════════════════════
+
+describe('resolveOrDismiss', () => {
+  it('applies optimistic update immediately, then server value', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1, REPORT_2],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+    const resolved = {
+      ...REPORT_1,
+      status: 'resolved' as const,
+      resolved_by: 'prof-1',
+      resolved_at: '2026-04-18T12:00:00Z',
+      resolution_note: 'fixed',
+    };
+    mockResolveReport.mockResolvedValueOnce(resolved);
+
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    await act(async () => {
+      await result.current.resolveOrDismiss('rep-1', 'resolved', 'fixed');
+    });
+
+    const item = result.current.reports.find((r) => r.id === 'rep-1');
+    expect(item?.status).toBe('resolved');
+    expect(item?.resolution_note).toBe('fixed');
+    expect(item?.resolved_by).toBe('prof-1');
+  });
+
+  it('reverts list on server error', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1, REPORT_2],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+    mockResolveReport.mockRejectedValueOnce(new Error('HTTP 403: forbidden'));
+
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.resolveOrDismiss('rep-1', 'resolved', 'fixed')
+      ).rejects.toThrow('forbidden');
+    });
+
+    // Revert: REPORT_1 should still be pending
+    const item = result.current.reports.find((r) => r.id === 'rep-1');
+    expect(item?.status).toBe('pending');
+    expect(item?.resolution_note).toBeNull();
+  });
+
+  it('passes status + resolutionNote to service', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    mockResolveReport.mockResolvedValueOnce({ ...REPORT_1, status: 'dismissed' });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    await act(async () => {
+      await result.current.resolveOrDismiss('rep-1', 'dismissed', 'invalid');
+    });
+    expect(mockResolveReport).toHaveBeenCalledWith('rep-1', {
+      status: 'dismissed',
+      resolutionNote: 'invalid',
+    });
+  });
+
+  it('handles optional resolutionNote (undefined)', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [REPORT_1],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    mockResolveReport.mockResolvedValueOnce({ ...REPORT_1, status: 'reviewed' });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    await act(async () => {
+      await result.current.resolveOrDismiss('rep-1', 'reviewed');
+    });
+    expect(mockResolveReport).toHaveBeenCalledWith('rep-1', {
+      status: 'reviewed',
+      resolutionNote: undefined,
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Pagination helpers + computed values
+// ══════════════════════════════════════════════════════════════
+
+describe('pagination', () => {
+  async function seedWithTotal(total: number) {
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total,
+      limit: 20,
+      offset: 0,
+    });
+    const hook = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await hook.result.current.fetchReports();
+    });
+    return hook;
+  }
+
+  it('goToPage triggers fetchReports with computed offset', async () => {
+    const { result } = await seedWithTotal(100);
+    // clear seed call
+    mockGetReports.mockClear();
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total: 100,
+      limit: 20,
+      offset: 40,
+    });
+    await act(async () => {
+      result.current.goToPage(2);
+    });
+    await waitFor(() => {
+      expect(mockGetReports).toHaveBeenCalledWith('inst-1', expect.objectContaining({ offset: 40 }));
+    });
+  });
+
+  it('nextPage increments offset by limit when hasNextPage', async () => {
+    const { result } = await seedWithTotal(100);
+    mockGetReports.mockClear();
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total: 100,
+      limit: 20,
+      offset: 20,
+    });
+    await act(async () => {
+      result.current.nextPage();
+    });
+    await waitFor(() => {
+      expect(mockGetReports).toHaveBeenCalledWith('inst-1', expect.objectContaining({ offset: 20 }));
+    });
+  });
+
+  it('nextPage is no-op when already at the last page', async () => {
+    // Seed with total=20, offset=0 → one page
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total: 20,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      await result.current.fetchReports();
+    });
+    mockGetReports.mockClear();
+    await act(async () => {
+      result.current.nextPage();
+    });
+    expect(mockGetReports).not.toHaveBeenCalled();
+  });
+
+  it('prevPage clamps to offset=0 when on first page', async () => {
+    const { result } = await seedWithTotal(100);
+    mockGetReports.mockClear();
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total: 100,
+      limit: 20,
+      offset: 0,
+    });
+    await act(async () => {
+      result.current.prevPage();
+    });
+    await waitFor(() => {
+      expect(mockGetReports).toHaveBeenCalledWith(
+        'inst-1',
+        expect.objectContaining({ offset: 0 })
+      );
+    });
+  });
+
+  it('computed: totalPages, hasNextPage, hasPrevPage reflect pagination', async () => {
+    const { result } = await seedWithTotal(100);
+    expect(result.current.totalPages).toBe(5);
+    expect(result.current.currentPage).toBe(0);
+    expect(result.current.hasNextPage).toBe(true);
+    expect(result.current.hasPrevPage).toBe(false);
+  });
+
+  it('computed: totalPages=0 when total is 0', () => {
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    expect(result.current.totalPages).toBe(0);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// updateFilters
+// ══════════════════════════════════════════════════════════════
+
+describe('updateFilters', () => {
+  it('resets offset to 0 and triggers fetchReports with new filters', async () => {
+    mockGetReports.mockResolvedValueOnce({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      result.current.updateFilters({ status: 'resolved' });
+    });
+    await waitFor(() => {
+      expect(mockGetReports).toHaveBeenCalledWith('inst-1', expect.objectContaining({
+        status: 'resolved',
+        offset: 0,
+      }));
+    });
+  });
+
+  it('replaces existing filters (does not merge)', async () => {
+    mockGetReports.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+    const { result } = renderHook(() => useAiReports('inst-1'));
+    await act(async () => {
+      result.current.updateFilters({ status: 'resolved', reason: 'incorrect' });
+    });
+    await waitFor(() => {
+      expect(result.current.filters).toEqual({ status: 'resolved', reason: 'incorrect' });
+    });
+    await act(async () => {
+      result.current.updateFilters({ status: 'pending' });
+    });
+    await waitFor(() => {
+      expect(result.current.filters).toEqual({ status: 'pending' });
+    });
+  });
+});

--- a/src/app/hooks/__tests__/useBreakpoint.test.ts
+++ b/src/app/hooks/__tests__/useBreakpoint.test.ts
@@ -1,0 +1,148 @@
+// ============================================================
+// Axon -- Tests for useBreakpoint + useIsMobileBreakpoint
+//
+// Tailwind-style breakpoints (sm/md/lg/xl) via matchMedia.
+// SSR default = true (desktop-first). jsdom mock mirrors a
+// MediaQueryList with addEventListener('change', cb).
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useBreakpoint,
+  useIsMobileBreakpoint,
+  BREAKPOINTS,
+} from '@/app/hooks/useBreakpoint';
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  listeners: Array<(e: MediaQueryListEvent) => void>;
+  addEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => void;
+  removeEventListener: (
+    type: string,
+    cb: (e: MediaQueryListEvent) => void,
+  ) => void;
+  __setMatches: (value: boolean) => void;
+}
+
+const mqlRegistry = new Map<string, MockMql>();
+
+function installMatchMediaMock(matchesPredicate: (query: string) => boolean) {
+  mqlRegistry.clear();
+  window.matchMedia = vi.fn((query: string) => {
+    let mql = mqlRegistry.get(query);
+    if (!mql) {
+      mql = {
+        matches: matchesPredicate(query),
+        media: query,
+        listeners: [],
+        addEventListener(type, cb) {
+          if (type === 'change') this.listeners.push(cb);
+        },
+        removeEventListener(type, cb) {
+          if (type === 'change') {
+            this.listeners = this.listeners.filter((l) => l !== cb);
+          }
+        },
+        __setMatches(value: boolean) {
+          this.matches = value;
+          const evt = { matches: value, media: query } as MediaQueryListEvent;
+          this.listeners.slice().forEach((cb) => cb(evt));
+        },
+      };
+      mqlRegistry.set(query, mql);
+    }
+    return mql as unknown as MediaQueryList;
+  });
+}
+
+beforeEach(() => {
+  installMatchMediaMock(() => false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BREAKPOINTS', () => {
+  it('matches Tailwind defaults', () => {
+    expect(BREAKPOINTS.sm).toBe(640);
+    expect(BREAKPOINTS.md).toBe(768);
+    expect(BREAKPOINTS.lg).toBe(1024);
+    expect(BREAKPOINTS.xl).toBe(1280);
+  });
+});
+
+describe('useBreakpoint', () => {
+  it('builds (min-width: Xpx) query for "md"', () => {
+    renderHook(() => useBreakpoint('md'));
+    const q = (window.matchMedia as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(q).toBe('(min-width: 768px)');
+  });
+
+  it('builds (min-width: 1280px) for "xl"', () => {
+    renderHook(() => useBreakpoint('xl'));
+    const q = (window.matchMedia as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(q).toBe('(min-width: 1280px)');
+  });
+
+  it('returns initial match from matchMedia', () => {
+    installMatchMediaMock(() => true);
+    const { result } = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when matchMedia reports false', () => {
+    installMatchMediaMock(() => false);
+    const { result } = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(false);
+  });
+
+  it('updates when MediaQueryList dispatches "change"', () => {
+    const { result } = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(false);
+
+    const mql = mqlRegistry.get('(min-width: 1024px)');
+    act(() => {
+      mql?.__setMatches(true);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('removes the listener on unmount', () => {
+    const { unmount } = renderHook(() => useBreakpoint('sm'));
+    const mql = mqlRegistry.get('(min-width: 640px)');
+    expect(mql?.listeners.length).toBe(1);
+    unmount();
+    expect(mql?.listeners.length).toBe(0);
+  });
+});
+
+describe('useIsMobileBreakpoint', () => {
+  it('returns TRUE when viewport < lg', () => {
+    installMatchMediaMock((q) =>
+      q === '(min-width: 1024px)' ? false : true,
+    );
+    const { result } = renderHook(() => useIsMobileBreakpoint());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns FALSE when viewport >= lg', () => {
+    installMatchMediaMock(() => true);
+    const { result } = renderHook(() => useIsMobileBreakpoint());
+    expect(result.current).toBe(false);
+  });
+
+  it('reacts to "change" events on the lg query', () => {
+    installMatchMediaMock(() => false);
+    const { result } = renderHook(() => useIsMobileBreakpoint());
+    expect(result.current).toBe(true); // viewport is < lg
+
+    const mql = mqlRegistry.get('(min-width: 1024px)');
+    act(() => {
+      mql?.__setMatches(true); // now viewport >= lg
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/app/hooks/__tests__/useDebouncedValue.test.ts
+++ b/src/app/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,148 @@
+// ============================================================
+// Axon -- Tests for useDebouncedValue
+//
+// Verify the hook only updates after `delayMs` of stability and
+// that timer resets on every change. Uses vi.useFakeTimers().
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedValue } from '@/app/hooks/useDebouncedValue';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDebouncedValue', () => {
+  it('returns the initial value synchronously', () => {
+    const { result } = renderHook(() => useDebouncedValue('init', 300));
+    expect(result.current).toBe('init');
+  });
+
+  it('does NOT update before the delay has elapsed', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 300),
+      { initialProps: { v: 'a' } },
+    );
+    rerender({ v: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe('a');
+  });
+
+  it('updates exactly when the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 300),
+      { initialProps: { v: 'a' } },
+    );
+    rerender({ v: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('resets the timer when value changes mid-debounce', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 500),
+      { initialProps: { v: 'a' } },
+    );
+
+    rerender({ v: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    // Still 'a' — less than 500ms since last change.
+    expect(result.current).toBe('a');
+
+    rerender({ v: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    // Still 'a' — timer was reset by the 'c' change.
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // Now 500ms since 'c' — debounce emits 'c'.
+    expect(result.current).toBe('c');
+  });
+
+  it('handles delayMs = 0 (emits on next tick)', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 0),
+      { initialProps: { v: 'a' } },
+    );
+    rerender({ v: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('supports generic types (numbers)', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: number }) => useDebouncedValue<number>(v, 100),
+      { initialProps: { v: 1 } },
+    );
+    expect(result.current).toBe(1);
+    rerender({ v: 2 });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe(2);
+  });
+
+  it('supports generic types (objects) and returns the same reference', () => {
+    const objA = { id: 1 };
+    const objB = { id: 2 };
+    const { result, rerender } = renderHook(
+      ({ v }: { v: { id: number } }) => useDebouncedValue(v, 200),
+      { initialProps: { v: objA } },
+    );
+    expect(result.current).toBe(objA);
+    rerender({ v: objB });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe(objB);
+  });
+
+  it('re-starts the debounce when delay changes', () => {
+    const { result, rerender } = renderHook(
+      ({ v, d }: { v: string; d: number }) => useDebouncedValue(v, d),
+      { initialProps: { v: 'a', d: 500 } },
+    );
+    rerender({ v: 'b', d: 500 });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe('a');
+
+    // Change delay -> triggers effect -> new timer of 100ms from now.
+    rerender({ v: 'b', d: 100 });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('clears the pending timer on unmount (no crashes)', () => {
+    const { rerender, unmount } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 500),
+      { initialProps: { v: 'a' } },
+    );
+    rerender({ v: 'b' });
+    unmount();
+    // Advance past the debounce window — should not throw.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+  });
+});

--- a/src/app/hooks/__tests__/useFlashcardCoverage.test.ts
+++ b/src/app/hooks/__tests__/useFlashcardCoverage.test.ts
@@ -1,0 +1,283 @@
+/**
+ * useFlashcardCoverage.test.ts — Tests for the flashcard↔topic FSRS coverage hook (T-01)
+ *
+ * Coverage: initial load, keywordStats aggregation from mapping + queue,
+ *           fallback to study-queue when mapping fetch fails, refresh()
+ *           bypassing the cache, empty-deck edge case, due/new counters.
+ *
+ * NOTE (MASTERY-SYSTEMS.md): `avgPKnow` / `avgStability` / `avgDifficulty`
+ * derive from StudyQueueItem FSRS scheduling (p_know here is the card's
+ * SRS probability-of-recall, Sistema B domain — card mastery absoluto).
+ * The hook only averages; no threshold comparisons are made.
+ *
+ * Mocks: @/app/services/flashcardMappingApi (getAllFlashcardMappings)
+ *        → mocked via dynamic vi.mock and module reset to bypass
+ *          the module-level cache between scenarios.
+ *
+ * Run: npx vitest run src/app/hooks/__tests__/useFlashcardCoverage.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+import type { StudyQueueItem } from '@/app/lib/studyQueueApi';
+
+// ── Mock setup (declared once; reset per test via resetModules) ──
+
+const mockGetAllFlashcardMappings = vi.fn();
+
+vi.mock('@/app/services/flashcardMappingApi', () => ({
+  getAllFlashcardMappings: (...args: unknown[]) => mockGetAllFlashcardMappings(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────
+
+function makeQueueItem(overrides: Partial<StudyQueueItem> = {}): StudyQueueItem {
+  return {
+    flashcard_id: 'fc-1',
+    summary_id: 'sum-1',
+    keyword_id: 'kw-1',
+    subtopic_id: 'sub-1',
+    front: 'Q',
+    back: 'A',
+    front_image_url: null,
+    back_image_url: null,
+    need_score: 0.5,
+    retention: 0.9,
+    mastery_color: 'yellow',
+    p_know: 0.5,
+    fsrs_state: 'review',
+    due_at: null,
+    stability: 10,
+    difficulty: 5,
+    is_new: false,
+    is_leech: false,
+    consecutive_lapses: 0,
+    clinical_priority: 0,
+    ...overrides,
+  };
+}
+
+function makeMapping(
+  entries: Array<[string, string, string | null]>
+): Map<string, { subtopic_id: string | null; keyword_id: string }> {
+  const m = new Map<string, { subtopic_id: string | null; keyword_id: string }>();
+  for (const [id, kw, sub] of entries) {
+    m.set(id, { subtopic_id: sub, keyword_id: kw });
+  }
+  return m;
+}
+
+// We must reset modules between tests to clear the module-level _mappingCache.
+async function loadHook() {
+  const mod = await import('../useFlashcardCoverage');
+  return mod.useFlashcardCoverage;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mockGetAllFlashcardMappings.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe('useFlashcardCoverage', () => {
+  it('starts in loading state with empty maps', async () => {
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(new Map());
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], true));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.mappingLookup.size).toBe(0);
+    expect(result.current.keywordStats.size).toBe(0);
+  });
+
+  it('loads mapping and completes loading when sqLoading=false', async () => {
+    const mapping = makeMapping([
+      ['fc-1', 'kw-A', 'sub-A'],
+      ['fc-2', 'kw-A', 'sub-A'],
+      ['fc-3', 'kw-B', 'sub-B'],
+    ]);
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.mappingLookup.size).toBe(3);
+    expect(result.current.fallback).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('remains loading=true when sqLoading=true even after fetch resolves', async () => {
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(new Map());
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], true));
+    // mapping fetched but sq still loading → loading stays true
+    await waitFor(() => expect(result.current.mappingLookup.size).toBe(0));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('computes keywordStats from mapping totals + queue items', async () => {
+    // mapping: kw-A has 2 cards, kw-B has 1 card
+    const mapping = makeMapping([
+      ['fc-1', 'kw-A', 'sub-A'],
+      ['fc-2', 'kw-A', 'sub-A'],
+      ['fc-3', 'kw-B', 'sub-B'],
+    ]);
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+
+    // queue has scheduling for fc-1 (kw-A) and fc-3 (kw-B) — only 1 of kw-A's 2 is scheduled
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-1', keyword_id: 'kw-A', p_know: 0.4, stability: 5, difficulty: 4, is_new: false, due_at: '2020-01-01T00:00:00Z' }),
+      makeQueueItem({ flashcard_id: 'fc-3', keyword_id: 'kw-B', p_know: 0.8, stability: 20, difficulty: 6, is_new: true, due_at: null, fsrs_state: 'new' }),
+    ];
+
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const statsA = result.current.keywordStats.get('kw-A')!;
+    const statsB = result.current.keywordStats.get('kw-B')!;
+    expect(statsA).toBeDefined();
+    expect(statsB).toBeDefined();
+
+    // kw-A: 2 total cards in mapping, 1 scheduled, 1 due (past date), 0 new
+    expect(statsA.totalCards).toBe(2);
+    expect(statsA.scheduledCards).toBe(1);
+    expect(statsA.dueCards).toBe(1);
+    expect(statsA.newCards).toBe(0);
+    expect(statsA.avgPKnow).toBeCloseTo(0.4, 5);
+    expect(statsA.coverage).toBeCloseTo(0.5, 5);
+
+    // kw-B: 1 total, 1 scheduled, 1 new (fsrs_state=new), 0 due (due_at null)
+    expect(statsB.totalCards).toBe(1);
+    expect(statsB.scheduledCards).toBe(1);
+    expect(statsB.newCards).toBe(1);
+    expect(statsB.dueCards).toBe(0);
+    expect(statsB.coverage).toBe(1);
+  });
+
+  it('coverage caps at 1 when queue has more scheduled than mapping has total', async () => {
+    const mapping = makeMapping([['fc-1', 'kw-A', 'sub-A']]); // only 1
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-1', keyword_id: 'kw-A' }),
+      makeQueueItem({ flashcard_id: 'fc-2', keyword_id: 'kw-A' }),
+    ];
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const stats = result.current.keywordStats.get('kw-A')!;
+    // totalCards = max(total=1, scheduled=2) = 2 (source line 88)
+    expect(stats.totalCards).toBe(2);
+    expect(stats.scheduledCards).toBe(2);
+    expect(stats.coverage).toBe(1); // clamped by Math.min(ratio, 1)
+  });
+
+  it('returns coverage=0 when a keyword has total=0 in mapping', async () => {
+    // Keyword kw-Z exists only in the queue, not in mapping
+    const mapping = makeMapping([['fc-1', 'kw-A', 'sub-A']]);
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-orphan', keyword_id: 'kw-Z', p_know: 0.7 }),
+    ];
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const stats = result.current.keywordStats.get('kw-Z')!;
+    expect(stats.totalCards).toBe(1); // max(0, 1)
+    expect(stats.scheduledCards).toBe(1);
+    // totalByKeyword.get returned undefined → total=0 → coverage=0
+    expect(stats.coverage).toBe(0);
+  });
+
+  it('ignores queue items with falsy keyword_id (defensive)', async () => {
+    const mapping = makeMapping([]);
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-bad', keyword_id: '' }),
+    ];
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.keywordStats.size).toBe(0);
+  });
+
+  it('falls back to study-queue when getAllFlashcardMappings throws', async () => {
+    mockGetAllFlashcardMappings.mockRejectedValueOnce(new Error('500 backend down'));
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-1', keyword_id: 'kw-A', subtopic_id: 'sub-A' }),
+      makeQueueItem({ flashcard_id: 'fc-2', keyword_id: 'kw-A', subtopic_id: 'sub-A' }),
+    ];
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.fallback).toBe(true);
+    expect(result.current.error).toContain('500 backend down');
+    // fallback map built from queue items
+    expect(result.current.mappingLookup.size).toBe(2);
+    expect(result.current.mappingLookup.get('fc-1')).toEqual({ subtopic_id: 'sub-A', keyword_id: 'kw-A' });
+  });
+
+  it('sets a non-Error string rejection to a default message', async () => {
+    mockGetAllFlashcardMappings.mockRejectedValueOnce('string-reject');
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.fallback).toBe(true);
+    expect(result.current.error).toBe('Failed to fetch flashcard mappings');
+  });
+
+  it('returns empty keywordStats when deck and queue are both empty', async () => {
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(new Map());
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.keywordStats.size).toBe(0);
+  });
+
+  it('refresh() re-fetches mapping (cache bypassed)', async () => {
+    const mapping1 = makeMapping([['fc-1', 'kw-A', 'sub-A']]);
+    const mapping2 = makeMapping([
+      ['fc-1', 'kw-A', 'sub-A'],
+      ['fc-2', 'kw-B', 'sub-B'],
+    ]);
+    mockGetAllFlashcardMappings
+      .mockResolvedValueOnce(mapping1)
+      .mockResolvedValueOnce(mapping2);
+
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage([], false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.mappingLookup.size).toBe(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockGetAllFlashcardMappings).toHaveBeenCalledTimes(2);
+    expect(result.current.mappingLookup.size).toBe(2);
+  });
+
+  it('avgStability and avgDifficulty are means over scheduled items only', async () => {
+    const mapping = makeMapping([
+      ['fc-1', 'kw-A', 'sub-A'],
+      ['fc-2', 'kw-A', 'sub-A'],
+      ['fc-3', 'kw-A', 'sub-A'], // not in queue
+    ]);
+    mockGetAllFlashcardMappings.mockResolvedValueOnce(mapping);
+    const queue: StudyQueueItem[] = [
+      makeQueueItem({ flashcard_id: 'fc-1', keyword_id: 'kw-A', stability: 10, difficulty: 4, p_know: 0.5 }),
+      makeQueueItem({ flashcard_id: 'fc-2', keyword_id: 'kw-A', stability: 20, difficulty: 6, p_know: 0.7 }),
+    ];
+    const useFlashcardCoverage = await loadHook();
+    const { result } = renderHook(() => useFlashcardCoverage(queue, false));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const stats = result.current.keywordStats.get('kw-A')!;
+    expect(stats.avgStability).toBeCloseTo(15, 5);
+    expect(stats.avgDifficulty).toBeCloseTo(5, 5);
+    expect(stats.avgPKnow).toBeCloseTo(0.6, 5);
+    // scheduled=2, total=3, coverage ~0.6667
+    expect(stats.coverage).toBeCloseTo(2 / 3, 5);
+  });
+});

--- a/src/app/hooks/__tests__/useFlashcardImage.test.ts
+++ b/src/app/hooks/__tests__/useFlashcardImage.test.ts
@@ -1,0 +1,221 @@
+// ============================================================
+// Hook Tests — useFlashcardImage
+//
+// Coverage: initial idle state, mutation happy-path (POST endpoint +
+// body), query invalidation, toast success + error, error exposure,
+// isGenerating flag lifecycle.
+//
+// Mocks:
+//   - @/app/lib/api (apiCall)
+//   - sonner (toast.success / toast.error)
+//
+// Run: npx vitest run src/app/hooks/__tests__/useFlashcardImage.test.ts
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ── Mocks ─────────────────────────────────────────────────
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...a: unknown[]) => mockToastSuccess(...a),
+    error: (...a: unknown[]) => mockToastError(...a),
+  },
+}));
+
+// ── Import AFTER mocks ────────────────────────────────────
+
+import { apiCall } from '@/app/lib/api';
+import { useFlashcardImage } from '@/app/hooks/useFlashcardImage';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Wrapper factory ──────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe('useFlashcardImage', () => {
+  beforeEach(() => {
+    // reset to drop mockResolvedValueOnce queues
+    mockApiCall.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+  });
+
+  it('returns idle state with null error and isGenerating=false', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+    expect(result.current.isGenerating).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.generateImage).toBe('function');
+  });
+
+  it('POSTs to /content/flashcards/:id/generate-image with the flashcardId', async () => {
+    mockApiCall.mockResolvedValueOnce({
+      image_url: 'https://img/url',
+      model: 'gemini-img-1',
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      await result.current.generateImage('fc-42');
+    });
+
+    expect(mockApiCall).toHaveBeenCalledTimes(1);
+    const [path, options] = mockApiCall.mock.calls[0];
+    expect(path).toBe('/content/flashcards/fc-42/generate-image');
+    expect((options as RequestInit).method).toBe('POST');
+  });
+
+  it('forwards imagePrompt and stylePackId in the JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce({ image_url: 'u', model: 'm' });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      await result.current.generateImage('fc-1', {
+        imagePrompt: 'a red heart',
+        stylePackId: 'pack-anatomy',
+      });
+    });
+
+    const options = mockApiCall.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(options.body as string);
+    expect(body).toEqual({
+      imagePrompt: 'a red heart',
+      stylePackId: 'pack-anatomy',
+    });
+  });
+
+  it('sends body with undefined fields when opts is omitted', async () => {
+    mockApiCall.mockResolvedValueOnce({ image_url: 'u', model: 'm' });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      await result.current.generateImage('fc-1');
+    });
+
+    const options = mockApiCall.mock.calls[0][1] as RequestInit;
+    const parsed = JSON.parse(options.body as string);
+    // JSON.stringify drops undefined keys → object may be empty {}
+    expect(parsed.imagePrompt).toBeUndefined();
+    expect(parsed.stylePackId).toBeUndefined();
+  });
+
+  it('shows success toast and invalidates flashcards queries on success', async () => {
+    mockApiCall.mockResolvedValueOnce({ image_url: 'u', model: 'm' });
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      await result.current.generateImage('fc-1');
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith('Imagen generada exitosamente');
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['flashcards'] }),
+    );
+  });
+
+  it('shows error toast with message on failure and rejects', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('AI quota exceeded'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    let caught: unknown = null;
+    await act(async () => {
+      try {
+        await result.current.generateImage('fc-1');
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Error generando imagen: AI quota exceeded',
+    );
+  });
+
+  it('exposes error.message via the `error` field after a failure', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('bad request'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.generateImage('fc-1');
+      } catch {
+        /* noop */
+      }
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('bad request'));
+  });
+
+  it('does not call toast.success when the request fails', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('x'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.generateImage('fc-1');
+      } catch {
+        /* noop */
+      }
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('flips isGenerating during an in-flight request', async () => {
+    let resolveApi!: (value: unknown) => void;
+    mockApiCall.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveApi = resolve;
+        }),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFlashcardImage(), { wrapper });
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.generateImage('fc-1');
+    });
+
+    await waitFor(() => expect(result.current.isGenerating).toBe(true));
+
+    await act(async () => {
+      resolveApi({ image_url: 'u', model: 'm' });
+      await pending;
+    });
+
+    await waitFor(() => expect(result.current.isGenerating).toBe(false));
+  });
+});

--- a/src/app/hooks/__tests__/useGamification.test.ts
+++ b/src/app/hooks/__tests__/useGamification.test.ts
@@ -1,0 +1,357 @@
+// ============================================================
+// Hook Tests — useGamification (React Query wrappers)
+//
+// Coverage (observable behaviour only):
+//   - Queries disabled without institutionId (return null/defaults)
+//   - Queries call the underlying API when institutionId provided
+//   - Query keys include institutionId / period parts
+//   - useStudyQueue always calls the API (no institutionId gating)
+//   - useDailyCheckIn / useStreakRepair invalidate streak+profile caches
+//
+// Ownership note: useGamification.ts is SHARED with the Gamification
+// agent. These tests target observable React-Query behaviour of the
+// hook; they do NOT assert on the API service internals.
+//
+// Mocks:
+//   - @/app/services/gamificationApi (all functions used by the hook)
+//
+// Run: npx vitest run src/app/hooks/__tests__/useGamification.test.ts
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ── Mocks ─────────────────────────────────────────────────
+
+const mockGetProfile = vi.fn();
+const mockGetStreakStatus = vi.fn();
+const mockGetBadges = vi.fn();
+const mockGetLeaderboard = vi.fn();
+const mockGetXPHistory = vi.fn();
+const mockGetStudyQueue = vi.fn();
+const mockDailyCheckIn = vi.fn();
+const mockRepairStreak = vi.fn();
+
+vi.mock('@/app/services/gamificationApi', () => ({
+  getProfile: (...a: unknown[]) => mockGetProfile(...a),
+  getStreakStatus: (...a: unknown[]) => mockGetStreakStatus(...a),
+  getBadges: (...a: unknown[]) => mockGetBadges(...a),
+  getLeaderboard: (...a: unknown[]) => mockGetLeaderboard(...a),
+  getXPHistory: (...a: unknown[]) => mockGetXPHistory(...a),
+  getStudyQueue: (...a: unknown[]) => mockGetStudyQueue(...a),
+  dailyCheckIn: (...a: unknown[]) => mockDailyCheckIn(...a),
+  repairStreak: (...a: unknown[]) => mockRepairStreak(...a),
+}));
+
+// ── Import AFTER mocks ────────────────────────────────────
+
+import {
+  useGamificationProfile,
+  useStreakStatus,
+  useBadges,
+  useLeaderboard,
+  useXPHistory,
+  useStudyQueue,
+  useDailyCheckIn,
+  useStreakRepair,
+} from '@/app/hooks/useGamification';
+
+// ── Wrapper factory ──────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+const INST = 'inst-42';
+
+// ── Reset mocks ───────────────────────────────────────────
+
+beforeEach(() => {
+  mockGetProfile.mockReset();
+  mockGetStreakStatus.mockReset();
+  mockGetBadges.mockReset();
+  mockGetLeaderboard.mockReset();
+  mockGetXPHistory.mockReset();
+  mockGetStudyQueue.mockReset();
+  mockDailyCheckIn.mockReset();
+  mockRepairStreak.mockReset();
+});
+
+// ============================================================
+// useGamificationProfile
+// ============================================================
+
+describe('useGamificationProfile', () => {
+  it('is disabled when institutionId is missing (no API call)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useGamificationProfile(undefined), { wrapper });
+    // disabled → stays in idle-like state; fetchStatus 'idle'
+    expect(mockGetProfile).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('calls getProfile with institutionId when provided', async () => {
+    mockGetProfile.mockResolvedValueOnce({
+      xp: {
+        total: 120,
+        today: 10,
+        this_week: 50,
+        level: 2,
+        daily_goal_minutes: 30,
+        daily_cap: 500,
+        streak_freezes_owned: 0,
+      },
+      streak: { current: 3, longest: 7, last_study_date: '2026-04-17' },
+      badges_earned: 1,
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useGamificationProfile(INST), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetProfile).toHaveBeenCalledWith(INST);
+    expect(result.current.data?.xp.total).toBe(120);
+  });
+});
+
+// ============================================================
+// useStreakStatus
+// ============================================================
+
+describe('useStreakStatus', () => {
+  it('is disabled without institutionId', () => {
+    const { wrapper } = createWrapper();
+    renderHook(() => useStreakStatus(undefined), { wrapper });
+    expect(mockGetStreakStatus).not.toHaveBeenCalled();
+  });
+
+  it('calls getStreakStatus and returns the payload', async () => {
+    mockGetStreakStatus.mockResolvedValueOnce({
+      current_streak: 5,
+      longest_streak: 10,
+      last_check_in: '2026-04-17',
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStreakStatus(INST), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetStreakStatus).toHaveBeenCalledWith(INST);
+    expect(result.current.data?.current_streak).toBe(5);
+  });
+});
+
+// ============================================================
+// useBadges
+// ============================================================
+
+describe('useBadges', () => {
+  it('always calls getBadges (no gating on institutionId)', async () => {
+    mockGetBadges.mockResolvedValueOnce({ badges: [], total: 0, earned_count: 0 });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBadges(INST), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetBadges).toHaveBeenCalledWith(INST);
+  });
+
+  it('forwards undefined institutionId to getBadges (public badges)', async () => {
+    mockGetBadges.mockResolvedValueOnce({ badges: [], total: 0, earned_count: 0 });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBadges(undefined), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetBadges).toHaveBeenCalledWith(undefined);
+  });
+});
+
+// ============================================================
+// useLeaderboard
+// ============================================================
+
+describe('useLeaderboard', () => {
+  it('is disabled without institutionId', () => {
+    const { wrapper } = createWrapper();
+    renderHook(() => useLeaderboard(undefined), { wrapper });
+    expect(mockGetLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it('calls getLeaderboard with default weekly period', async () => {
+    mockGetLeaderboard.mockResolvedValueOnce({
+      leaderboard: [],
+      my_rank: null,
+      period: 'weekly',
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeaderboard(INST), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetLeaderboard).toHaveBeenCalledWith(INST, { period: 'weekly' });
+  });
+
+  it('passes daily period through', async () => {
+    mockGetLeaderboard.mockResolvedValueOnce({
+      leaderboard: [],
+      my_rank: null,
+      period: 'daily',
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeaderboard(INST, 'daily'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetLeaderboard).toHaveBeenCalledWith(INST, { period: 'daily' });
+  });
+
+  it('uses different cache entries for different periods', async () => {
+    mockGetLeaderboard.mockResolvedValue({
+      leaderboard: [],
+      my_rank: null,
+      period: 'weekly',
+    });
+    const { wrapper } = createWrapper();
+    const { result: weekly } = renderHook(() => useLeaderboard(INST, 'weekly'), { wrapper });
+    const { result: daily } = renderHook(() => useLeaderboard(INST, 'daily'), { wrapper });
+    await waitFor(() => expect(weekly.current.isSuccess).toBe(true));
+    await waitFor(() => expect(daily.current.isSuccess).toBe(true));
+    // Each hook fetched separately → two calls
+    expect(mockGetLeaderboard).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ============================================================
+// useXPHistory
+// ============================================================
+
+describe('useXPHistory', () => {
+  it('is disabled without institutionId', () => {
+    const { wrapper } = createWrapper();
+    renderHook(() => useXPHistory(undefined), { wrapper });
+    expect(mockGetXPHistory).not.toHaveBeenCalled();
+  });
+
+  it('calls getXPHistory with limit=50', async () => {
+    mockGetXPHistory.mockResolvedValueOnce({
+      items: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useXPHistory(INST), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetXPHistory).toHaveBeenCalledWith(INST, { limit: 50 });
+  });
+});
+
+// ============================================================
+// useStudyQueue
+// ============================================================
+
+describe('useStudyQueue', () => {
+  it('calls getStudyQueue with limit=20 (no institutionId gate)', async () => {
+    mockGetStudyQueue.mockResolvedValueOnce({
+      queue: [],
+      meta: {
+        total_due: 0,
+        total_new: 0,
+        total_in_queue: 0,
+        returned: 0,
+        limit: 20,
+        include_future: false,
+        course_id: null,
+        generated_at: '2026-04-18T00:00:00Z',
+        algorithm: 'fsrs',
+        engine: 'sql',
+      },
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStudyQueue(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetStudyQueue).toHaveBeenCalledWith({ limit: 20 });
+  });
+});
+
+// ============================================================
+// useDailyCheckIn (mutation)
+// ============================================================
+
+describe('useDailyCheckIn', () => {
+  it('resolves to null and does not call API when institutionId missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDailyCheckIn(undefined), { wrapper });
+    await act(async () => {
+      result.current.mutate();
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDailyCheckIn).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('calls dailyCheckIn with institutionId and invalidates streak + profile caches', async () => {
+    mockDailyCheckIn.mockResolvedValueOnce({
+      streak_status: { current_streak: 1, longest_streak: 1, last_check_in: '2026-04-18' },
+      events: [{ type: 'streak_started', message: 'ok' }],
+    });
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDailyCheckIn(INST), { wrapper });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDailyCheckIn).toHaveBeenCalledWith(INST);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (c) => (c[0] as { queryKey: readonly unknown[] }).queryKey,
+    );
+    // Keys from hook: ['gamification','streak',INST] and ['gamification','profile',INST]
+    expect(invalidatedKeys).toContainEqual(['gamification', 'streak', INST]);
+    expect(invalidatedKeys).toContainEqual(['gamification', 'profile', INST]);
+  });
+});
+
+// ============================================================
+// useStreakRepair (mutation)
+// ============================================================
+
+describe('useStreakRepair', () => {
+  it('resolves to null without calling API when institutionId missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStreakRepair(undefined), { wrapper });
+    await act(async () => {
+      result.current.mutate();
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRepairStreak).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('calls repairStreak and invalidates streak + profile caches on success', async () => {
+    mockRepairStreak.mockResolvedValueOnce({
+      repaired: true,
+      restored_streak: 5,
+      xp_spent: 50,
+      remaining_xp: 100,
+    });
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useStreakRepair(INST), { wrapper });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRepairStreak).toHaveBeenCalledWith(INST);
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (c) => (c[0] as { queryKey: readonly unknown[] }).queryKey,
+    );
+    expect(invalidatedKeys).toContainEqual(['gamification', 'streak', INST]);
+    expect(invalidatedKeys).toContainEqual(['gamification', 'profile', INST]);
+  });
+});

--- a/src/app/hooks/__tests__/useIsMobile.test.ts
+++ b/src/app/hooks/__tests__/useIsMobile.test.ts
@@ -1,0 +1,149 @@
+// ============================================================
+// Axon -- Tests for useIsMobile
+//
+// Default breakpoint: 1024px. Query uses (max-width: 1023px)
+// so the initial read uses window.innerWidth and the live
+// update comes from the 'change' event.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useIsMobile } from '@/app/hooks/useIsMobile';
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  listeners: Array<(e: MediaQueryListEvent) => void>;
+  addEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => void;
+  removeEventListener: (
+    type: string,
+    cb: (e: MediaQueryListEvent) => void,
+  ) => void;
+  __setMatches: (value: boolean) => void;
+}
+
+const mqlRegistry = new Map<string, MockMql>();
+
+function installMatchMediaMock(matchesPredicate: (query: string) => boolean) {
+  mqlRegistry.clear();
+  window.matchMedia = vi.fn((query: string) => {
+    let mql = mqlRegistry.get(query);
+    if (!mql) {
+      mql = {
+        matches: matchesPredicate(query),
+        media: query,
+        listeners: [],
+        addEventListener(type, cb) {
+          if (type === 'change') this.listeners.push(cb);
+        },
+        removeEventListener(type, cb) {
+          if (type === 'change') {
+            this.listeners = this.listeners.filter((l) => l !== cb);
+          }
+        },
+        __setMatches(value: boolean) {
+          this.matches = value;
+          const evt = { matches: value, media: query } as MediaQueryListEvent;
+          this.listeners.slice().forEach((cb) => cb(evt));
+        },
+      };
+      mqlRegistry.set(query, mql);
+    }
+    return mql as unknown as MediaQueryList;
+  });
+}
+
+function setInnerWidth(px: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: px,
+  });
+}
+
+beforeEach(() => {
+  installMatchMediaMock(() => false);
+  setInnerWidth(1440); // default: desktop-ish
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useIsMobile — default breakpoint (1024)', () => {
+  it('initial state is based on window.innerWidth (desktop)', () => {
+    setInnerWidth(1440);
+    installMatchMediaMock(() => false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('initial state is TRUE when innerWidth < 1024', () => {
+    setInnerWidth(800);
+    installMatchMediaMock(() => true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('builds (max-width: 1023px) query', () => {
+    renderHook(() => useIsMobile());
+    const q = (window.matchMedia as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(q).toBe('(max-width: 1023px)');
+  });
+});
+
+describe('useIsMobile — custom breakpoint', () => {
+  it('builds (max-width: 767px) for breakpoint=768', () => {
+    renderHook(() => useIsMobile(768));
+    const q = (window.matchMedia as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(q).toBe('(max-width: 767px)');
+  });
+
+  it('re-subscribes when breakpoint prop changes', () => {
+    const { rerender } = renderHook(
+      ({ bp }: { bp: number }) => useIsMobile(bp),
+      { initialProps: { bp: 1024 } },
+    );
+    expect(mqlRegistry.get('(max-width: 1023px)')?.listeners.length).toBe(1);
+
+    rerender({ bp: 768 });
+    expect(mqlRegistry.get('(max-width: 1023px)')?.listeners.length).toBe(0);
+    expect(mqlRegistry.get('(max-width: 767px)')?.listeners.length).toBe(1);
+  });
+});
+
+describe('useIsMobile — reactive updates', () => {
+  it('updates when the MediaQueryList dispatches "change"', () => {
+    setInnerWidth(1440);
+    installMatchMediaMock(() => false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    const mql = mqlRegistry.get('(max-width: 1023px)');
+    act(() => {
+      mql?.__setMatches(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      mql?.__setMatches(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('syncs to mql.matches on mount (overrides innerWidth-based initial)', () => {
+    // innerWidth says desktop, but matchMedia says mobile -> effect syncs.
+    setInnerWidth(1440);
+    installMatchMediaMock(() => true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('removes the listener on unmount', () => {
+    const { unmount } = renderHook(() => useIsMobile());
+    const mql = mqlRegistry.get('(max-width: 1023px)');
+    expect(mql?.listeners.length).toBe(1);
+    unmount();
+    expect(mql?.listeners.length).toBe(0);
+  });
+});

--- a/src/app/hooks/__tests__/useKeywordMastery.test.ts
+++ b/src/app/hooks/__tests__/useKeywordMastery.test.ts
@@ -1,0 +1,348 @@
+/**
+ * useKeywordMastery.test.ts — Tests for the keyword-level mastery hook.
+ *
+ * SISTEMA C (MASTERY-SYSTEMS.md): this hook consumes StudyQueueItem[]
+ * (which carries `p_know` per card), groups by keyword_id, averages p_know,
+ * and classifies via `getKeywordDeltaColorSafe(avg, priority=1)` →
+ * threshold 0.70 (low priority default).
+ *
+ * Delta thresholds in use (all default priority 1 → threshold 0.70):
+ *   delta = avg_p_know / 0.70
+ *     < 0.50   → gray   (avg < 0.35)
+ *     >= 0.50  → red    (avg >= 0.35)
+ *     >= 0.85  → yellow (avg >= 0.595)
+ *     >= 1.00  → green  (avg >= 0.70)
+ *     >= 1.10  → blue   (avg >= 0.77)
+ *   (delta rounded to 2 decimals before comparing)
+ *
+ * Coverage:
+ *   - masteryMap construction (avg p_know + delta level per keyword)
+ *   - getMastery / getPKnow for known + unknown keywords
+ *   - getStats aggregation across mixed masteries
+ *   - getSortedEntries ordering (weakest first by pKnow)
+ *   - empty input → empty stats
+ *   - loading is passed through verbatim
+ *   - masteryConfig exports one entry per DeltaColorLevel
+ *
+ * RUN: npx vitest run src/app/hooks/__tests__/useKeywordMastery.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { StudyQueueItem } from '@/app/lib/studyQueueApi';
+import {
+  useKeywordMastery,
+  masteryConfig,
+} from '@/app/hooks/useKeywordMastery';
+
+// ── Fixture helpers ───────────────────────────────────────
+
+function makeItem(
+  keyword_id: string,
+  p_know: number,
+  overrides: Partial<StudyQueueItem> = {},
+): StudyQueueItem {
+  return {
+    flashcard_id: `fc-${keyword_id}-${p_know}`,
+    summary_id: 'sum-1',
+    keyword_id,
+    subtopic_id: `sub-${keyword_id}`,
+    front: 'Q',
+    back: 'A',
+    front_image_url: null,
+    back_image_url: null,
+    need_score: 0.5,
+    retention: 0.8,
+    mastery_color: 'green',
+    p_know,
+    fsrs_state: 'review',
+    due_at: null,
+    stability: 10,
+    difficulty: 5,
+    is_new: false,
+    is_leech: false,
+    consecutive_lapses: 0,
+    clinical_priority: 0,
+    ...overrides,
+  };
+}
+
+function buildByKeyword(
+  groups: Record<string, number[]>,
+): Map<string, StudyQueueItem[]> {
+  const map = new Map<string, StudyQueueItem[]>();
+  for (const [kw, scores] of Object.entries(groups)) {
+    map.set(kw, scores.map((s) => makeItem(kw, s)));
+  }
+  return map;
+}
+
+// ─────────────────────────────────────────────────────────
+// Suite 1: empty input
+// ─────────────────────────────────────────────────────────
+
+describe('useKeywordMastery', () => {
+  describe('when input Map is empty', () => {
+    it('returns an empty masteryMap', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), false),
+      );
+      expect(result.current.masteryMap.size).toBe(0);
+    });
+
+    it('getStats returns all zeros', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), false),
+      );
+      const stats = result.current.getStats();
+      expect(stats).toEqual({
+        gray: 0,
+        red: 0,
+        yellow: 0,
+        green: 0,
+        blue: 0,
+        total: 0,
+      });
+    });
+
+    it('getSortedEntries returns an empty array', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), false),
+      );
+      expect(result.current.getSortedEntries()).toEqual([]);
+    });
+
+    it('getMastery / getPKnow return null for any keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), false),
+      );
+      expect(result.current.getMastery('whatever')).toBeNull();
+      expect(result.current.getPKnow('whatever')).toBeNull();
+    });
+
+    it('propagates loading=true verbatim', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), true),
+      );
+      expect(result.current.loading).toBe(true);
+    });
+
+    it('propagates loading=false verbatim', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(new Map(), false),
+      );
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Suite 2: single keyword, avg + classification
+  // ─────────────────────────────────────────────────────────
+
+  describe('single keyword with multiple cards', () => {
+    it('computes avg(p_know) across cards', () => {
+      // avg = (0.6 + 0.8) / 2 = 0.70
+      const input = buildByKeyword({ 'kw-A': [0.6, 0.8] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      const entry = result.current.masteryMap.get('kw-A')!;
+      expect(entry.pKnow).toBeCloseTo(0.7, 10);
+      expect(entry.cardCount).toBe(2);
+      expect(entry.keywordId).toBe('kw-A');
+    });
+
+    it('classifies avg=0.70 as green (delta=1.00 at threshold 0.70)', () => {
+      const input = buildByKeyword({ 'kw-A': [0.6, 0.8] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-A')!.mastery).toBe('green');
+    });
+
+    it('classifies avg=0.20 as gray (delta≈0.29 < 0.50)', () => {
+      const input = buildByKeyword({ 'kw-low': [0.2] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-low')!.mastery).toBe('gray');
+    });
+
+    it('classifies avg=0.40 as red (delta≈0.57 ≥ 0.50)', () => {
+      const input = buildByKeyword({ 'kw-red': [0.4] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-red')!.mastery).toBe('red');
+    });
+
+    it('classifies avg=0.60 as yellow (delta≈0.86 ≥ 0.85)', () => {
+      const input = buildByKeyword({ 'kw-yellow': [0.6] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-yellow')!.mastery).toBe('yellow');
+    });
+
+    it('classifies avg=0.80 as blue (delta≈1.14 ≥ 1.10)', () => {
+      const input = buildByKeyword({ 'kw-blue': [0.8] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-blue')!.mastery).toBe('blue');
+    });
+
+    it('classifies avg=1.00 as blue (delta≈1.43)', () => {
+      const input = buildByKeyword({ 'kw-max': [1.0, 1.0, 1.0] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-max')!.mastery).toBe('blue');
+    });
+
+    it('classifies avg=0.00 as gray (delta = 0)', () => {
+      const input = buildByKeyword({ 'kw-zero': [0.0] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.get('kw-zero')!.mastery).toBe('gray');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Suite 3: multiple keywords → aggregation
+  // ─────────────────────────────────────────────────────────
+
+  describe('aggregation across multiple keywords', () => {
+    const MIX: Record<string, number[]> = {
+      'kw-gray': [0.1, 0.2],           // avg 0.15 → gray
+      'kw-red': [0.4, 0.4],            // avg 0.40 → red
+      'kw-yellow': [0.6, 0.6],         // avg 0.60 → yellow
+      'kw-green': [0.7, 0.7, 0.7],     // avg 0.70 → green
+      'kw-blue': [0.9, 0.9],           // avg 0.90 → blue
+    };
+
+    it('masteryMap contains every keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.masteryMap.size).toBe(5);
+      for (const kw of Object.keys(MIX)) {
+        expect(result.current.masteryMap.has(kw)).toBe(true);
+      }
+    });
+
+    it('getStats counts one keyword per bucket', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.getStats()).toEqual({
+        gray: 1,
+        red: 1,
+        yellow: 1,
+        green: 1,
+        blue: 1,
+        total: 5,
+      });
+    });
+
+    it('getSortedEntries orders by pKnow ascending (weakest first)', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      const sorted = result.current.getSortedEntries();
+      const ids = sorted.map((e) => e.keywordId);
+      expect(ids).toEqual([
+        'kw-gray',
+        'kw-red',
+        'kw-yellow',
+        'kw-green',
+        'kw-blue',
+      ]);
+    });
+
+    it('getMastery returns the correct level for a known keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.getMastery('kw-blue')).toBe('blue');
+      expect(result.current.getMastery('kw-gray')).toBe('gray');
+    });
+
+    it('getMastery returns null for an unknown keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.getMastery('kw-does-not-exist')).toBeNull();
+    });
+
+    it('getPKnow returns the avg for a known keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.getPKnow('kw-yellow')).toBeCloseTo(0.6, 10);
+    });
+
+    it('getPKnow returns null for an unknown keyword', () => {
+      const { result } = renderHook(() =>
+        useKeywordMastery(buildByKeyword(MIX), false),
+      );
+      expect(result.current.getPKnow('kw-missing')).toBeNull();
+    });
+
+    it('same keyword appearing multiple times is averaged once (single entry)', () => {
+      // Users must come in pre-indexed by useStudyQueueData; we verify the
+      // hook honors the indexed shape (one entry per key).
+      const input = buildByKeyword({ 'kw-dup': [0.2, 0.4, 0.6, 0.8] });
+      const { result } = renderHook(() => useKeywordMastery(input, false));
+      expect(result.current.masteryMap.size).toBe(1);
+      const entry = result.current.masteryMap.get('kw-dup')!;
+      expect(entry.cardCount).toBe(4);
+      // avg = 0.50 → delta 0.71 → red
+      expect(entry.pKnow).toBeCloseTo(0.5, 10);
+      expect(entry.mastery).toBe('red');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Suite 4: memoization stability
+  // ─────────────────────────────────────────────────────────
+
+  describe('memoization', () => {
+    it('masteryMap is stable across re-renders with the same input', () => {
+      const input = buildByKeyword({ 'kw-A': [0.5] });
+      const { result, rerender } = renderHook(
+        ({ m, l }: { m: Map<string, StudyQueueItem[]>; l: boolean }) =>
+          useKeywordMastery(m, l),
+        { initialProps: { m: input, l: false } },
+      );
+      const firstMap = result.current.masteryMap;
+      rerender({ m: input, l: false });
+      expect(result.current.masteryMap).toBe(firstMap);
+    });
+
+    it('masteryMap is rebuilt when input reference changes', () => {
+      const input1 = buildByKeyword({ 'kw-A': [0.5] });
+      const input2 = buildByKeyword({ 'kw-A': [0.5] });
+      const { result, rerender } = renderHook(
+        ({ m }: { m: Map<string, StudyQueueItem[]> }) =>
+          useKeywordMastery(m, false),
+        { initialProps: { m: input1 } },
+      );
+      const firstMap = result.current.masteryMap;
+      rerender({ m: input2 });
+      expect(result.current.masteryMap).not.toBe(firstMap);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Suite 5: masteryConfig export
+  // ─────────────────────────────────────────────────────────
+
+  describe('masteryConfig export', () => {
+    it('contains one entry per delta level', () => {
+      const levels = Object.keys(masteryConfig).sort();
+      expect(levels).toEqual(['blue', 'gray', 'green', 'red', 'yellow']);
+    });
+
+    it('each entry has label / color / bg / border / description as strings', () => {
+      for (const level of ['gray', 'red', 'yellow', 'green', 'blue'] as const) {
+        const cfg = masteryConfig[level];
+        expect(typeof cfg.label).toBe('string');
+        expect(typeof cfg.color).toBe('string');
+        expect(typeof cfg.bg).toBe('string');
+        expect(typeof cfg.border).toBe('string');
+        expect(typeof cfg.description).toBe('string');
+      }
+    });
+
+    it('label is the Spanish localized delta label', () => {
+      // Spot-check the canonical mapping without reasserting helper logic.
+      expect(masteryConfig.gray.label).toBe('Por descubrir');
+      expect(masteryConfig.blue.label).toBe('Maestría');
+    });
+  });
+});

--- a/src/app/hooks/__tests__/useMediaQuery.test.ts
+++ b/src/app/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,172 @@
+// ============================================================
+// Axon -- Tests for useMediaQuery
+//
+// Exercises SSR guard, initial match, and live updates via the
+// MediaQueryList 'change' event. window.matchMedia is mocked
+// with a minimal implementation that supports addEventListener
+// and manual dispatch.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMediaQuery } from '@/app/hooks/useMediaQuery';
+
+// ── matchMedia mock ─────────────────────────────────────────
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  onchange: null;
+  listeners: Array<(e: MediaQueryListEvent) => void>;
+  addEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => void;
+  removeEventListener: (
+    type: string,
+    cb: (e: MediaQueryListEvent) => void,
+  ) => void;
+  addListener: (cb: (e: MediaQueryListEvent) => void) => void;
+  removeListener: (cb: (e: MediaQueryListEvent) => void) => void;
+  dispatchEvent: (e: MediaQueryListEvent) => boolean;
+  __setMatches: (value: boolean) => void;
+}
+
+const mqlRegistry = new Map<string, MockMql>();
+
+function createMockMql(query: string, initial: boolean): MockMql {
+  const mql: MockMql = {
+    matches: initial,
+    media: query,
+    onchange: null,
+    listeners: [],
+    addEventListener(type, cb) {
+      if (type === 'change') this.listeners.push(cb);
+    },
+    removeEventListener(type, cb) {
+      if (type === 'change') {
+        this.listeners = this.listeners.filter((l) => l !== cb);
+      }
+    },
+    addListener(cb) {
+      this.listeners.push(cb);
+    },
+    removeListener(cb) {
+      this.listeners = this.listeners.filter((l) => l !== cb);
+    },
+    dispatchEvent() {
+      return true;
+    },
+    __setMatches(value: boolean) {
+      this.matches = value;
+      const evt = { matches: value, media: query } as MediaQueryListEvent;
+      this.listeners.slice().forEach((cb) => cb(evt));
+    },
+  };
+  return mql;
+}
+
+function installMatchMediaMock(defaultMatches = false) {
+  mqlRegistry.clear();
+  window.matchMedia = vi.fn((query: string) => {
+    let mql = mqlRegistry.get(query);
+    if (!mql) {
+      mql = createMockMql(query, defaultMatches);
+      mqlRegistry.set(query, mql);
+    }
+    return mql as unknown as MediaQueryList;
+  });
+}
+
+beforeEach(() => {
+  installMatchMediaMock(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useMediaQuery — initial state', () => {
+  it('returns matchMedia(query).matches as initial value', () => {
+    installMatchMediaMock(true);
+    const { result } = renderHook(() => useMediaQuery(768));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when query does not match', () => {
+    installMatchMediaMock(false);
+    const { result } = renderHook(() => useMediaQuery(1024));
+    expect(result.current).toBe(false);
+  });
+
+  it('builds a (min-width: Xpx) query', () => {
+    renderHook(() => useMediaQuery(768));
+    const mqlCall = (window.matchMedia as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(mqlCall).toBe('(min-width: 768px)');
+  });
+});
+
+describe('useMediaQuery — reactive updates', () => {
+  it('updates when the underlying MediaQueryList dispatches "change"', () => {
+    const { result } = renderHook(() => useMediaQuery(768));
+    expect(result.current).toBe(false);
+
+    const mql = mqlRegistry.get('(min-width: 768px)');
+    expect(mql).toBeDefined();
+    act(() => {
+      mql?.__setMatches(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      mql?.__setMatches(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('attaches a "change" listener and removes it on unmount', () => {
+    const { unmount } = renderHook(() => useMediaQuery(768));
+    const mql = mqlRegistry.get('(min-width: 768px)');
+    expect(mql?.listeners.length).toBe(1);
+    unmount();
+    expect(mql?.listeners.length).toBe(0);
+  });
+
+  it('re-subscribes when breakpoint changes', () => {
+    const { rerender } = renderHook(
+      ({ bp }: { bp: number }) => useMediaQuery(bp),
+      { initialProps: { bp: 768 } },
+    );
+    expect(mqlRegistry.get('(min-width: 768px)')?.listeners.length).toBe(1);
+
+    rerender({ bp: 1024 });
+    expect(mqlRegistry.get('(min-width: 768px)')?.listeners.length).toBe(0);
+    expect(mqlRegistry.get('(min-width: 1024px)')?.listeners.length).toBe(1);
+  });
+});
+
+describe('useMediaQuery — fallback path for old Safari', () => {
+  it('falls back to addListener when addEventListener is absent', () => {
+    // Replace matchMedia with a version that lacks addEventListener.
+    const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+    window.matchMedia = vi.fn((query: string) => {
+      return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: (cb: (e: MediaQueryListEvent) => void) => {
+          listeners.push(cb);
+        },
+        removeListener: (cb: (e: MediaQueryListEvent) => void) => {
+          const i = listeners.indexOf(cb);
+          if (i !== -1) listeners.splice(i, 1);
+        },
+        // addEventListener intentionally missing
+        dispatchEvent: () => true,
+      } as unknown as MediaQueryList;
+    });
+
+    const { unmount } = renderHook(() => useMediaQuery(480));
+    expect(listeners.length).toBe(1);
+    unmount();
+    expect(listeners.length).toBe(0);
+  });
+});

--- a/src/app/hooks/__tests__/useRagAnalytics.test.ts
+++ b/src/app/hooks/__tests__/useRagAnalytics.test.ts
@@ -1,0 +1,441 @@
+// ============================================================
+// Unit tests for useRagAnalytics hook.
+//
+// Coverage:
+//   - fetchAnalytics: guards, passes dateRange, sets state, rethrows errors
+//   - fetchCoverage: guards, sets state, rethrows errors
+//   - fetchAll: parallel dispatch, phase transitions, concurrent guard,
+//     error state
+//   - updateDateRange: stores range and refetches analytics only
+//   - Computed: feedbackRate, positiveRate, zeroResultRate (null/0 edges)
+//
+// Mocks: @/app/services/aiService (getRagAnalytics, getEmbeddingCoverage)
+//
+// RUN: npx vitest run src/app/hooks/__tests__/useRagAnalytics.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ── Mocks BEFORE imports ────────────────────────────────────
+
+const mockGetRagAnalytics = vi.fn();
+const mockGetEmbeddingCoverage = vi.fn();
+
+vi.mock('@/app/services/aiService', () => ({
+  getRagAnalytics: (...args: unknown[]) => mockGetRagAnalytics(...args),
+  getEmbeddingCoverage: (...args: unknown[]) => mockGetEmbeddingCoverage(...args),
+}));
+
+import { useRagAnalytics } from '@/app/hooks/useRagAnalytics';
+import type { RagAnalytics, EmbeddingCoverage } from '@/app/services/aiService';
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+const ANALYTICS: RagAnalytics = {
+  total_queries: 100,
+  avg_similarity: 0.78,
+  avg_latency_ms: 450,
+  positive_feedback: 60,
+  negative_feedback: 20,
+  zero_result_queries: 5,
+};
+
+const ZERO_ANALYTICS: RagAnalytics = {
+  total_queries: 0,
+  avg_similarity: null,
+  avg_latency_ms: null,
+  positive_feedback: 0,
+  negative_feedback: 0,
+  zero_result_queries: 0,
+};
+
+const COVERAGE: EmbeddingCoverage = {
+  total_chunks: 500,
+  chunks_with_embedding: 450,
+  coverage_pct: 90,
+};
+
+beforeEach(() => {
+  mockGetRagAnalytics.mockReset();
+  mockGetEmbeddingCoverage.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Initial state
+// ══════════════════════════════════════════════════════════════
+
+describe('useRagAnalytics — initial state', () => {
+  it('starts in idle with null analytics/coverage/error', () => {
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.analytics).toBeNull();
+    expect(result.current.coverage).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('starts with empty dateRange', () => {
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    expect(result.current.dateRange).toEqual({});
+  });
+
+  it('computed metrics are null when analytics is null', () => {
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    expect(result.current.feedbackRate).toBeNull();
+    expect(result.current.positiveRate).toBeNull();
+    expect(result.current.zeroResultRate).toBeNull();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchAnalytics
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchAnalytics', () => {
+  it('no-ops when institutionId is empty', async () => {
+    const { result } = renderHook(() => useRagAnalytics(''));
+    await act(async () => {
+      const out = await result.current.fetchAnalytics();
+      expect(out).toBeUndefined();
+    });
+    expect(mockGetRagAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('stores analytics on success', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAnalytics();
+    });
+    expect(result.current.analytics).toEqual(ANALYTICS);
+  });
+
+  it('returns fetched analytics to caller', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    let returned: RagAnalytics | undefined;
+    await act(async () => {
+      returned = await result.current.fetchAnalytics();
+    });
+    expect(returned).toEqual(ANALYTICS);
+  });
+
+  it('uses explicit dateRange when provided', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAnalytics({ from: '2026-01-01', to: '2026-04-01' });
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledWith(
+      'inst-1',
+      { from: '2026-01-01', to: '2026-04-01' }
+    );
+  });
+
+  it('falls back to stored dateRange when no argument is passed', async () => {
+    mockGetRagAnalytics.mockResolvedValue(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      result.current.updateDateRange({ from: '2026-02-01' });
+    });
+    // updateDateRange itself calls fetchAnalytics; clear mock to isolate our next call
+    mockGetRagAnalytics.mockClear();
+    await act(async () => {
+      await result.current.fetchAnalytics();
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledWith('inst-1', { from: '2026-02-01' });
+  });
+
+  it('rethrows errors (caller handles)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetRagAnalytics.mockRejectedValueOnce(new Error('analytics failed'));
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await expect(result.current.fetchAnalytics()).rejects.toThrow('analytics failed');
+    });
+    spy.mockRestore();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchCoverage
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchCoverage', () => {
+  it('no-ops when institutionId is empty', async () => {
+    const { result } = renderHook(() => useRagAnalytics(''));
+    await act(async () => {
+      const out = await result.current.fetchCoverage();
+      expect(out).toBeUndefined();
+    });
+    expect(mockGetEmbeddingCoverage).not.toHaveBeenCalled();
+  });
+
+  it('stores coverage on success', async () => {
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchCoverage();
+    });
+    expect(result.current.coverage).toEqual(COVERAGE);
+  });
+
+  it('returns fetched coverage to caller', async () => {
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    let returned: EmbeddingCoverage | undefined;
+    await act(async () => {
+      returned = await result.current.fetchCoverage();
+    });
+    expect(returned).toEqual(COVERAGE);
+  });
+
+  it('rethrows errors', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetEmbeddingCoverage.mockRejectedValueOnce(new Error('coverage failed'));
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await expect(result.current.fetchCoverage()).rejects.toThrow('coverage failed');
+    });
+    spy.mockRestore();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fetchAll
+// ══════════════════════════════════════════════════════════════
+
+describe('fetchAll', () => {
+  it('no-ops when institutionId is empty', async () => {
+    const { result } = renderHook(() => useRagAnalytics(''));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(mockGetRagAnalytics).not.toHaveBeenCalled();
+    expect(mockGetEmbeddingCoverage).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('transitions idle → loading → ready with analytics + coverage populated', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.analytics).toEqual(ANALYTICS);
+    expect(result.current.coverage).toEqual(COVERAGE);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('dispatches both services in parallel', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledTimes(1);
+    expect(mockGetEmbeddingCoverage).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes range to analytics and nothing to coverage', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll({ from: '2026-03-01' });
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledWith('inst-1', { from: '2026-03-01' });
+    expect(mockGetEmbeddingCoverage).toHaveBeenCalledWith('inst-1');
+  });
+
+  it('falls back to stored dateRange when no argument', async () => {
+    mockGetRagAnalytics.mockResolvedValue(ANALYTICS);
+    mockGetEmbeddingCoverage.mockResolvedValue(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      result.current.updateDateRange({ from: '2026-02-01' });
+    });
+    mockGetRagAnalytics.mockClear();
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledWith('inst-1', { from: '2026-02-01' });
+  });
+
+  it('transitions to phase=error with message when analytics fails', async () => {
+    mockGetRagAnalytics.mockRejectedValueOnce(new Error('db error'));
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('db error');
+  });
+
+  it('transitions to phase=error when coverage fails', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    mockGetEmbeddingCoverage.mockRejectedValueOnce(new Error('coverage err'));
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('coverage err');
+  });
+
+  it('falls back to generic error message if err.message is absent', async () => {
+    mockGetRagAnalytics.mockRejectedValueOnce({});
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    expect(result.current.error).toBe('Error al cargar analytics RAG');
+  });
+
+  it('guards against concurrent invocations (fetchingRef)', async () => {
+    let resolveA: (v: any) => void = () => {};
+    mockGetRagAnalytics.mockImplementationOnce(
+      () => new Promise((r) => { resolveA = r; })
+    );
+    mockGetEmbeddingCoverage.mockImplementationOnce(
+      () => new Promise(() => {})
+    );
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+
+    // Kick off first fetchAll — it will hang (never resolves)
+    act(() => {
+      result.current.fetchAll();
+    });
+    // Attempt second — should be ignored
+    await act(async () => {
+      await result.current.fetchAll();
+    });
+    // Only 1 call each
+    expect(mockGetRagAnalytics).toHaveBeenCalledTimes(1);
+    expect(mockGetEmbeddingCoverage).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+    await act(async () => {
+      resolveA(ANALYTICS);
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// updateDateRange
+// ══════════════════════════════════════════════════════════════
+
+describe('updateDateRange', () => {
+  it('stores the new range in state', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      result.current.updateDateRange({ from: '2026-03-01', to: '2026-04-01' });
+    });
+    expect(result.current.dateRange).toEqual({ from: '2026-03-01', to: '2026-04-01' });
+  });
+
+  it('triggers fetchAnalytics (but NOT fetchCoverage) on update', async () => {
+    mockGetRagAnalytics.mockResolvedValueOnce(ANALYTICS);
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      result.current.updateDateRange({ from: '2026-03-01' });
+    });
+    expect(mockGetRagAnalytics).toHaveBeenCalledWith('inst-1', { from: '2026-03-01' });
+    expect(mockGetEmbeddingCoverage).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetchAnalytics errors (handled via .catch)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetRagAnalytics.mockRejectedValueOnce(new Error('bad'));
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    // Should not throw unhandled rejection
+    await act(async () => {
+      result.current.updateDateRange({ from: '2026-03-01' });
+    });
+    // Give microtasks a chance
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.dateRange).toEqual({ from: '2026-03-01' });
+    spy.mockRestore();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Computed metrics
+// ══════════════════════════════════════════════════════════════
+
+describe('computed metrics', () => {
+  async function loadAnalytics(data: RagAnalytics) {
+    mockGetRagAnalytics.mockResolvedValueOnce(data);
+    mockGetEmbeddingCoverage.mockResolvedValueOnce(COVERAGE);
+    const hook = renderHook(() => useRagAnalytics('inst-1'));
+    await act(async () => {
+      await hook.result.current.fetchAll();
+    });
+    return hook;
+  }
+
+  it('feedbackRate: (positive + negative) / total * 100', async () => {
+    const { result } = await loadAnalytics(ANALYTICS);
+    // (60 + 20) / 100 * 100 = 80
+    expect(result.current.feedbackRate).toBe(80);
+  });
+
+  it('feedbackRate returns 0 when total_queries is 0', async () => {
+    const { result } = await loadAnalytics(ZERO_ANALYTICS);
+    expect(result.current.feedbackRate).toBe(0);
+  });
+
+  it('positiveRate: positive / (positive + negative) * 100', async () => {
+    const { result } = await loadAnalytics(ANALYTICS);
+    // 60 / (60 + 20) * 100 = 75
+    expect(result.current.positiveRate).toBe(75);
+  });
+
+  it('positiveRate returns null when no feedback at all', async () => {
+    const { result } = await loadAnalytics(ZERO_ANALYTICS);
+    expect(result.current.positiveRate).toBeNull();
+  });
+
+  it('positiveRate returns 100 when all feedback is positive', async () => {
+    const { result } = await loadAnalytics({
+      ...ANALYTICS,
+      positive_feedback: 10,
+      negative_feedback: 0,
+    });
+    expect(result.current.positiveRate).toBe(100);
+  });
+
+  it('positiveRate returns 0 when all feedback is negative', async () => {
+    const { result } = await loadAnalytics({
+      ...ANALYTICS,
+      positive_feedback: 0,
+      negative_feedback: 10,
+    });
+    expect(result.current.positiveRate).toBe(0);
+  });
+
+  it('zeroResultRate: zero_result_queries / total_queries * 100', async () => {
+    const { result } = await loadAnalytics(ANALYTICS);
+    // 5 / 100 * 100 = 5
+    expect(result.current.zeroResultRate).toBe(5);
+  });
+
+  it('zeroResultRate returns 0 when total_queries is 0', async () => {
+    const { result } = await loadAnalytics(ZERO_ANALYTICS);
+    expect(result.current.zeroResultRate).toBe(0);
+  });
+
+  it('all computed metrics null when analytics never loaded', () => {
+    const { result } = renderHook(() => useRagAnalytics('inst-1'));
+    expect(result.current.feedbackRate).toBeNull();
+    expect(result.current.positiveRate).toBeNull();
+    expect(result.current.zeroResultRate).toBeNull();
+  });
+});

--- a/src/app/hooks/__tests__/useReadingTimeTracker.test.ts
+++ b/src/app/hooks/__tests__/useReadingTimeTracker.test.ts
@@ -23,7 +23,7 @@
 // RUN: npx vitest run src/app/hooks/__tests__/useReadingTimeTracker.test.ts
 // ============================================================
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, cleanup } from '@testing-library/react';
 
 // ── Mocks ──────────────────────────────────────────────────
 
@@ -56,6 +56,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Defensively unmount any hooks still attached to prevent beforeunload /
+  // visibilitychange listeners from leaking into the next test and causing
+  // double-fires on shared window/document events.
+  cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });

--- a/src/app/hooks/__tests__/useReadingTimeTracker.test.ts
+++ b/src/app/hooks/__tests__/useReadingTimeTracker.test.ts
@@ -1,0 +1,382 @@
+// ============================================================
+// Unit tests for useReadingTimeTracker hook.
+//
+// Coverage:
+//   - Periodic save after 30s interval
+//   - visibilitychange → save when document.hidden
+//   - beforeunload → saveBeacon uses fetch with keepalive
+//   - Unmount cleanup
+//   - Skip-save when elapsed < MIN_ELAPSED_TO_SAVE (5s)
+//   - snapshotForExternalSave atomic + reset semantics
+//   - getCurrentTotal includes unsaved session time
+//   - Save error swallowed (silent retry)
+//   - initialTimeSpent sync via Math.max (never lowers)
+//
+// Uses real timers globally (setup.ts baseline) and enables fake
+// timers PER-TEST with beforeEach/afterEach to avoid leaks.
+//
+// Mocks:
+//   - @/app/services/studentSummariesApi (upsertReadingState)
+//   - @/app/lib/api (ANON_KEY, API_BASE, getAccessToken)
+//   - global.fetch (for saveBeacon / keepalive)
+//
+// RUN: npx vitest run src/app/hooks/__tests__/useReadingTimeTracker.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ── Mocks ──────────────────────────────────────────────────
+
+const mockUpsertReadingState = vi.fn();
+vi.mock('@/app/services/studentSummariesApi', () => ({
+  upsertReadingState: (...args: unknown[]) => mockUpsertReadingState(...args),
+}));
+
+vi.mock('@/app/lib/api', () => ({
+  API_BASE: 'https://api.test/server',
+  ANON_KEY: 'anon-test-key',
+  getAccessToken: () => 'jwt-test-token',
+}));
+
+import { useReadingTimeTracker } from '@/app/hooks/useReadingTimeTracker';
+
+const SAVE_INTERVAL_MS = 30_000;
+
+// ── Global setup ───────────────────────────────────────────
+
+beforeEach(() => {
+  mockUpsertReadingState.mockReset();
+  mockUpsertReadingState.mockResolvedValue({ id: 'rs-1' });
+  vi.useFakeTimers();
+  // Reset document visibility to visible at start of each test
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Layer 1: Periodic save
+// ══════════════════════════════════════════════════════════════
+
+describe('periodic save (30s interval)', () => {
+  it('does not save before the interval fires', () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    // Advance less than one interval
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(mockUpsertReadingState).not.toHaveBeenCalled();
+  });
+
+  it('saves accumulated time after 30s', async () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 100));
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      // Let microtasks (the async save) flush
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).toHaveBeenCalledTimes(1);
+    const payload = mockUpsertReadingState.mock.calls[0][0];
+    expect(payload.summary_id).toBe('sum-1');
+    // initial 100s + ~30s elapsed = 130s
+    expect(payload.time_spent_seconds).toBeGreaterThanOrEqual(130);
+    expect(payload.time_spent_seconds).toBeLessThanOrEqual(131);
+    expect(typeof payload.last_read_at).toBe('string');
+  });
+
+  it('does not pass scroll_position when getter is undefined', async () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    const payload = mockUpsertReadingState.mock.calls[0][0];
+    expect(payload).not.toHaveProperty('scroll_position');
+  });
+
+  it('includes scroll_position when getter returns a number', async () => {
+    const getter = vi.fn().mockReturnValue(42);
+    renderHook(() => useReadingTimeTracker('sum-1', 0, getter));
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    const payload = mockUpsertReadingState.mock.calls[0][0];
+    expect(payload.scroll_position).toBe(42);
+  });
+
+  it('omits scroll_position when getter returns undefined', async () => {
+    const getter = vi.fn().mockReturnValue(undefined);
+    renderHook(() => useReadingTimeTracker('sum-1', 0, getter));
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    const payload = mockUpsertReadingState.mock.calls[0][0];
+    expect(payload).not.toHaveProperty('scroll_position');
+  });
+
+  it('swallows save errors and retries on next tick', async () => {
+    mockUpsertReadingState
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ id: 'rs-1' });
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).toHaveBeenCalledTimes(1);
+    // Next interval: should try again (not give up)
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).toHaveBeenCalledTimes(2);
+  });
+
+  it('accumulates across multiple saves (no double-counting)', async () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 100));
+    // First save after 30s → ~130s
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    const first = mockUpsertReadingState.mock.calls[0][0].time_spent_seconds;
+    // Second save after another 30s → ~160s (not ~130 + ~30 + ~30 = 190)
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    const second = mockUpsertReadingState.mock.calls[1][0].time_spent_seconds;
+    expect(second - first).toBeGreaterThanOrEqual(29);
+    expect(second - first).toBeLessThanOrEqual(31);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Layer 2: visibilitychange
+// ══════════════════════════════════════════════════════════════
+
+describe('visibilitychange listener', () => {
+  it('saves when tab becomes hidden', async () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    // Advance past MIN_ELAPSED_TO_SAVE (5s) but before interval
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    // Flip visibility + dispatch
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT save when tab becomes visible (ignored)', async () => {
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    // Visibility still 'visible' — no hide → no save
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).not.toHaveBeenCalled();
+  });
+
+  it('removes listener on unmount (no save after unmount)', async () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useReadingTimeTracker('sum-1', 0));
+    unmount();
+    // At least one removeEventListener('visibilitychange', ...) was called
+    const calls = removeSpy.mock.calls.filter((c) => c[0] === 'visibilitychange');
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Layer 3: beforeunload → saveBeacon (keepalive fetch)
+// ══════════════════════════════════════════════════════════════
+
+describe('beforeunload / saveBeacon', () => {
+  it('fires keepalive fetch on beforeunload after enough elapsed time', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((() => Promise.resolve(new Response('{}'))) as any);
+    renderHook(() => useReadingTimeTracker('sum-1', 50));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000); // > MIN_ELAPSED_TO_SAVE
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/server/reading-states');
+    const opts = options as RequestInit;
+    expect(opts.method).toBe('POST');
+    expect(opts.keepalive).toBe(true);
+    const body = JSON.parse(opts.body as string);
+    expect(body.summary_id).toBe('sum-1');
+    expect(body.time_spent_seconds).toBeGreaterThanOrEqual(55);
+    const headers = opts.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer anon-test-key');
+    expect(headers['X-Access-Token']).toBe('jwt-test-token');
+  });
+
+  it('does NOT fire beacon when elapsed < MIN_ELAPSED_TO_SAVE', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((() => Promise.resolve(new Response('{}'))) as any);
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    await act(async () => {
+      vi.advanceTimersByTime(1_000); // < 5s
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetch errors silently', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('fetch failed');
+    });
+    renderHook(() => useReadingTimeTracker('sum-1', 0));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    // Should not throw
+    expect(() => {
+      window.dispatchEvent(new Event('beforeunload'));
+    }).not.toThrow();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Public API: snapshotForExternalSave + getCurrentTotal
+// ══════════════════════════════════════════════════════════════
+
+describe('snapshotForExternalSave', () => {
+  it('returns current total including unsaved session elapsed', () => {
+    const { result } = renderHook(() => useReadingTimeTracker('sum-1', 100));
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    let snap = 0;
+    act(() => {
+      snap = result.current.snapshotForExternalSave();
+    });
+    expect(snap).toBeGreaterThanOrEqual(109);
+    expect(snap).toBeLessThanOrEqual(111);
+  });
+
+  it('resets the session clock so next periodic save starts from 0 elapsed', async () => {
+    const { result } = renderHook(() => useReadingTimeTracker('sum-1', 100));
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    act(() => {
+      result.current.snapshotForExternalSave();
+    });
+    // Now immediately fire interval — session elapsed is ~0 so save is skipped
+    // (below MIN_ELAPSED_TO_SAVE=5s). Advance just the remaining interval.
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS - 10_000);
+      await Promise.resolve();
+    });
+    // Zero saves because elapsed since snapshot is ~20s but reset happened,
+    // meaning lastSaveTime = just now. Actual elapsed = 20_000ms = 20s,
+    // the save DOES happen but with total = snapshot + 20. This is still fine.
+    // More importantly, it must not double-count: total never exceeds snap + session
+    if (mockUpsertReadingState.mock.calls.length > 0) {
+      const total = mockUpsertReadingState.mock.calls[0][0].time_spent_seconds;
+      expect(total).toBeLessThanOrEqual(135);
+    }
+  });
+});
+
+describe('getCurrentTotal', () => {
+  it('returns initial time when no time has passed', () => {
+    const { result } = renderHook(() => useReadingTimeTracker('sum-1', 500));
+    const total = result.current.getCurrentTotal();
+    expect(total).toBe(500);
+  });
+
+  it('includes in-flight session seconds without mutating state', () => {
+    const { result } = renderHook(() => useReadingTimeTracker('sum-1', 500));
+    act(() => {
+      vi.advanceTimersByTime(7_000);
+    });
+    const total = result.current.getCurrentTotal();
+    expect(total).toBeGreaterThanOrEqual(506);
+    expect(total).toBeLessThanOrEqual(508);
+    // Called again — same result (pure read)
+    const again = result.current.getCurrentTotal();
+    expect(again).toBeGreaterThanOrEqual(506);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// initialTimeSpent sync (Math.max — never lowers)
+// ══════════════════════════════════════════════════════════════
+
+describe('initialTimeSpent prop sync', () => {
+  it('raises accumulated total when a higher initialTimeSpent is passed', async () => {
+    const { rerender, result } = renderHook(
+      ({ initial }) => useReadingTimeTracker('sum-1', initial),
+      { initialProps: { initial: 100 } },
+    );
+    expect(result.current.getCurrentTotal()).toBe(100);
+    rerender({ initial: 500 });
+    // The sync is in useEffect — flush
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.getCurrentTotal()).toBeGreaterThanOrEqual(500);
+  });
+
+  it('does NOT lower accumulated total when a smaller initialTimeSpent is passed', async () => {
+    const { rerender, result } = renderHook(
+      ({ initial }) => useReadingTimeTracker('sum-1', initial),
+      { initialProps: { initial: 500 } },
+    );
+    rerender({ initial: 100 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.getCurrentTotal()).toBeGreaterThanOrEqual(500);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Unmount
+// ══════════════════════════════════════════════════════════════
+
+describe('unmount', () => {
+  it('clears the periodic interval (no further saves)', async () => {
+    const { unmount } = renderHook(() => useReadingTimeTracker('sum-1', 0));
+    unmount();
+    // Any save-on-unmount triggers once, but no more intervals should fire
+    mockUpsertReadingState.mockClear();
+    await act(async () => {
+      vi.advanceTimersByTime(SAVE_INTERVAL_MS * 3);
+      await Promise.resolve();
+    });
+    expect(mockUpsertReadingState).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/hooks/__tests__/useSmartGeneration.test.ts
+++ b/src/app/hooks/__tests__/useSmartGeneration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * useSmartGeneration.test.ts — Tests for the smart AI generation hook (v4.5)
+ *
+ * Coverage: idle state, generate() happy paths (single + bulk + chunked
+ *           counts > 10), error path, abort, reset, progress updates,
+ *           stats aggregation (uniqueKeywords/uniqueSubtopics/avgPKnow).
+ *
+ * NOTE (MASTERY-SYSTEMS.md): `avgPKnow` here comes from `_smart.p_know`
+ * returned by the backend's BKT targeting. This is Sistema A (rating
+ * INPUT / target score) — NOT the card's absolute mastery (Sistema B)
+ * nor a keyword-delta (Sistema C). No thresholds are compared against
+ * p_know in this file; it is merely averaged for display.
+ *
+ * Mocks: @/app/services/aiService (generateSmart)
+ *
+ * Run: npx vitest run src/app/hooks/__tests__/useSmartGeneration.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ── Mocks ─────────────────────────────────────────────────
+
+const mockGenerateSmart = vi.fn();
+
+vi.mock('@/app/services/aiService', () => ({
+  generateSmart: (...args: unknown[]) => mockGenerateSmart(...args),
+}));
+
+// ── SUT ───────────────────────────────────────────────────
+
+import { useSmartGeneration } from '@/app/hooks/useSmartGeneration';
+
+// ── Helpers ───────────────────────────────────────────────
+
+function makeSmart(p_know = 0.4, target_subtopic: string | null = 'sub-A') {
+  return {
+    target_keyword: 'kw-name-A',
+    target_summary: 'sum-A',
+    target_subtopic,
+    p_know,
+    need_score: 0.8,
+    primary_reason: 'low_mastery' as const,
+  };
+}
+
+function makeSingleResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'item-single',
+    front: 'Q',
+    back: 'A',
+    summary_id: 'sum-1',
+    keyword_id: 'kw-1',
+    subtopic_id: 'sub-1',
+    _smart: makeSmart(0.5, 'sub-1'),
+    ...overrides,
+  };
+}
+
+function makeBulkResponse(count: number, overrides: Partial<Record<'uniformSubtopic', string | null>> = {}) {
+  const items = Array.from({ length: count }, (_, i) => ({
+    type: 'flashcard',
+    id: `b-${i}`,
+    keyword_id: `kw-${i}`,
+    keyword_name: `name-${i}`,
+    summary_id: `sum-${i}`,
+    _smart: makeSmart(0.3 + i * 0.05, overrides.uniformSubtopic ?? `sub-${i}`),
+  }));
+  return {
+    items,
+    errors: [],
+    _meta: {
+      model: 'gemini',
+      action: 'flashcard',
+      total_attempted: count,
+      total_generated: count,
+      total_failed: 0,
+      total_targets_available: count,
+      tokens: { input: 0, output: 0 },
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe('useSmartGeneration', () => {
+  beforeEach(() => {
+    // Use mockReset() — clearAllMocks does NOT drain mockResolvedValueOnce queues,
+    // causing leftover queued values to leak into subsequent tests.
+    mockGenerateSmart.mockReset();
+  });
+
+  it('starts in idle phase with null result/progress/error', () => {
+    const { result } = renderHook(() => useSmartGeneration());
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.progress).toBeNull();
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns early (no state change, no API call) when count <= 0', async () => {
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 0 });
+    });
+    expect(mockGenerateSmart).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.result).toBeNull();
+  });
+
+  it('handles single-item generation (count=1) returning item directly', async () => {
+    mockGenerateSmart.mockResolvedValueOnce(makeSingleResponse());
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 1 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(mockGenerateSmart).toHaveBeenCalledTimes(1);
+    expect(result.current.result?.items).toHaveLength(1);
+    expect(result.current.result?.stats.requested).toBe(1);
+    expect(result.current.result?.stats.generated).toBe(1);
+    expect(result.current.result?.stats.failed).toBe(0);
+    // single path does not pass count in args
+    const args = mockGenerateSmart.mock.calls[0][0];
+    expect(args.count).toBeUndefined();
+  });
+
+  it('handles bulk chunk (1 < count <= 10) with items[] response', async () => {
+    mockGenerateSmart.mockResolvedValueOnce(makeBulkResponse(5));
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 5, summaryId: 'sum-X' });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(mockGenerateSmart).toHaveBeenCalledTimes(1);
+    const args = mockGenerateSmart.mock.calls[0][0];
+    expect(args.count).toBe(5);
+    expect(args.summaryId).toBe('sum-X');
+    expect(result.current.result?.items).toHaveLength(5);
+    expect(result.current.result?.stats.generated).toBe(5);
+  });
+
+  it('chunks large counts into groups of 10 (count=25 → 10+10+5)', async () => {
+    mockGenerateSmart
+      .mockResolvedValueOnce(makeBulkResponse(10))
+      .mockResolvedValueOnce(makeBulkResponse(10))
+      .mockResolvedValueOnce(makeBulkResponse(5));
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 25 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(mockGenerateSmart).toHaveBeenCalledTimes(3);
+    const callCounts = mockGenerateSmart.mock.calls.map((c: any[]) => c[0].count);
+    expect(callCounts).toEqual([10, 10, 5]);
+    expect(result.current.result?.stats.generated).toBe(25);
+    expect(result.current.result?.stats.requested).toBe(25);
+  });
+
+  it('accumulates errors from bulk response', async () => {
+    const bulk = makeBulkResponse(2);
+    bulk.errors = [
+      { keyword_id: 'kw-err', keyword_name: 'bad kw', error: 'AI timeout' },
+    ] as any;
+    mockGenerateSmart.mockResolvedValueOnce(bulk);
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 2 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.errors).toHaveLength(1);
+    expect(result.current.result?.stats.failed).toBe(1);
+  });
+
+  it('catches thrown errors per-chunk and adds synthetic error entry', async () => {
+    // count=2 triggers the bulk branch which throws
+    mockGenerateSmart.mockRejectedValueOnce(new Error('network down'));
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 2 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.errors).toHaveLength(1);
+    expect(result.current.result?.errors[0].keyword_id).toBe('unknown');
+    expect(result.current.result?.errors[0].error).toBe('network down');
+    expect(result.current.result?.stats.generated).toBe(0);
+    expect(result.current.result?.stats.failed).toBe(1);
+  });
+
+  it('falls back to "Error desconocido" when thrown error lacks message', async () => {
+    mockGenerateSmart.mockRejectedValueOnce({});
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 2 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.errors[0].error).toBe('Error desconocido');
+  });
+
+  it('computes uniqueKeywords and uniqueSubtopics correctly', async () => {
+    // 3 items with 2 distinct keywords and 2 distinct subtopics via _smart.target_subtopic
+    mockGenerateSmart.mockResolvedValueOnce({
+      items: [
+        { type: 'flashcard', id: '1', keyword_id: 'kwA', keyword_name: 'A', summary_id: 's', _smart: makeSmart(0.1, 'subA') },
+        { type: 'flashcard', id: '2', keyword_id: 'kwA', keyword_name: 'A', summary_id: 's', _smart: makeSmart(0.2, 'subA') },
+        { type: 'flashcard', id: '3', keyword_id: 'kwB', keyword_name: 'B', summary_id: 's', _smart: makeSmart(0.3, 'subB') },
+      ],
+      errors: [],
+      _meta: {},
+    });
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 3 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.stats.uniqueKeywords).toBe(2);
+    expect(result.current.result?.stats.uniqueSubtopics).toBe(2);
+  });
+
+  it('averages p_know across returned items (ignores falsy subtopic for uniqueSubtopics)', async () => {
+    mockGenerateSmart.mockResolvedValueOnce({
+      items: [
+        { type: 'flashcard', id: '1', keyword_id: 'kwA', keyword_name: 'A', summary_id: 's', _smart: makeSmart(0.2, null) },
+        { type: 'flashcard', id: '2', keyword_id: 'kwB', keyword_name: 'B', summary_id: 's', _smart: makeSmart(0.8, null) },
+      ],
+      errors: [],
+      _meta: {},
+    });
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 2 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.stats.avgPKnow).toBeCloseTo(0.5, 5);
+    // null subtopic values are filtered out
+    expect(result.current.result?.stats.uniqueSubtopics).toBe(0);
+  });
+
+  it('reports progress with latestItem after a chunk completes', async () => {
+    mockGenerateSmart.mockResolvedValueOnce(makeBulkResponse(3));
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 3 });
+    });
+    // progress should reflect final state
+    expect(result.current.progress?.generated).toBe(3);
+    expect(result.current.progress?.total).toBe(3);
+    expect(result.current.progress?.latestItem?.id).toBe('b-2');
+  });
+
+  it('abort() stops processing subsequent chunks', async () => {
+    // 15 items → 10 + 5 chunks. Abort after first chunk.
+    mockGenerateSmart
+      .mockImplementationOnce(async () => makeBulkResponse(10))
+      .mockImplementationOnce(async () => {
+        throw new Error('should not be called if aborted');
+      });
+    const { result } = renderHook(() => useSmartGeneration());
+
+    // Start generating then immediately abort synchronously during the await
+    const promise = act(async () => {
+      const p = result.current.generate({ action: 'flashcard', count: 15 });
+      // abort before second chunk runs
+      result.current.abort();
+      await p;
+    });
+    await promise;
+
+    // Only first chunk should have been invoked before abort kicked in
+    expect(mockGenerateSmart).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset() clears all state back to idle', async () => {
+    mockGenerateSmart.mockResolvedValueOnce(makeSingleResponse());
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 1 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.progress).toBeNull();
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('skips a single-item response that is missing id (no push)', async () => {
+    mockGenerateSmart.mockResolvedValueOnce({}); // no id
+    const { result } = renderHook(() => useSmartGeneration());
+    await act(async () => {
+      await result.current.generate({ action: 'flashcard', count: 1 });
+    });
+    await waitFor(() => expect(result.current.phase).toBe('done'));
+    expect(result.current.result?.items).toHaveLength(0);
+    expect(result.current.result?.stats.generated).toBe(0);
+  });
+});

--- a/src/app/hooks/__tests__/useStudentSummaryReader.test.ts
+++ b/src/app/hooks/__tests__/useStudentSummaryReader.test.ts
@@ -1,0 +1,668 @@
+// ============================================================
+// Unit tests for useStudentSummaryReader hook
+//
+// This hook is a large state/behavior aggregator with ~15 external
+// dependencies. We mock everything and exercise the observable state
+// machine: tab/panel toggles, view-mode auto-switch, pagination
+// clamping, keyboard shortcuts, scroll-spy, sidebar clicks, and
+// search matching.
+//
+// Mocks: every child hook + summary-content-helpers. Fake timers
+// used selectively for the 2s auto-switch effect.
+//
+// RUN: npx vitest run src/app/hooks/__tests__/useStudentSummaryReader.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ── Mock child hooks / modules BEFORE import ───────────────
+
+vi.mock('@/app/hooks/queries/useSummaryReaderQueries', () => ({
+  useSummaryReaderQueries: vi.fn(() => ({
+    chunks: [],
+    chunksLoading: false,
+    keywords: [],
+    keywordsLoading: false,
+    textAnnotations: [],
+    annotationsLoading: false,
+    hasBlocks: true,
+    blocksLoading: false,
+    invalidateAnnotations: vi.fn(),
+  })),
+}));
+
+vi.mock('@/app/hooks/queries/useKeywordDetailQueries', () => ({
+  useKeywordDetailQueries: vi.fn(() => ({
+    subtopics: [],
+    subtopicsLoading: false,
+    kwNotes: [],
+    kwNotesLoading: false,
+    invalidateKwNotes: vi.fn(),
+  })),
+}));
+
+const mockHandlers = {
+  handleMarkCompleted: vi.fn(),
+  handleUnmarkCompleted: vi.fn(),
+  handleCreateAnnotation: vi.fn(),
+  handleDeleteAnnotation: vi.fn(),
+  handleCreateKwNote: vi.fn(),
+  handleUpdateKwNote: vi.fn(),
+  handleDeleteKwNote: vi.fn(),
+};
+
+vi.mock('@/app/hooks/queries/useSummaryReaderMutations', () => ({
+  useSummaryReaderMutations: vi.fn(() => ({
+    ...mockHandlers,
+    markingRead: false,
+    savingAnnotation: false,
+    savingKwNote: false,
+    showXpToast: false,
+  })),
+}));
+
+vi.mock('@/app/hooks/queries/useSummaryBlockMastery', () => ({
+  useSummaryBlockMastery: vi.fn(() => ({ data: {}, isLoading: false })),
+}));
+
+vi.mock('@/app/hooks/useReadingTimeTracker', () => ({
+  useReadingTimeTracker: vi.fn(() => ({
+    save: vi.fn(),
+    snapshotForExternalSave: vi.fn(() => 0),
+    getCurrentTotal: vi.fn(() => 0),
+  })),
+}));
+
+vi.mock('@/app/hooks/useScrollPositionSave', () => ({
+  useScrollPositionSave: vi.fn(() => ({ getScrollPercentage: vi.fn(() => 0) })),
+}));
+
+vi.mock('@/app/hooks/useScrollPositionRestore', () => ({
+  useScrollPositionRestore: vi.fn(() => ({
+    initialViewMode: 'enriched' as const,
+    initialContentPage: 0,
+    restoreScroll: vi.fn(),
+  })),
+}));
+
+vi.mock('@/app/hooks/queries/useVideoPlayerQueries', () => ({
+  useVideoListQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+vi.mock('@/app/hooks/useThemeToggle', () => ({
+  useThemeToggle: vi.fn(() => ({ isDark: false, toggle: vi.fn() })),
+}));
+
+vi.mock('@/app/components/student/ReadingSettingsPanel', () => ({
+  useReadingSettings: vi.fn(() => ({
+    settings: {
+      fontSize: 17,
+      lineHeight: 1.65,
+      fontFamily: 'Inter, sans-serif',
+      focusMode: false,
+    },
+    update: vi.fn(),
+  })),
+}));
+
+vi.mock('@/app/hooks/queries/useSummaryBlocksQuery', () => ({
+  useSummaryBlocksQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+const mockHandleNavigateKeywordWrapped = vi.fn();
+vi.mock('@/app/hooks/useKeywordPageNavigation', () => ({
+  useKeywordPageNavigation: vi.fn(() => ({
+    handleNavigateKeyword: mockHandleNavigateKeywordWrapped,
+  })),
+}));
+
+vi.mock('@/app/lib/summary-content-helpers', () => ({
+  CONTENT_PAGE_SIZE: 2000,
+  enrichHtmlWithImages: vi.fn((html: string) => html),
+  paginateHtml: vi.fn((html: string) => (html ? [html] : [])),
+  paginateLines: vi.fn((text: string) => (text ? [text.split('\n')] : [])),
+}));
+
+// ── Import under test AFTER mocks ──────────────────────────
+import { useStudentSummaryReader } from '@/app/hooks/useStudentSummaryReader';
+import type { Summary } from '@/app/services/summariesApi';
+import type { ReadingState } from '@/app/services/studentSummariesApi';
+import { useSummaryBlocksQuery } from '@/app/hooks/queries/useSummaryBlocksQuery';
+
+// ── Fixtures ───────────────────────────────────────────────
+
+function makeSummary(overrides: Partial<Summary> = {}): Summary {
+  return {
+    id: 'sum-1',
+    topic_id: 'top-1',
+    title: 'Test summary',
+    content_markdown: null,
+    status: 'published',
+    order_index: 0,
+    is_active: true,
+    created_at: '2026-04-18T09:00:00Z',
+    updated_at: '2026-04-18T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeReadingState(overrides: Partial<ReadingState> = {}): ReadingState {
+  return {
+    id: 'rs-1',
+    student_id: 'stu-1',
+    summary_id: 'sum-1',
+    scroll_position: 0,
+    time_spent_seconds: 0,
+    completed: false,
+    last_read_at: null,
+    created_at: '2026-04-18T09:00:00Z',
+    updated_at: '2026-04-18T09:00:00Z',
+    ...overrides,
+  };
+}
+
+// jsdom does not implement IntersectionObserver. The hook's scroll-spy
+// effect instantiates one whenever sidebarBlocks.length > 0, so stub it.
+class IntersectionObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset window size for sidebar init
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 1440,
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).IntersectionObserver = IntersectionObserverStub;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Initial state
+// ══════════════════════════════════════════════════════════════
+
+describe('initial state', () => {
+  it('initializes with default tab = keywords', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.activeTab).toBe('keywords');
+  });
+
+  it('honors initialTab prop', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+        initialTab: 'notes',
+      }),
+    );
+    expect(result.current.activeTab).toBe('notes');
+  });
+
+  it('sidebar expanded when window >= 1280 px', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1440, writable: true });
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.sidebarCollapsed).toBe(false);
+  });
+
+  it('sidebar collapsed when window < 1280 px', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.sidebarCollapsed).toBe(true);
+  });
+
+  it('isCompleted reflects readingState.completed', () => {
+    const { result: r1 } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: makeReadingState({ completed: false }),
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(r1.current.isCompleted).toBe(false);
+
+    const { result: r2 } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: makeReadingState({ completed: true }),
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(r2.current.isCompleted).toBe(true);
+  });
+
+  it('isCompleted is false when readingState is null', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.isCompleted).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Tab/panel toggles
+// ══════════════════════════════════════════════════════════════
+
+describe('panel toggles', () => {
+  it('setShowTimer flips showTimer state', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.showTimer).toBe(false);
+    act(() => result.current.setShowTimer(true));
+    expect(result.current.showTimer).toBe(true);
+  });
+
+  it('setShowSettings, setShowStickyNotes, setShowBookmarksPanel are independent', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => {
+      result.current.setShowSettings(true);
+      result.current.setShowStickyNotes(true);
+      result.current.setShowBookmarksPanel(true);
+    });
+    expect(result.current.showSettings).toBe(true);
+    expect(result.current.showStickyNotes).toBe(true);
+    expect(result.current.showBookmarksPanel).toBe(true);
+  });
+
+  it('setActiveTab updates the current tab', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setActiveTab('notes'));
+    expect(result.current.activeTab).toBe('notes');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Pagination
+// ══════════════════════════════════════════════════════════════
+
+describe('pagination', () => {
+  it('totalPages = 0 when content_markdown is null', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: null }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.totalPages).toBe(0);
+    expect(result.current.isHtmlContent).toBe(false);
+    expect(result.current.htmlPages).toEqual([]);
+  });
+
+  it('isHtmlContent=true when markdown contains HTML tags', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: '<p>hello</p>' }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.isHtmlContent).toBe(true);
+    expect(result.current.totalPages).toBeGreaterThan(0);
+  });
+
+  it('isHtmlContent=false for plain-text markdown', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: 'just\ntext\nlines' }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.isHtmlContent).toBe(false);
+    expect(result.current.textPages.length).toBeGreaterThan(0);
+  });
+
+  it('safePage clamps to totalPages - 1', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: '<p>x</p>' }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setContentPage(999));
+    expect(result.current.safePage).toBe(result.current.totalPages - 1);
+  });
+
+  it('safePage is 0 when totalPages = 0 (Math.max guards against negative)', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: null }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.safePage).toBe(0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// View mode auto-switch
+// ══════════════════════════════════════════════════════════════
+
+describe('view mode auto-switch', () => {
+  it('stays in enriched when content_markdown is null', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: null }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.viewMode).toBe('enriched');
+  });
+
+  it('allows manual view-mode change to reading', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: 'plain text' }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setViewMode('reading'));
+    expect(result.current.viewMode).toBe('reading');
+  });
+
+  it('auto-switches reading → enriched after 2s when content_markdown is null', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: null }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setViewMode('reading'));
+    expect(result.current.viewMode).toBe('reading');
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.viewMode).toBe('enriched');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Expanded keyword toggle
+// ══════════════════════════════════════════════════════════════
+
+describe('toggleKeywordExpand', () => {
+  it('toggles expandedKeyword on repeated click', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.expandedKeyword).toBeNull();
+    act(() => result.current.toggleKeywordExpand('kw-1'));
+    expect(result.current.expandedKeyword).toBe('kw-1');
+    // Same key → collapse
+    act(() => result.current.toggleKeywordExpand('kw-1'));
+    expect(result.current.expandedKeyword).toBeNull();
+  });
+
+  it('switches expanded keyword between different keys', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.toggleKeywordExpand('kw-1'));
+    act(() => result.current.toggleKeywordExpand('kw-2'));
+    expect(result.current.expandedKeyword).toBe('kw-2');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Search
+// ══════════════════════════════════════════════════════════════
+
+describe('search', () => {
+  it('searchResultCount is 0 when query is empty', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.searchResultCount).toBe(0);
+  });
+
+  it('searchResultCount counts matching blocks (case-insensitive)', () => {
+    // Inject blocks via the useSummaryBlocksQuery mock for every render
+    const mockedBlocksQuery = vi.mocked(useSummaryBlocksQuery);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedBlocksQuery.mockReturnValue({
+      data: [
+        { id: 'b1', content: { title: 'Mitocondria energy plant' } },
+        { id: 'b2', content: { text: 'The nucleus stores DNA' } },
+        { id: 'b3', content: { label: 'MITOCONDRIA label' } },
+      ],
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setSearchQuery('mitocondria'));
+    expect(result.current.searchResultCount).toBe(2);
+    // Restore default mock so other tests see empty blocks
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedBlocksQuery.mockReturnValue({ data: [], isLoading: false } as any);
+  });
+
+  it('setSearchOpen / setSearchQuery update public state', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => {
+      result.current.setSearchOpen(true);
+      result.current.setSearchQuery('hello');
+    });
+    expect(result.current.searchOpen).toBe(true);
+    expect(result.current.searchQuery).toBe('hello');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Keyboard shortcuts
+// ══════════════════════════════════════════════════════════════
+
+describe('keyboard shortcuts', () => {
+  it('Ctrl+F opens search', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.searchOpen).toBe(false);
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'f', ctrlKey: true }),
+      );
+    });
+    expect(result.current.searchOpen).toBe(true);
+  });
+
+  it('Escape closes searchOpen and clears query', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => {
+      result.current.setSearchOpen(true);
+      result.current.setSearchQuery('hi');
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(result.current.searchOpen).toBe(false);
+    expect(result.current.searchQuery).toBe('');
+  });
+
+  it('Escape closes the topmost overlay first (bookmarks before sticky)', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => {
+      result.current.setShowBookmarksPanel(true);
+      result.current.setShowStickyNotes(true);
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    // Bookmarks closed, stickyNotes still open
+    expect(result.current.showBookmarksPanel).toBe(false);
+    expect(result.current.showStickyNotes).toBe(true);
+  });
+
+  it('Escape closes showTimer last when all other overlays are closed', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setShowTimer(true));
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(result.current.showTimer).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Sidebar block click (enriched mode)
+// ══════════════════════════════════════════════════════════════
+
+describe('handleSidebarBlockClick', () => {
+  it('does not throw when called with non-existent block id', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(() => {
+      act(() => result.current.handleSidebarBlockClick('nonexistent'));
+    }).not.toThrow();
+  });
+
+  it('switches view mode from reading → enriched before scrolling', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary({ content_markdown: 'abc' }),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    act(() => result.current.setViewMode('reading'));
+    expect(result.current.viewMode).toBe('reading');
+    act(() => result.current.handleSidebarBlockClick('blk-1'));
+    expect(result.current.viewMode).toBe('enriched');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Navigation passthrough
+// ══════════════════════════════════════════════════════════════
+
+describe('wired handlers', () => {
+  it('exposes handleNavigateKeywordWrapped from useKeywordPageNavigation mock', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.handleNavigateKeywordWrapped).toBe(
+      mockHandleNavigateKeywordWrapped,
+    );
+  });
+
+  it('exposes mutation handlers from useSummaryReaderMutations mock', () => {
+    const { result } = renderHook(() =>
+      useStudentSummaryReader({
+        summary: makeSummary(),
+        readingState: null,
+        onReadingStateChanged: vi.fn(),
+      }),
+    );
+    expect(result.current.handleMarkCompleted).toBe(mockHandlers.handleMarkCompleted);
+    expect(result.current.handleCreateAnnotation).toBe(mockHandlers.handleCreateAnnotation);
+    expect(result.current.handleDeleteAnnotation).toBe(mockHandlers.handleDeleteAnnotation);
+  });
+});

--- a/src/app/hooks/__tests__/useTopicMastery.test.ts
+++ b/src/app/hooks/__tests__/useTopicMastery.test.ts
@@ -1,0 +1,490 @@
+/**
+ * useTopicMastery.test.ts — Tests for the topic-level mastery hook.
+ *
+ * SISTEMA B (MASTERY-SYSTEMS.md): this hook is the CARD-ABSOLUTE side —
+ * it reads `p_know` from BKT states and emits `masteryPercent = round(p_know*100)`
+ * AS-IS without any delta/priority rescaling. Any threshold decisions live
+ * inside MASTERY_LOW_THRESHOLD (0.5) for the `needsReview` flag and in the
+ * priority-score heuristic. This file asserts the raw mapping, not any
+ * delta-color classification (that is Sistema C and lives in
+ * useKeywordMastery).
+ *
+ * IMPORTANT stability note: the hook's internal `fetchFsrsAndFlashcards` is
+ * memoized with `[topicIds]` as the dep. If a test passes a new array
+ * literal on every render, it re-triggers the effect infinitely. Every
+ * renderHook call in this file therefore uses a STABLE array reference
+ * created ONCE at the top of the test.
+ *
+ * Coverage (happy path + main errors):
+ *   - loading state aggregation (studentLoading || fsrsLoading)
+ *   - BKT p_know → masteryPercent rounding + attempts passthrough
+ *   - Missing BKT state → pKnow=null, masteryPercent=0, needsReview=true
+ *   - groupBktByTopic keeps the record with highest total_attempts
+ *   - FSRS aggregation per topic (totalCards, dueCount, avgStability, dominant)
+ *   - fsrsDueCount only counts states whose `due` is strictly before now
+ *   - flashcardToTopicMap built from flashcards with subtopic_id
+ *   - topicIds override vs. default (keys of BKT map)
+ *   - courseMastery averages masteryPercent per course id
+ *   - courseMastery empty when topicToCourseMap not provided
+ *   - needsReview true when pKnow < 0.5 OR dueCount > 0
+ *   - priorityScore higher for low mastery + overdue cards
+ *   - graceful fallback when getFsrsStates rejects → [] (hook still works)
+ *   - graceful fallback when getFlashcardsByTopic rejects → topic ignored
+ *   - refresh() re-triggers the fetch
+ *
+ * MOCKS:
+ *   - @/app/context/StudentDataContext (useStudentDataContext)
+ *   - @/app/services/platformApi (getFsrsStates)
+ *   - @/app/services/flashcardApi (getFlashcardsByTopic)
+ *   - @/app/utils/constants (getAxonToday, pinned to a fixed instant)
+ *
+ * RUN: npx vitest run src/app/hooks/__tests__/useTopicMastery.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// ── Pin "now" so `due < now` branch is deterministic ──────
+// All FSRS fixtures below compare against 2026-04-18T12:00:00Z.
+const FIXED_NOW = new Date('2026-04-18T12:00:00Z');
+
+vi.mock('@/app/utils/constants', () => ({
+  getAxonToday: () => new Date(FIXED_NOW),
+}));
+
+// ── Context mock ──────────────────────────────────────────
+const studentCtxState: { bktStates: any[]; loading: boolean } = {
+  bktStates: [],
+  loading: false,
+};
+
+vi.mock('@/app/context/StudentDataContext', () => ({
+  useStudentDataContext: () => studentCtxState,
+}));
+
+// ── Service mocks ─────────────────────────────────────────
+const getFsrsStatesMock = vi.fn();
+const getFlashcardsByTopicMock = vi.fn();
+
+vi.mock('@/app/services/platformApi', () => ({
+  getFsrsStates: (...args: any[]) => getFsrsStatesMock(...args),
+}));
+
+vi.mock('@/app/services/flashcardApi', () => ({
+  getFlashcardsByTopic: (...args: any[]) => getFlashcardsByTopicMock(...args),
+}));
+
+// ── Imports AFTER mocks ───────────────────────────────────
+import { useTopicMastery } from '@/app/hooks/useTopicMastery';
+
+// ── Stable array references (see note above) ──────────────
+// Keep a pool of frozen arrays so test bodies never pass literals that
+// would change reference between re-renders.
+const IDS_T1 = Object.freeze(['t-1']) as unknown as string[];
+const IDS_T1_T2 = Object.freeze(['t-1', 't-2']) as unknown as string[];
+const IDS_ORPHAN = Object.freeze(['t-orphan']) as unknown as string[];
+const IDS_ABC = Object.freeze(['t-A', 't-B', 't-C']) as unknown as string[];
+const IDS_AB = Object.freeze(['t-A', 't-B']) as unknown as string[];
+const IDS_WEAK_STRONG = Object.freeze(['t-weak', 't-strong']) as unknown as string[];
+const IDS_EMPTY = Object.freeze([]) as unknown as string[];
+
+// ── Fixture helpers ───────────────────────────────────────
+
+function makeBkt(
+  subtopic_id: string,
+  p_know: number,
+  overrides: Record<string, any> = {},
+): any {
+  return {
+    id: `bkt-${subtopic_id}`,
+    subtopic_id,
+    p_know,
+    p_transit: 0.1,
+    p_slip: 0.1,
+    p_guess: 0.2,
+    delta: 0,
+    total_attempts: 5,
+    correct_attempts: 3,
+    last_attempt_at: '2026-04-18T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeFsrs(
+  flashcard_id: string,
+  overrides: Record<string, any> = {},
+): any {
+  return {
+    id: `fs-${flashcard_id}`,
+    flashcard_id,
+    stability: 5,
+    difficulty: 5,
+    reps: 1,
+    lapses: 0,
+    state: 'review' as const,
+    due: null,
+    ...overrides,
+  };
+}
+
+function makeFlashcard(id: string, subtopic_id: string | null): any {
+  return {
+    id,
+    summary_id: 'sum-1',
+    keyword_id: 'kw-1',
+    subtopic_id,
+    front: 'Q',
+    back: 'A',
+    source: 'ai',
+    is_active: true,
+    deleted_at: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function mockFlashcardsByTopic(byTopic: Record<string, any[]>) {
+  getFlashcardsByTopicMock.mockImplementation(async (topicId: string) => ({
+    items: byTopic[topicId] ?? [],
+    total: (byTopic[topicId] ?? []).length,
+    limit: 500,
+    offset: 0,
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  studentCtxState.bktStates = [];
+  studentCtxState.loading = false;
+  getFsrsStatesMock.mockResolvedValue([]);
+  getFlashcardsByTopicMock.mockResolvedValue({
+    items: [],
+    total: 0,
+    limit: 500,
+    offset: 0,
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Suite 1: loading state
+// ─────────────────────────────────────────────────────────
+
+describe('useTopicMastery — loading', () => {
+  it('is loading while FSRS fetch is in flight', () => {
+    getFsrsStatesMock.mockReturnValueOnce(new Promise(() => {}));
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('is loading when student context is loading', async () => {
+    studentCtxState.loading = true;
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    // Even after FSRS drains, studentLoading keeps us in loading state.
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+  });
+
+  it('is NOT loading once FSRS resolved and context is ready', async () => {
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Suite 2: BKT → masteryPercent mapping (Sistema B)
+// ─────────────────────────────────────────────────────────
+
+describe('useTopicMastery — BKT → masteryPercent', () => {
+  it('maps p_know=0.6 to masteryPercent=60 (absolute, no rescale)', async () => {
+    studentCtxState.bktStates = [
+      makeBkt('t-1', 0.6, { total_attempts: 8, correct_attempts: 5 }),
+    ];
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.pKnow).toBeCloseTo(0.6, 10);
+    expect(info.masteryPercent).toBe(60);
+    expect(info.totalAttempts).toBe(8);
+    expect(info.correctAttempts).toBe(5);
+  });
+
+  it('rounds masteryPercent (e.g. 0.555 → 56)', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.555)];
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.topicMastery.get('t-1')!.masteryPercent).toBe(56);
+  });
+
+  it('returns pKnow=null + masteryPercent=0 when no BKT state exists for the topic', async () => {
+    studentCtxState.bktStates = [];
+    const { result } = renderHook(() => useTopicMastery(IDS_ORPHAN));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-orphan')!;
+    expect(info.pKnow).toBeNull();
+    expect(info.masteryPercent).toBe(0);
+    expect(info.totalAttempts).toBe(0);
+    expect(info.correctAttempts).toBe(0);
+    // pKnow is null → hook marks needsReview=true (unknown == review).
+    expect(info.needsReview).toBe(true);
+  });
+
+  it('needsReview=true when pKnow<0.5 and no due cards', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.3)];
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.topicMastery.get('t-1')!.needsReview).toBe(true);
+  });
+
+  it('needsReview=false when pKnow>=0.5 and no due cards', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.8)];
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.topicMastery.get('t-1')!.needsReview).toBe(false);
+  });
+
+  it('keeps the BKT record with highest total_attempts when duplicates exist', async () => {
+    studentCtxState.bktStates = [
+      makeBkt('t-1', 0.2, { id: 'low', total_attempts: 2 }),
+      makeBkt('t-1', 0.9, { id: 'hi', total_attempts: 20 }),
+      makeBkt('t-1', 0.5, { id: 'mid', total_attempts: 10 }),
+    ];
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.pKnow).toBeCloseTo(0.9, 10);
+    expect(info.totalAttempts).toBe(20);
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Suite 3: FSRS aggregation
+// ─────────────────────────────────────────────────────────
+
+describe('useTopicMastery — FSRS aggregation', () => {
+  it('aggregates total cards, due count, stability, and dominant state per topic', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.7)];
+
+    mockFlashcardsByTopic({
+      't-1': [
+        makeFlashcard('fc-1', 't-1'),
+        makeFlashcard('fc-2', 't-1'),
+        makeFlashcard('fc-3', 't-1'),
+      ],
+      't-2': [makeFlashcard('fc-4', 't-2')],
+    });
+
+    // fc-1 overdue; fc-2 future; fc-3 null. states: 2 review + 1 learning.
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-1', { state: 'review', stability: 2, due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-2', { state: 'review', stability: 10, due: '2026-04-30T00:00:00Z' }),
+      makeFsrs('fc-3', { state: 'learning', stability: 0.5, due: null }),
+    ]);
+
+    const { result } = renderHook(() => useTopicMastery(IDS_T1_T2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.fsrsTotalCards).toBe(3);
+    expect(info.fsrsDueCount).toBe(1);
+    expect(info.avgStability).toBeCloseTo((2 + 10 + 0.5) / 3, 10);
+    expect(info.dominantFsrsState).toBe('review');
+  });
+
+  it('fsrsDueCount=0 when a card has no due date', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.7)];
+    mockFlashcardsByTopic({ 't-1': [makeFlashcard('fc-1', 't-1')] });
+    getFsrsStatesMock.mockResolvedValue([makeFsrs('fc-1', { due: null })]);
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.topicMastery.get('t-1')!.fsrsDueCount).toBe(0);
+  });
+
+  it('needsReview=true when mastery is fine but cards are due', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.9)];
+    mockFlashcardsByTopic({ 't-1': [makeFlashcard('fc-1', 't-1')] });
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-1', { due: '2026-04-17T00:00:00Z' }),
+    ]);
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.topicMastery.get('t-1')!.needsReview).toBe(true);
+  });
+
+  it('priorityScore grows as mastery drops and due cards accumulate', async () => {
+    studentCtxState.bktStates = [makeBkt('t-weak', 0.2), makeBkt('t-strong', 0.9)];
+    mockFlashcardsByTopic({
+      't-weak': [makeFlashcard('fc-w1', 't-weak'), makeFlashcard('fc-w2', 't-weak')],
+      't-strong': [makeFlashcard('fc-s1', 't-strong')],
+    });
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-w1', { state: 'relearning', stability: 0.1, due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-w2', { state: 'learning', stability: 0.2, due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-s1', { state: 'review', stability: 100, due: '2026-05-01T00:00:00Z' }),
+    ]);
+
+    const { result } = renderHook(() => useTopicMastery(IDS_WEAK_STRONG));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const weak = result.current.topicMastery.get('t-weak')!;
+    const strong = result.current.topicMastery.get('t-strong')!;
+    expect(weak.priorityScore).toBeGreaterThan(strong.priorityScore);
+    expect(weak.priorityScore).toBeLessThanOrEqual(100);
+  });
+
+  it('FSRS entries whose flashcard_id is not in any topic are ignored', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.5)];
+    mockFlashcardsByTopic({ 't-1': [makeFlashcard('fc-1', 't-1')] });
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-1', { due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-orphan', { due: '2026-04-17T00:00:00Z' }),
+    ]);
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.fsrsTotalCards).toBe(1);
+    expect(info.fsrsDueCount).toBe(1);
+  });
+
+  it('flashcards without subtopic_id do not pollute the map', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.5)];
+    mockFlashcardsByTopic({
+      't-1': [makeFlashcard('fc-1', 't-1'), makeFlashcard('fc-2', null)],
+    });
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-1', { due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-2', { due: '2026-04-17T00:00:00Z' }),
+    ]);
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.fsrsTotalCards).toBe(1);
+    expect(result.current.flashcardToTopicMap.size).toBe(1);
+    expect(result.current.flashcardToTopicMap.get('fc-1')).toBe('t-1');
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Suite 4: topicIds vs default + courseMastery
+// ─────────────────────────────────────────────────────────
+
+describe('useTopicMastery — topicIds and courseMastery', () => {
+  it('defaults to BKT subtopic ids when topicIds is not provided', async () => {
+    studentCtxState.bktStates = [makeBkt('t-A', 0.5), makeBkt('t-B', 0.7)];
+    const { result } = renderHook(() => useTopicMastery());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const ids = Array.from(result.current.topicMastery.keys()).sort();
+    expect(ids).toEqual(['t-A', 't-B']);
+    // No topicIds → no per-topic flashcards fetch.
+    expect(getFlashcardsByTopicMock).not.toHaveBeenCalled();
+  });
+
+  it('does not request flashcards-by-topic when topicIds is empty', async () => {
+    studentCtxState.bktStates = [makeBkt('t-A', 0.5)];
+    const { result } = renderHook(() => useTopicMastery(IDS_EMPTY));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getFlashcardsByTopicMock).not.toHaveBeenCalled();
+    // Caller passed an explicit [] → hook uses it (??-check is "defined",
+    // not "truthy"), so topicMastery ends up empty too.
+    expect(result.current.topicMastery.size).toBe(0);
+  });
+
+  it('courseMastery is empty when topicToCourseMap is not provided', async () => {
+    studentCtxState.bktStates = [makeBkt('t-A', 0.8)];
+    const AIDS = Object.freeze(['t-A']) as unknown as string[];
+    const { result } = renderHook(() => useTopicMastery(AIDS));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.courseMastery.size).toBe(0);
+  });
+
+  it('courseMastery averages masteryPercent per course', async () => {
+    studentCtxState.bktStates = [
+      makeBkt('t-A', 0.6),   // 60
+      makeBkt('t-B', 0.8),   // 80
+      makeBkt('t-C', 0.4),   // 40
+    ];
+    const topicToCourse = new Map<string, string>([
+      ['t-A', 'c-1'],
+      ['t-B', 'c-1'],
+      ['t-C', 'c-2'],
+    ]);
+    const { result } = renderHook(() =>
+      useTopicMastery(IDS_ABC, topicToCourse),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.courseMastery.get('c-1')).toBe(70); // (60+80)/2
+    expect(result.current.courseMastery.get('c-2')).toBe(40);
+  });
+
+  it('courseMastery skips topics without a course mapping', async () => {
+    studentCtxState.bktStates = [makeBkt('t-A', 0.6), makeBkt('t-B', 1.0)];
+    const topicToCourse = new Map<string, string>([['t-A', 'c-1']]);
+    const { result } = renderHook(() =>
+      useTopicMastery(IDS_AB, topicToCourse),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.courseMastery.get('c-1')).toBe(60);
+    expect(result.current.courseMastery.has('c-2')).toBe(false);
+    expect(result.current.courseMastery.size).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Suite 5: Error paths + refresh
+// ─────────────────────────────────────────────────────────
+
+describe('useTopicMastery — error paths and refresh', () => {
+  it('continues with empty FSRS data when getFsrsStates rejects', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.7)];
+    getFsrsStatesMock.mockRejectedValueOnce(new Error('fsrs 500'));
+    mockFlashcardsByTopic({ 't-1': [makeFlashcard('fc-1', 't-1')] });
+
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const info = result.current.topicMastery.get('t-1')!;
+    expect(info.fsrsTotalCards).toBe(0);
+    expect(info.fsrsDueCount).toBe(0);
+    // BKT side still works.
+    expect(info.masteryPercent).toBe(70);
+  });
+
+  it('tolerates getFlashcardsByTopic rejections via Promise.allSettled', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.7), makeBkt('t-2', 0.5)];
+    getFsrsStatesMock.mockResolvedValue([
+      makeFsrs('fc-1', { due: '2026-04-17T00:00:00Z' }),
+      makeFsrs('fc-2', { due: '2026-04-17T00:00:00Z' }),
+    ]);
+    getFlashcardsByTopicMock.mockImplementation(async (topicId: string) => {
+      if (topicId === 't-1') {
+        return { items: [makeFlashcard('fc-1', 't-1')], total: 1, limit: 500, offset: 0 };
+      }
+      throw new Error('flashcards 500 for ' + topicId);
+    });
+
+    const { result } = renderHook(() => useTopicMastery(IDS_T1_T2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const t1 = result.current.topicMastery.get('t-1')!;
+    const t2 = result.current.topicMastery.get('t-2')!;
+    expect(t1.fsrsTotalCards).toBe(1);
+    expect(t2.fsrsTotalCards).toBe(0);
+    expect(t2.fsrsDueCount).toBe(0);
+  });
+
+  it('refresh() re-invokes the fetch pipeline', async () => {
+    studentCtxState.bktStates = [makeBkt('t-1', 0.7)];
+    mockFlashcardsByTopic({ 't-1': [] });
+    const { result } = renderHook(() => useTopicMastery(IDS_T1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const fsrsCallsBefore = getFsrsStatesMock.mock.calls.length;
+    const flashcardCallsBefore = getFlashcardsByTopicMock.mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(getFsrsStatesMock.mock.calls.length).toBeGreaterThan(fsrsCallsBefore);
+    expect(getFlashcardsByTopicMock.mock.calls.length).toBeGreaterThan(
+      flashcardCallsBefore,
+    );
+  });
+});

--- a/src/app/lib/__tests__/calendar-focus.test.ts
+++ b/src/app/lib/__tests__/calendar-focus.test.ts
@@ -1,0 +1,163 @@
+// ============================================================
+// Axon -- Tests for calendar-focus.ts
+//
+// Focus management helpers used by Sheet/Drawer interactions.
+// Uses jsdom + requestAnimationFrame (provided by jsdom env).
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  focusElement,
+  captureFocusTrigger,
+  createFocusManager,
+} from '@/app/lib/calendar-focus';
+import type { RefObject } from 'react';
+
+// Flush queued requestAnimationFrame callbacks deterministically.
+function flushRAF() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+function makeRef(el: HTMLElement | null): RefObject<HTMLElement | null> {
+  return { current: el };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('focusElement', () => {
+  it('focuses the referenced element after a RAF tick', async () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const spy = vi.spyOn(button, 'focus');
+
+    focusElement(makeRef(button));
+    expect(spy).not.toHaveBeenCalled(); // deferred until RAF
+
+    await flushRAF();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('passes preventScroll=false when explicitly requested', async () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const spy = vi.spyOn(button, 'focus');
+
+    focusElement(makeRef(button), { preventScroll: false });
+    await flushRAF();
+    expect(spy).toHaveBeenCalledWith({ preventScroll: false });
+  });
+
+  it('defaults preventScroll to true when options is empty', async () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const spy = vi.spyOn(button, 'focus');
+
+    focusElement(makeRef(button), {});
+    await flushRAF();
+    expect(spy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('does not throw when ref.current is null', async () => {
+    expect(() => focusElement(makeRef(null))).not.toThrow();
+    await flushRAF(); // no crash
+  });
+});
+
+describe('captureFocusTrigger', () => {
+  it('returns a function that restores focus to the active element at capture time', async () => {
+    const a = document.createElement('button');
+    const b = document.createElement('button');
+    document.body.appendChild(a);
+    document.body.appendChild(b);
+    a.focus();
+
+    const restore = captureFocusTrigger();
+    b.focus(); // move focus away
+    expect(document.activeElement).toBe(b);
+
+    const spy = vi.spyOn(a, 'focus');
+    restore();
+    await flushRAF();
+    expect(spy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('is safe to call when nothing is focused (trigger is null / body)', async () => {
+    // No element has focus -> document.activeElement is <body>
+    const restore = captureFocusTrigger();
+    expect(() => restore()).not.toThrow();
+    await flushRAF();
+  });
+});
+
+describe('createFocusManager', () => {
+  it('onOpen focuses target ref and onClose restores previous focus', async () => {
+    const trigger = document.createElement('button');
+    const target = document.createElement('input');
+    document.body.appendChild(trigger);
+    document.body.appendChild(target);
+
+    trigger.focus();
+    const triggerSpy = vi.spyOn(trigger, 'focus');
+    const targetSpy = vi.spyOn(target, 'focus');
+
+    const fm = createFocusManager();
+    fm.onOpen(makeRef(target));
+    await flushRAF();
+    expect(targetSpy).toHaveBeenCalledTimes(1);
+
+    fm.onClose();
+    await flushRAF();
+    expect(triggerSpy).toHaveBeenCalled();
+  });
+
+  it('onClose is a no-op when onOpen was never called', async () => {
+    const fm = createFocusManager();
+    expect(() => fm.onClose()).not.toThrow();
+  });
+
+  it('onClose only restores once per onOpen (second onClose is no-op)', async () => {
+    const trigger = document.createElement('button');
+    const target = document.createElement('input');
+    document.body.appendChild(trigger);
+    document.body.appendChild(target);
+
+    trigger.focus();
+    const spy = vi.spyOn(trigger, 'focus');
+
+    const fm = createFocusManager();
+    fm.onOpen(makeRef(target));
+    fm.onClose();
+    await flushRAF();
+    const callsAfterFirstClose = spy.mock.calls.length;
+
+    fm.onClose(); // second call — should not re-focus
+    await flushRAF();
+    expect(spy.mock.calls.length).toBe(callsAfterFirstClose);
+  });
+
+  it('supports multiple open/close cycles', async () => {
+    const trigger = document.createElement('button');
+    const target = document.createElement('input');
+    document.body.appendChild(trigger);
+    document.body.appendChild(target);
+
+    trigger.focus();
+    const spy = vi.spyOn(trigger, 'focus');
+
+    const fm = createFocusManager();
+    fm.onOpen(makeRef(target));
+    fm.onClose();
+    await flushRAF();
+
+    // Re-open
+    fm.onOpen(makeRef(target));
+    fm.onClose();
+    await flushRAF();
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/app/lib/__tests__/calendar-utils.test.ts
+++ b/src/app/lib/__tests__/calendar-utils.test.ts
@@ -1,0 +1,108 @@
+// ============================================================
+// Axon -- Tests for calendar-utils.ts
+//
+// Pure utilities: no mocks required.
+//   - formatDateISO  — YYYY-MM-DD output
+//   - getEventColor  — lookup EVENT_COLORS with 'exam' fallback
+//   - getTodayMidnight — Date at local 00:00:00
+// ============================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  formatDateISO,
+  getEventColor,
+  getTodayMidnight,
+} from '@/app/lib/calendar-utils';
+import { EVENT_COLORS } from '@/app/lib/calendar-constants';
+
+describe('formatDateISO', () => {
+  it('formats a date in YYYY-MM-DD with zero padding', () => {
+    const d = new Date(2024, 0, 5); // Jan 5 2024
+    expect(formatDateISO(d)).toBe('2024-01-05');
+  });
+
+  it('pads month correctly for single-digit months', () => {
+    expect(formatDateISO(new Date(2026, 3, 9))).toBe('2026-04-09');
+  });
+
+  it('pads day correctly for single-digit days', () => {
+    expect(formatDateISO(new Date(2026, 10, 1))).toBe('2026-11-01');
+  });
+
+  it('handles December (month index 11) as "12"', () => {
+    expect(formatDateISO(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+
+  it('handles January (month index 0) as "01"', () => {
+    expect(formatDateISO(new Date(2026, 0, 1))).toBe('2026-01-01');
+  });
+
+  it('outputs a 10-char string', () => {
+    expect(formatDateISO(new Date(2026, 5, 15))).toHaveLength(10);
+  });
+});
+
+describe('getEventColor', () => {
+  it('returns the color set for a known type ("exam")', () => {
+    expect(getEventColor('exam')).toBe(EVENT_COLORS.exam);
+  });
+
+  it('returns color for "review"', () => {
+    expect(getEventColor('review')).toBe(EVENT_COLORS.review);
+  });
+
+  it('returns color for "study"', () => {
+    expect(getEventColor('study')).toBe(EVENT_COLORS.study);
+  });
+
+  it('returns color for "oral"', () => {
+    expect(getEventColor('oral')).toBe(EVENT_COLORS.oral);
+  });
+
+  it('falls back to EVENT_COLORS.exam for an unknown type', () => {
+    expect(getEventColor('not-a-type')).toBe(EVENT_COLORS.exam);
+  });
+
+  it('falls back to EVENT_COLORS.exam for empty string', () => {
+    expect(getEventColor('')).toBe(EVENT_COLORS.exam);
+  });
+
+  it('returned object always has bg/text/border/dot keys', () => {
+    const result = getEventColor('practical');
+    expect(result).toHaveProperty('bg');
+    expect(result).toHaveProperty('text');
+    expect(result).toHaveProperty('border');
+    expect(result).toHaveProperty('dot');
+  });
+});
+
+describe('getTodayMidnight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a Date with hours/min/sec/ms zeroed', () => {
+    vi.setSystemTime(new Date(2026, 3, 18, 14, 33, 22, 555));
+    const result = getTodayMidnight();
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('preserves the current Y/M/D', () => {
+    vi.setSystemTime(new Date(2026, 3, 18, 14, 33, 22, 555));
+    const result = getTodayMidnight();
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(3);
+    expect(result.getDate()).toBe(18);
+  });
+
+  it('returns a Date instance', () => {
+    expect(getTodayMidnight()).toBeInstanceOf(Date);
+  });
+});

--- a/src/app/lib/__tests__/concurrency.test.ts
+++ b/src/app/lib/__tests__/concurrency.test.ts
@@ -1,0 +1,231 @@
+// ============================================================
+// Axon -- Tests for concurrency.ts (parallelWithLimit)
+//
+// Covers:
+//   - concurrency cap enforcement (never exceed limit)
+//   - FIFO task start order
+//   - result order matches input order
+//   - rejection captured in allSettled shape
+//   - fulfilled/rejected mixture
+//   - limit > tasks.length handled
+//   - empty task list
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import { parallelWithLimit } from '@/app/lib/concurrency';
+
+// ── Helpers ───────────────────────────────────────────────
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+// ================================================================
+
+describe('parallelWithLimit', () => {
+  it('returns empty array when given no tasks', async () => {
+    const result = await parallelWithLimit([], 5);
+    expect(result).toEqual([]);
+  });
+
+  it('runs all tasks and returns results in input order', async () => {
+    const tasks = [
+      () => Promise.resolve('a'),
+      () => Promise.resolve('b'),
+      () => Promise.resolve('c'),
+    ];
+    const result = await parallelWithLimit(tasks, 2);
+    expect(result).toEqual([
+      { status: 'fulfilled', value: 'a' },
+      { status: 'fulfilled', value: 'b' },
+      { status: 'fulfilled', value: 'c' },
+    ]);
+  });
+
+  it('captures rejected tasks as allSettled shape', async () => {
+    const err = new Error('boom');
+    const tasks = [
+      () => Promise.resolve(1),
+      () => Promise.reject(err),
+      () => Promise.resolve(3),
+    ];
+    const result = await parallelWithLimit(tasks, 2);
+    expect(result[0]).toEqual({ status: 'fulfilled', value: 1 });
+    expect(result[1]).toEqual({ status: 'rejected', reason: err });
+    expect(result[2]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    const limit = 3;
+    let running = 0;
+    let peak = 0;
+
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      running++;
+      peak = Math.max(peak, running);
+      await delay(5);
+      running--;
+      return 'ok';
+    });
+
+    await parallelWithLimit(tasks, limit);
+    expect(peak).toBeLessThanOrEqual(limit);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it('fills worker slots immediately when a task completes (no chunk-barrier)', async () => {
+    // Three tasks. With limit=2, a and b start. If a finishes first,
+    // c should start BEFORE b finishes. If we were chunking, c would
+    // only start once BOTH a and b finished.
+    const a = deferred<string>();
+    const b = deferred<string>();
+    const c = deferred<string>();
+
+    const started: string[] = [];
+
+    const tasks = [
+      async () => {
+        started.push('a');
+        return a.promise;
+      },
+      async () => {
+        started.push('b');
+        return b.promise;
+      },
+      async () => {
+        started.push('c');
+        return c.promise;
+      },
+    ];
+
+    const resultP = parallelWithLimit(tasks, 2);
+
+    // Yield so microtasks flush
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // a and b should have started; c should NOT have started yet
+    expect(started).toEqual(['a', 'b']);
+
+    // Resolve a -> slot opens, c should start
+    a.resolve('A');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(['a', 'b', 'c']);
+
+    // Resolve the rest
+    b.resolve('B');
+    c.resolve('C');
+
+    const result = await resultP;
+    expect(result).toEqual([
+      { status: 'fulfilled', value: 'A' },
+      { status: 'fulfilled', value: 'B' },
+      { status: 'fulfilled', value: 'C' },
+    ]);
+  });
+
+  it('starts tasks in FIFO order', async () => {
+    const started: number[] = [];
+    const gates = [deferred(), deferred(), deferred(), deferred(), deferred()];
+    const tasks = gates.map((g, i) => async () => {
+      started.push(i);
+      await g.promise;
+      return i;
+    });
+
+    const p = parallelWithLimit(tasks, 2);
+
+    // Let the first two start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual([0, 1]);
+
+    // Release them one at a time and check order.
+    gates[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started[2]).toBe(2);
+
+    gates[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started[3]).toBe(3);
+
+    gates[2].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started[4]).toBe(4);
+
+    gates[3].resolve();
+    gates[4].resolve();
+    await p;
+    expect(started).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('handles limit greater than tasks.length gracefully', async () => {
+    const tasks = [
+      () => Promise.resolve(1),
+      () => Promise.resolve(2),
+    ];
+    const result = await parallelWithLimit(tasks, 100);
+    expect(result.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([1, 2]);
+  });
+
+  it('returns results in input order even when tasks complete out of order', async () => {
+    const tasks = [
+      () => delay(30).then(() => 'slow-first'),
+      () => delay(1).then(() => 'fast-second'),
+      () => delay(15).then(() => 'medium-third'),
+    ];
+    const result = await parallelWithLimit(tasks, 3);
+    expect(result).toEqual([
+      { status: 'fulfilled', value: 'slow-first' },
+      { status: 'fulfilled', value: 'fast-second' },
+      { status: 'fulfilled', value: 'medium-third' },
+    ]);
+  });
+
+  it('handles sync throws inside task factories as rejections', async () => {
+    const tasks = [
+      () => Promise.resolve(1),
+      // Throws synchronously before returning a promise. Because
+      // parallelWithLimit awaits the *return* of the task call,
+      // a synchronous throw propagates into the try/catch block.
+      (() => {
+        throw new Error('sync-fail');
+      }) as () => Promise<number>,
+      () => Promise.resolve(3),
+    ];
+    const result = await parallelWithLimit(tasks, 2);
+    expect(result[0]).toEqual({ status: 'fulfilled', value: 1 });
+    expect(result[1].status).toBe('rejected');
+    expect(result[2]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('respects limit of 1 (serial execution)', async () => {
+    let running = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 5 }, () => async () => {
+      running++;
+      peak = Math.max(peak, running);
+      await delay(2);
+      running--;
+      return 'x';
+    });
+
+    await parallelWithLimit(tasks, 1);
+    expect(peak).toBe(1);
+  });
+});

--- a/src/app/lib/__tests__/content-tree-helpers.test.ts
+++ b/src/app/lib/__tests__/content-tree-helpers.test.ts
@@ -1,0 +1,159 @@
+// ============================================================
+// Axon -- Tests for content-tree-helpers.ts
+//
+// Pure function: resolveBreadcrumb (tree, topicId) -> breadcrumb names
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import { resolveBreadcrumb } from '@/app/lib/content-tree-helpers';
+
+// ── Fixture builder ───────────────────────────────────────
+
+function makeTree() {
+  return {
+    courses: [
+      {
+        id: 'c1',
+        name: 'Math 101',
+        semesters: [
+          {
+            id: 's1',
+            name: 'Fall 2025',
+            sections: [
+              {
+                id: 'sec1',
+                name: 'Algebra',
+                topics: [
+                  { id: 't1', name: 'Linear Equations' },
+                  { id: 't2', name: 'Quadratic Equations' },
+                ],
+              },
+              {
+                id: 'sec2',
+                name: 'Geometry',
+                topics: [{ id: 't3', name: 'Triangles' }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'c2',
+        name: 'Physics 101',
+        semesters: [
+          {
+            id: 's2',
+            name: 'Spring 2026',
+            sections: [
+              {
+                id: 'sec3',
+                name: 'Mechanics',
+                topics: [{ id: 't4', name: 'Newton Laws' }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ================================================================
+// resolveBreadcrumb
+// ================================================================
+
+describe('resolveBreadcrumb', () => {
+  it('returns full breadcrumb for a topic in the first course', () => {
+    const result = resolveBreadcrumb(makeTree(), 't1');
+    expect(result).toEqual({
+      courseName: 'Math 101',
+      semesterName: 'Fall 2025',
+      sectionName: 'Algebra',
+      topicName: 'Linear Equations',
+    });
+  });
+
+  it('returns full breadcrumb for a topic in the second course', () => {
+    const result = resolveBreadcrumb(makeTree(), 't4');
+    expect(result).toEqual({
+      courseName: 'Physics 101',
+      semesterName: 'Spring 2026',
+      sectionName: 'Mechanics',
+      topicName: 'Newton Laws',
+    });
+  });
+
+  it('returns full breadcrumb for a topic in a different section', () => {
+    const result = resolveBreadcrumb(makeTree(), 't3');
+    expect(result.sectionName).toBe('Geometry');
+    expect(result.topicName).toBe('Triangles');
+  });
+
+  it('returns empty object when topic is not found', () => {
+    expect(resolveBreadcrumb(makeTree(), 'unknown-id')).toEqual({});
+  });
+
+  it('returns empty object when tree is null', () => {
+    expect(resolveBreadcrumb(null, 't1')).toEqual({});
+  });
+
+  it('returns empty object when tree is undefined', () => {
+    expect(resolveBreadcrumb(undefined, 't1')).toEqual({});
+  });
+
+  it('returns empty object when topicId is empty string', () => {
+    expect(resolveBreadcrumb(makeTree(), '')).toEqual({});
+  });
+
+  it('accepts a direct array of courses', () => {
+    const courses = makeTree().courses;
+    const result = resolveBreadcrumb(courses, 't2');
+    expect(result.topicName).toBe('Quadratic Equations');
+  });
+
+  it('handles tree with courses but no semesters', () => {
+    const tree = { courses: [{ id: 'c1', name: 'Empty' }] };
+    expect(resolveBreadcrumb(tree, 't1')).toEqual({});
+  });
+
+  it('handles semesters with missing sections', () => {
+    const tree = {
+      courses: [
+        {
+          id: 'c1',
+          name: 'C',
+          semesters: [{ id: 's1', name: 'S' }],
+        },
+      ],
+    };
+    expect(resolveBreadcrumb(tree, 't1')).toEqual({});
+  });
+
+  it('handles sections with missing topics', () => {
+    const tree = {
+      courses: [
+        {
+          id: 'c1',
+          name: 'C',
+          semesters: [
+            {
+              id: 's1',
+              name: 'S',
+              sections: [{ id: 'sec1', name: 'Sec' }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(resolveBreadcrumb(tree, 't1')).toEqual({});
+  });
+
+  it('returns empty for empty courses array', () => {
+    expect(resolveBreadcrumb({ courses: [] }, 't1')).toEqual({});
+  });
+
+  it('returns empty for {} tree without courses key', () => {
+    expect(resolveBreadcrumb({}, 't1')).toEqual({});
+  });
+});

--- a/src/app/lib/__tests__/flashcard-export.test.ts
+++ b/src/app/lib/__tests__/flashcard-export.test.ts
@@ -1,0 +1,337 @@
+// ============================================================
+// Axon -- Tests for flashcard-export.ts
+//
+// Coverage: flashcardsToCSV (escape, headers, is_active default,
+//           nulls/undefineds), exportFlashcardsCSV + exportFlashcardsJSON
+//           (Blob creation, <a download> trigger, cleanup timing).
+//
+// Pure CSV logic has NO mocks. The DOM download flow uses jsdom and
+// spies on document/URL APIs; no network or real file I/O.
+//
+// Run: npx vitest run src/app/lib/__tests__/flashcard-export.test.ts
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  flashcardsToCSV,
+  exportFlashcardsCSV,
+  exportFlashcardsJSON,
+} from '@/app/lib/flashcard-export';
+import type { FlashcardItem } from '@/app/services/flashcardApi';
+
+// jsdom's Blob does not implement .text() or .arrayBuffer(). Instead of
+// relying on those, we inspect the strings passed to `new Blob(parts, ...)`.
+// The Blob constructor stores its parts as-is; we intercept by wrapping
+// the global Blob with a passthrough that captures the parts argument.
+function installBlobSpy(): {
+  get lastParts(): BlobPart[];
+  restore: () => void;
+} {
+  const OriginalBlob = globalThis.Blob;
+  let captured: BlobPart[] = [];
+  class SpyBlob extends OriginalBlob {
+    constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+      super(parts, options);
+      captured = parts ?? [];
+    }
+  }
+  (globalThis as unknown as { Blob: typeof Blob }).Blob = SpyBlob as unknown as typeof Blob;
+  return {
+    get lastParts() {
+      return captured;
+    },
+    restore: () => {
+      (globalThis as unknown as { Blob: typeof Blob }).Blob = OriginalBlob;
+    },
+  };
+}
+
+function joinParts(parts: BlobPart[]): string {
+  return parts
+    .map((p) => (typeof p === 'string' ? p : ''))
+    .join('');
+}
+
+// ── Fixture builder ───────────────────────────────────────
+
+function makeCard(overrides: Partial<FlashcardItem> = {}): FlashcardItem {
+  return {
+    id: 'card-1',
+    summary_id: 'sum-1',
+    keyword_id: 'kw-1',
+    subtopic_id: 'sub-1',
+    front: 'What is mitosis?',
+    back: 'Cell division',
+    front_image_url: null,
+    back_image_url: null,
+    source: 'manual',
+    is_active: true,
+    deleted_at: null,
+    created_by: 'user-1',
+    created_at: '2026-01-01T10:00:00Z',
+    updated_at: '2026-01-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ============================================================
+// flashcardsToCSV — pure CSV generation
+// ============================================================
+
+describe('flashcardsToCSV', () => {
+  it('emits the canonical header row first', () => {
+    const csv = flashcardsToCSV([]);
+    const firstLine = csv.split('\n')[0];
+    expect(firstLine).toBe(
+      'id,front,back,keyword_id,subtopic_id,source,is_active,created_at',
+    );
+  });
+
+  it('produces header-only output for empty input', () => {
+    const csv = flashcardsToCSV([]);
+    expect(csv.split('\n')).toHaveLength(1);
+  });
+
+  it('serializes a simple row without quoting when no special chars', () => {
+    const csv = flashcardsToCSV([makeCard({ front: 'Q', back: 'A' })]);
+    const rows = csv.split('\n');
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toBe('card-1,Q,A,kw-1,sub-1,manual,true,2026-01-01T10:00:00Z');
+  });
+
+  it('wraps values containing commas in double quotes', () => {
+    const csv = flashcardsToCSV([makeCard({ front: 'Hola, mundo' })]);
+    expect(csv).toContain('"Hola, mundo"');
+  });
+
+  it('wraps values containing newlines in double quotes', () => {
+    const csv = flashcardsToCSV([makeCard({ back: 'Line1\nLine2' })]);
+    expect(csv).toContain('"Line1\nLine2"');
+  });
+
+  it('wraps values containing carriage returns in double quotes', () => {
+    const csv = flashcardsToCSV([makeCard({ back: 'Line1\rLine2' })]);
+    expect(csv).toContain('"Line1\rLine2"');
+  });
+
+  it('escapes double quotes by doubling them and wraps the value', () => {
+    const csv = flashcardsToCSV([makeCard({ front: 'He said "hi"' })]);
+    // "He said ""hi"""
+    expect(csv).toContain('"He said ""hi"""');
+  });
+
+  it('renders null/undefined string fields as empty cells', () => {
+    // subtopic_id is optional → undefined should become empty
+    const csv = flashcardsToCSV([
+      makeCard({ subtopic_id: null, created_at: undefined as unknown as string }),
+    ]);
+    const row = csv.split('\n')[1];
+    // subtopic_id is the 5th column (0: id, 1: front, 2: back, 3: keyword, 4: subtopic)
+    const cells = row.split(',');
+    expect(cells[4]).toBe('');
+    // created_at is the 8th column
+    expect(cells[7]).toBe('');
+  });
+
+  it('defaults is_active to "true" when not explicitly false', () => {
+    const csv = flashcardsToCSV([
+      makeCard({ is_active: undefined as unknown as boolean }),
+    ]);
+    const cells = csv.split('\n')[1].split(',');
+    expect(cells[6]).toBe('true');
+  });
+
+  it('emits is_active "false" only when explicitly false', () => {
+    const csv = flashcardsToCSV([makeCard({ is_active: false })]);
+    const cells = csv.split('\n')[1].split(',');
+    expect(cells[6]).toBe('false');
+  });
+
+  it('serializes multiple rows separated by \\n', () => {
+    const csv = flashcardsToCSV([
+      makeCard({ id: 'a' }),
+      makeCard({ id: 'b' }),
+      makeCard({ id: 'c' }),
+    ]);
+    const rows = csv.split('\n');
+    // 1 header + 3 data
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toMatch(/^a,/);
+    expect(rows[2]).toMatch(/^b,/);
+    expect(rows[3]).toMatch(/^c,/);
+  });
+
+  it('preserves ordering of input array', () => {
+    const csv = flashcardsToCSV([
+      makeCard({ id: 'third', front: 'C' }),
+      makeCard({ id: 'first', front: 'A' }),
+      makeCard({ id: 'second', front: 'B' }),
+    ]);
+    const dataRows = csv.split('\n').slice(1);
+    expect(dataRows[0]).toMatch(/^third,/);
+    expect(dataRows[1]).toMatch(/^first,/);
+    expect(dataRows[2]).toMatch(/^second,/);
+  });
+});
+
+// ============================================================
+// exportFlashcardsCSV — DOM + Blob download flow
+// ============================================================
+
+describe('exportFlashcardsCSV', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.fn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createObjectURLSpy = vi.fn(() => 'blob:mock-url');
+    revokeObjectURLSpy = vi.fn();
+    (globalThis.URL as unknown as { createObjectURL: unknown }).createObjectURL =
+      createObjectURLSpy;
+    (globalThis.URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL =
+      revokeObjectURLSpy;
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clickSpy.mockRestore();
+  });
+
+  it('creates a Blob via URL.createObjectURL and triggers a link click', () => {
+    exportFlashcardsCSV([makeCard()], 'my-export');
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toMatch(/text\/csv/);
+  });
+
+  it('prepends a BOM (\\uFEFF) for Excel compatibility', () => {
+    const blobSpy = installBlobSpy();
+    try {
+      exportFlashcardsCSV([makeCard({ front: 'Hola' })], 'out');
+      const text = joinParts(blobSpy.lastParts);
+      expect(text.charCodeAt(0)).toBe(0xfeff);
+    } finally {
+      blobSpy.restore();
+    }
+  });
+
+  it('uses the provided filename with .csv extension', () => {
+    // Capture the anchor element created inside export
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    exportFlashcardsCSV([makeCard()], 'my-export');
+    const appended = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(appended.download).toBe('my-export.csv');
+    expect(appended.href).toContain('blob:');
+    appendChildSpy.mockRestore();
+  });
+
+  it('defaults filename to "flashcards.csv" when omitted', () => {
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    exportFlashcardsCSV([makeCard()]);
+    const appended = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(appended.download).toBe('flashcards.csv');
+    appendChildSpy.mockRestore();
+  });
+
+  it('revokes the object URL and removes the link after 100ms', () => {
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild');
+    exportFlashcardsCSV([makeCard()], 'x');
+    // Before timer: still appended, not revoked
+    expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+    expect(removeChildSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+    expect(removeChildSpy).toHaveBeenCalledTimes(1);
+    removeChildSpy.mockRestore();
+  });
+
+  it('handles an empty flashcards array (headers-only download)', () => {
+    const blobSpy = installBlobSpy();
+    try {
+      exportFlashcardsCSV([], 'empty');
+      const text = joinParts(blobSpy.lastParts);
+      // BOM + header row only
+      expect(text).toContain('id,front,back');
+      // Strip leading BOM before splitting to count rows
+      const stripped = text.replace(/^\uFEFF/, '');
+      expect(stripped.split('\n')).toHaveLength(1);
+    } finally {
+      blobSpy.restore();
+    }
+  });
+});
+
+// ============================================================
+// exportFlashcardsJSON — DOM + Blob download flow
+// ============================================================
+
+describe('exportFlashcardsJSON', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.fn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createObjectURLSpy = vi.fn(() => 'blob:json-url');
+    revokeObjectURLSpy = vi.fn();
+    (globalThis.URL as unknown as { createObjectURL: unknown }).createObjectURL =
+      createObjectURLSpy;
+    (globalThis.URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL =
+      revokeObjectURLSpy;
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clickSpy.mockRestore();
+  });
+
+  it('creates a JSON-typed Blob', () => {
+    exportFlashcardsJSON([makeCard()], 'x');
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob.type).toMatch(/application\/json/);
+  });
+
+  it('writes JSON with 2-space indentation preserving input shape', () => {
+    const blobSpy = installBlobSpy();
+    try {
+      const cards = [makeCard({ id: 'c1' }), makeCard({ id: 'c2' })];
+      exportFlashcardsJSON(cards, 'x');
+      const text = joinParts(blobSpy.lastParts);
+      const parsed = JSON.parse(text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].id).toBe('c1');
+      // indentation → contains newlines
+      expect(text).toContain('\n  ');
+    } finally {
+      blobSpy.restore();
+    }
+  });
+
+  it('defaults filename to flashcards.json when omitted', () => {
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    exportFlashcardsJSON([makeCard()]);
+    const appended = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(appended.download).toBe('flashcards.json');
+    appendChildSpy.mockRestore();
+  });
+
+  it('uses provided filename with .json extension', () => {
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    exportFlashcardsJSON([makeCard()], 'backup-2026');
+    const appended = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(appended.download).toBe('backup-2026.json');
+    appendChildSpy.mockRestore();
+  });
+
+  it('cleans up the object URL after 100ms', () => {
+    exportFlashcardsJSON([makeCard()], 'x');
+    expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:json-url');
+  });
+});

--- a/src/app/lib/__tests__/flashcard-utils.test.ts
+++ b/src/app/lib/__tests__/flashcard-utils.test.ts
@@ -1,0 +1,166 @@
+// ============================================================
+// Axon -- Tests for flashcard-utils.ts
+//
+// Pure functions: extractImageUrl, extractText, detectCardType
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  extractImageUrl,
+  extractText,
+  detectCardType,
+} from '@/app/lib/flashcard-utils';
+
+// ================================================================
+// extractImageUrl
+// ================================================================
+
+describe('extractImageUrl', () => {
+  it('extracts URL from markdown ![img](URL)', () => {
+    expect(extractImageUrl('![img](https://example.com/pic.png)')).toBe('https://example.com/pic.png');
+  });
+
+  it('extracts URL when markdown is inside longer content', () => {
+    const content = 'Some text before ![img](https://example.com/a.jpg) trailing';
+    expect(extractImageUrl(content)).toBe('https://example.com/a.jpg');
+  });
+
+  it('extracts standalone HTTPS image URL', () => {
+    expect(extractImageUrl('https://example.com/pic.png')).toBe('https://example.com/pic.png');
+  });
+
+  it('extracts standalone HTTP image URL', () => {
+    expect(extractImageUrl('http://example.com/pic.jpeg')).toBe('http://example.com/pic.jpeg');
+  });
+
+  it('extracts URL with .jpg extension', () => {
+    expect(extractImageUrl('https://foo.com/bar.jpg')).toBe('https://foo.com/bar.jpg');
+  });
+
+  it('extracts URL with .webp extension', () => {
+    expect(extractImageUrl('https://foo.com/bar.webp')).toBe('https://foo.com/bar.webp');
+  });
+
+  it('extracts URL with .gif, .svg, .bmp extensions', () => {
+    expect(extractImageUrl('https://a.com/x.gif')).toBe('https://a.com/x.gif');
+    expect(extractImageUrl('https://a.com/x.svg')).toBe('https://a.com/x.svg');
+    expect(extractImageUrl('https://a.com/x.bmp')).toBe('https://a.com/x.bmp');
+  });
+
+  it('is case-insensitive for file extensions', () => {
+    expect(extractImageUrl('https://foo.com/bar.PNG')).toBe('https://foo.com/bar.PNG');
+    expect(extractImageUrl('https://foo.com/bar.Jpeg')).toBe('https://foo.com/bar.Jpeg');
+  });
+
+  it('trims surrounding whitespace before matching standalone URL', () => {
+    expect(extractImageUrl('   https://example.com/a.png   ')).toBe('https://example.com/a.png');
+  });
+
+  it('returns null for plain text', () => {
+    expect(extractImageUrl('just some text')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractImageUrl('')).toBeNull();
+  });
+
+  it('returns null when URL is not an image extension (standalone)', () => {
+    expect(extractImageUrl('https://example.com/page.html')).toBeNull();
+  });
+
+  it('prefers markdown match over standalone detection', () => {
+    // Content includes both markdown AND plain text that is not an image.
+    const content = 'intro ![img](https://a.com/inside.png) more';
+    expect(extractImageUrl(content)).toBe('https://a.com/inside.png');
+  });
+});
+
+// ================================================================
+// extractText
+// ================================================================
+
+describe('extractText', () => {
+  it('returns original string when no image markdown present', () => {
+    expect(extractText('hello world')).toBe('hello world');
+  });
+
+  it('removes markdown ![img](URL) token', () => {
+    expect(extractText('before ![img](https://a.com/x.png) after')).toBe('before  after');
+  });
+
+  it('removes multiple image markdown tokens', () => {
+    const input = '![img](a.png) middle ![img](b.png)';
+    expect(extractText(input)).toBe('middle');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(extractText('   hello   ')).toBe('hello');
+  });
+
+  it('returns empty string when input is only markdown image', () => {
+    expect(extractText('![img](https://a.com/x.png)')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(extractText('')).toBe('');
+  });
+});
+
+// ================================================================
+// detectCardType
+// ================================================================
+
+describe('detectCardType', () => {
+  it('detects "cloze" when front has {{...}} syntax', () => {
+    expect(detectCardType('The capital is {{Paris}}', 'Paris')).toBe('cloze');
+  });
+
+  it('cloze detection takes precedence over images', () => {
+    const front = '![img](https://a.com/x.png) and {{answer}}';
+    expect(detectCardType(front, 'back')).toBe('cloze');
+  });
+
+  it('detects "text" when neither side has images', () => {
+    expect(detectCardType('question?', 'answer')).toBe('text');
+  });
+
+  it('detects "text_image" when only back has an image', () => {
+    expect(
+      detectCardType('question?', '![img](https://a.com/x.png)')
+    ).toBe('text_image');
+  });
+
+  it('detects "image_text" when only front has an image', () => {
+    expect(
+      detectCardType('![img](https://a.com/x.png)', 'answer')
+    ).toBe('image_text');
+  });
+
+  it('detects "image_image" when both sides have only images (no text)', () => {
+    expect(
+      detectCardType('![img](https://a.com/q.png)', '![img](https://a.com/a.png)')
+    ).toBe('image_image');
+  });
+
+  it('detects "text_both" when both sides have images + text', () => {
+    const front = 'Question text ![img](https://a.com/q.png)';
+    const back = 'Answer text ![img](https://a.com/a.png)';
+    expect(detectCardType(front, back)).toBe('text_both');
+  });
+
+  it('does not classify as text_both if one side has no text', () => {
+    const front = '![img](https://a.com/q.png)';
+    const back = 'text only + ![img](https://a.com/a.png)';
+    // fTxt is empty, so text_both fails; falls through to image_image? No,
+    // bTxt is present so it's not image_image. That leaves image_text
+    // (only front has image, back has both). Per the algorithm, fImg &&
+    // bImg && fTxt && bTxt must ALL be true for text_both — here fTxt is
+    // empty. Next check: fImg && bImg => image_image.
+    expect(detectCardType(front, back)).toBe('image_image');
+  });
+
+  it('handles empty strings as text type', () => {
+    expect(detectCardType('', '')).toBe('text');
+  });
+});

--- a/src/app/lib/__tests__/palette.test.ts
+++ b/src/app/lib/__tests__/palette.test.ts
@@ -1,0 +1,96 @@
+// ============================================================
+// Axon -- Tests for palette.ts
+//
+// Static color + layout constants. These tests are guardrails to
+// detect accidental palette drift (e.g. amberBg reverting to
+// '#fef3c7' — the bug D-07 AUDIT FIXED).
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+import { axon, tint, layout } from '@/app/lib/palette';
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+describe('axon brand palette', () => {
+  it('exposes dark teal family', () => {
+    expect(axon.darkTeal).toBe('#1B3B36');
+    expect(axon.tealAccent).toBe('#2a8c7a');
+    expect(axon.hoverTeal).toBe('#244e47');
+    expect(axon.darkPanel).toBe('#1a2e2a');
+  });
+
+  it('exposes page/card backgrounds', () => {
+    expect(axon.pageBg).toBe('#F0F2F5');
+    expect(axon.cardBg).toBe('#FFFFFF');
+  });
+
+  it('exposes progress gradient stops', () => {
+    expect(axon.progressStart).toBe('#2dd4a8');
+    expect(axon.progressEnd).toBe('#0d9488');
+    expect(axon.progressLabel).toBe('#5cbdaa');
+  });
+
+  it('exposes sidebar text colors', () => {
+    expect(axon.sidebarText).toBe('#8fbfb3');
+    expect(axon.sidebarSub).toBe('#6db5a5');
+  });
+
+  it('every value is a 6-char hex color', () => {
+    for (const value of Object.values(axon)) {
+      expect(value).toMatch(HEX);
+    }
+  });
+});
+
+describe('tint palette', () => {
+  it('locks amberBg to the canonical #fef9ee (D-07 audit)', () => {
+    expect(tint.amberBg).toBe('#fef9ee');
+    expect(tint.amberBg).not.toBe('#fef3c7');
+  });
+
+  it('exposes teal tints', () => {
+    expect(tint.tealBg).toBe('#e8f5f1');
+    expect(tint.tealBorder).toBe('#b3ddd2');
+    expect(tint.tealSoft).toBe('#d1f0e7');
+  });
+
+  it('exposes amber tints (in-progress)', () => {
+    expect(tint.amberBorder).toBe('#fde68a');
+    expect(tint.amberText).toBe('#b45309');
+    expect(tint.amberIcon).toBe('#d97706');
+  });
+
+  it('exposes success tints', () => {
+    expect(tint.successBg).toBe('#d1fae5');
+    expect(tint.successBorder).toBe('#6ee7b7');
+    expect(tint.successText).toBe('#047857');
+    expect(tint.successAccent).toBe('#10b981');
+  });
+
+  it('exposes neutral tints', () => {
+    expect(tint.neutralBg).toBe('#f8f9fa');
+    expect(tint.neutralBorder).toBe('#e5e7eb');
+    expect(tint.neutralText).toBe('#9ca3af');
+    expect(tint.subtitleText).toBe('#6b7280');
+  });
+
+  it('every tint value is a 6-char hex color', () => {
+    for (const value of Object.values(tint)) {
+      expect(value).toMatch(HEX);
+    }
+  });
+});
+
+describe('layout constants', () => {
+  it('a4Width is the mm string consumed by Tailwind', () => {
+    expect(layout.a4Width).toBe('210mm');
+  });
+
+  it('a4Height is 297mm', () => {
+    expect(layout.a4Height).toBe('297mm');
+  });
+
+  it('a4WidthPx matches 210mm at 96 DPI', () => {
+    expect(layout.a4WidthPx).toBe(794);
+  });
+});

--- a/src/app/lib/__tests__/queryClient.test.ts
+++ b/src/app/lib/__tests__/queryClient.test.ts
@@ -1,0 +1,51 @@
+// ============================================================
+// Axon -- Tests for queryClient.ts
+//
+// Centralised singleton TanStack Query client. We verify the
+// shape of its default options so accidental regressions don't
+// slip through (e.g. auto-refetch-on-focus getting re-enabled).
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+import { queryClient } from '@/app/lib/queryClient';
+import { QueryClient } from '@tanstack/react-query';
+
+describe('queryClient singleton', () => {
+  it('is a QueryClient instance', () => {
+    expect(queryClient).toBeInstanceOf(QueryClient);
+  });
+
+  it('exposes a getDefaultOptions() method', () => {
+    expect(typeof queryClient.getDefaultOptions).toBe('function');
+  });
+
+  it('sets queries.staleTime to 5 minutes', () => {
+    const opts = queryClient.getDefaultOptions();
+    expect(opts.queries?.staleTime).toBe(5 * 60 * 1000);
+  });
+
+  it('sets queries.gcTime to 10 minutes', () => {
+    const opts = queryClient.getDefaultOptions();
+    expect(opts.queries?.gcTime).toBe(10 * 60 * 1000);
+  });
+
+  it('retries once on failure', () => {
+    const opts = queryClient.getDefaultOptions();
+    expect(opts.queries?.retry).toBe(1);
+  });
+
+  it('refetchOnWindowFocus is false (avoid surprise refetches)', () => {
+    const opts = queryClient.getDefaultOptions();
+    expect(opts.queries?.refetchOnWindowFocus).toBe(false);
+  });
+
+  it('refetchOnReconnect is true', () => {
+    const opts = queryClient.getDefaultOptions();
+    expect(opts.queries?.refetchOnReconnect).toBe(true);
+  });
+
+  it('is a module-level singleton (same reference across imports)', async () => {
+    const again = await import('@/app/lib/queryClient');
+    expect(again.queryClient).toBe(queryClient);
+  });
+});

--- a/src/app/lib/__tests__/quiz-utils.test.ts
+++ b/src/app/lib/__tests__/quiz-utils.test.ts
@@ -1,0 +1,238 @@
+// ============================================================
+// quiz-utils.test.ts — Pure-logic tests for quiz utilities.
+//
+// Covers:
+//   - LETTERS constant (A–H)
+//   - normalizeText: lowercase, NFD accent strip, trim
+//   - checkAnswer: MCQ exact match, true/false normalized, open
+//     / fill_blank flexible substring match
+//
+// These are deterministic, no mocks.
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import { LETTERS, normalizeText, checkAnswer } from '@/app/lib/quiz-utils';
+import type { QuizQuestion } from '@/app/services/quizApi';
+
+// ── Fixture builders ─────────────────────────────────────
+
+/** Build a minimal QuizQuestion fixture for checkAnswer tests. */
+function makeQuestion(overrides: Partial<QuizQuestion> & { question_type: QuizQuestion['question_type']; correct_answer: string }): QuizQuestion {
+  return {
+    id: 'qq-test',
+    summary_id: 'sum-1',
+    keyword_id: 'kw-1',
+    block_id: null,
+    subtopic_id: null,
+    question: 'Sample?',
+    options: null,
+    explanation: null,
+    difficulty: 1,
+    source: 'manual',
+    is_active: true,
+    created_at: '2026-04-18T00:00:00.000Z',
+    updated_at: '2026-04-18T00:00:00.000Z',
+    ...overrides,
+  } as QuizQuestion;
+}
+
+// ══════════════════════════════════════════════════════════════
+// LETTERS
+// ══════════════════════════════════════════════════════════════
+
+describe('LETTERS', () => {
+  it('contains A through H in order', () => {
+    expect(LETTERS).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+  });
+
+  it('has length 8', () => {
+    expect(LETTERS.length).toBe(8);
+  });
+
+  it('is a readonly tuple (cannot be mutated via mutating method types)', () => {
+    // Compile-time check via `as const`; at runtime the array is still
+    // a normal array, but we can ensure the values are strings.
+    LETTERS.forEach((letter) => {
+      expect(typeof letter).toBe('string');
+      expect(letter.length).toBe(1);
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// normalizeText
+// ══════════════════════════════════════════════════════════════
+
+describe('normalizeText', () => {
+  it('lowercases ASCII input', () => {
+    expect(normalizeText('HELLO')).toBe('hello');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeText('  hello  ')).toBe('hello');
+  });
+
+  it('strips Spanish acute accents (NFD decomposition)', () => {
+    expect(normalizeText('árbol')).toBe('arbol');
+    expect(normalizeText('Árbol')).toBe('arbol');
+    expect(normalizeText('José')).toBe('jose');
+  });
+
+  it('strips Spanish tilde (ñ → n)', () => {
+    expect(normalizeText('mañana')).toBe('manana');
+  });
+
+  it('strips diaeresis (ü → u)', () => {
+    expect(normalizeText('pingüino')).toBe('pinguino');
+  });
+
+  it('preserves internal spaces', () => {
+    expect(normalizeText('Hola Mundo')).toBe('hola mundo');
+  });
+
+  it('returns empty string when input is whitespace only', () => {
+    expect(normalizeText('   ')).toBe('');
+  });
+
+  it('returns empty string when input is empty', () => {
+    expect(normalizeText('')).toBe('');
+  });
+
+  it('preserves numbers and punctuation', () => {
+    expect(normalizeText('42!')).toBe('42!');
+    expect(normalizeText('Hello, World.')).toBe('hello, world.');
+  });
+
+  it('is idempotent (f(f(x)) === f(x))', () => {
+    const samples = ['Hola', '  árbol  ', 'MAÑANA', 'José María'];
+    for (const s of samples) {
+      expect(normalizeText(normalizeText(s))).toBe(normalizeText(s));
+    }
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// checkAnswer — MCQ
+// ══════════════════════════════════════════════════════════════
+
+describe('checkAnswer — MCQ', () => {
+  const q = makeQuestion({ question_type: 'mcq', correct_answer: 'B' });
+
+  it('returns true when answer exactly matches correct option key', () => {
+    expect(checkAnswer(q, 'B')).toBe(true);
+  });
+
+  it('returns false when answer does not match correct option key', () => {
+    expect(checkAnswer(q, 'A')).toBe(false);
+    expect(checkAnswer(q, 'C')).toBe(false);
+  });
+
+  it('is case-sensitive for MCQ (exact match on option key)', () => {
+    expect(checkAnswer(q, 'b')).toBe(false);
+  });
+
+  it('returns false for whitespace-padded option (no normalization for MCQ)', () => {
+    expect(checkAnswer(q, ' B ')).toBe(false);
+  });
+
+  it('returns false when answer is empty', () => {
+    expect(checkAnswer(q, '')).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// checkAnswer — True/False
+// ══════════════════════════════════════════════════════════════
+
+describe('checkAnswer — true_false', () => {
+  const q = makeQuestion({ question_type: 'true_false', correct_answer: 'True' });
+
+  it('returns true on exact match', () => {
+    expect(checkAnswer(q, 'True')).toBe(true);
+  });
+
+  it('returns true on case-insensitive match', () => {
+    expect(checkAnswer(q, 'true')).toBe(true);
+    expect(checkAnswer(q, 'TRUE')).toBe(true);
+  });
+
+  it('returns true ignoring leading/trailing whitespace', () => {
+    expect(checkAnswer(q, '  true  ')).toBe(true);
+  });
+
+  it('returns false for the other value', () => {
+    expect(checkAnswer(q, 'false')).toBe(false);
+  });
+
+  it('handles Spanish "Verdadero" correct_answer with accent-insensitive compare', () => {
+    const qEs = makeQuestion({ question_type: 'true_false', correct_answer: 'Verdadero' });
+    expect(checkAnswer(qEs, 'verdadero')).toBe(true);
+    expect(checkAnswer(qEs, 'VERDADERO')).toBe(true);
+    expect(checkAnswer(qEs, 'Falso')).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// checkAnswer — fill_blank / open (flexible match)
+// ══════════════════════════════════════════════════════════════
+
+describe('checkAnswer — fill_blank', () => {
+  const q = makeQuestion({ question_type: 'fill_blank', correct_answer: 'mitocondria' });
+
+  it('returns true on exact normalized match', () => {
+    expect(checkAnswer(q, 'mitocondria')).toBe(true);
+  });
+
+  it('returns true on case-insensitive match', () => {
+    expect(checkAnswer(q, 'Mitocondria')).toBe(true);
+  });
+
+  it('returns true on accent-insensitive match', () => {
+    const qAcc = makeQuestion({ question_type: 'fill_blank', correct_answer: 'árbol' });
+    expect(checkAnswer(qAcc, 'arbol')).toBe(true);
+  });
+
+  it('returns true when expected is a substring of the answer', () => {
+    // "la mitocondria" contains "mitocondria"
+    expect(checkAnswer(q, 'la mitocondria')).toBe(true);
+  });
+
+  it('returns true when the answer is a substring of expected', () => {
+    const qLong = makeQuestion({
+      question_type: 'fill_blank',
+      correct_answer: 'la mitocondria de la celula',
+    });
+    // "mitocondria" is a substring of the expected
+    expect(checkAnswer(qLong, 'mitocondria')).toBe(true);
+  });
+
+  it('returns false on empty answer', () => {
+    expect(checkAnswer(q, '')).toBe(false);
+    expect(checkAnswer(q, '   ')).toBe(false);
+  });
+
+  it('returns false for unrelated answer', () => {
+    expect(checkAnswer(q, 'nucleo')).toBe(false);
+  });
+});
+
+describe('checkAnswer — open', () => {
+  const q = makeQuestion({ question_type: 'open', correct_answer: 'Fotosintesis' });
+
+  it('returns true on exact case-insensitive + accent-insensitive match', () => {
+    expect(checkAnswer(q, 'fotosíntesis')).toBe(true);
+  });
+
+  it('returns true when the expected short answer is embedded in a longer response', () => {
+    expect(checkAnswer(q, 'La fotosintesis es un proceso')).toBe(true);
+  });
+
+  it('returns false when neither direction contains the other', () => {
+    expect(checkAnswer(q, 'respiracion celular')).toBe(false);
+  });
+
+  it('returns false on empty answer', () => {
+    expect(checkAnswer(q, '')).toBe(false);
+  });
+});

--- a/src/app/lib/__tests__/session-stats.test.ts
+++ b/src/app/lib/__tests__/session-stats.test.ts
@@ -1,0 +1,146 @@
+// ============================================================
+// Axon -- Tests for session-stats.ts
+//
+// Pure functions: countCorrect, computeMasteryPct, computeDeltaStats
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  countCorrect,
+  computeMasteryPct,
+  computeDeltaStats,
+} from '@/app/lib/session-stats';
+
+// ================================================================
+// countCorrect
+// ================================================================
+
+describe('countCorrect', () => {
+  it('returns 0 for empty array', () => {
+    expect(countCorrect([])).toBe(0);
+  });
+
+  it('counts ratings >= 3 as correct', () => {
+    expect(countCorrect([1, 2, 3, 4, 5])).toBe(3);
+  });
+
+  it('returns 0 when all ratings are below 3', () => {
+    expect(countCorrect([0, 1, 2])).toBe(0);
+  });
+
+  it('returns total length when all ratings >= 3', () => {
+    expect(countCorrect([3, 4, 5, 3, 4])).toBe(5);
+  });
+
+  it('treats exactly 3 as correct (inclusive)', () => {
+    expect(countCorrect([3])).toBe(1);
+    expect(countCorrect([2])).toBe(0);
+  });
+});
+
+// ================================================================
+// computeMasteryPct
+// ================================================================
+
+describe('computeMasteryPct', () => {
+  it('returns 0 when summary is null and stats are empty', () => {
+    expect(computeMasteryPct(null, [])).toBe(0);
+  });
+
+  it('uses topicSummary when it has keywords', () => {
+    const summary = { keywordsTotal: 10, keywordsMastered: 5, overallMastery: 0.73 } as any;
+    expect(computeMasteryPct(summary, [])).toBe(73);
+  });
+
+  it('rounds topic summary mastery to nearest integer', () => {
+    const summary = { keywordsTotal: 5, keywordsMastered: 2, overallMastery: 0.555 } as any;
+    expect(computeMasteryPct(summary, [])).toBe(56);
+  });
+
+  it('falls back to stats average when summary has zero keywords', () => {
+    const summary = { keywordsTotal: 0, keywordsMastered: 0, overallMastery: 0 } as any;
+    // average 4 => 4/5 = 0.8 => 80%
+    expect(computeMasteryPct(summary, [4, 4, 4, 4])).toBe(80);
+  });
+
+  it('falls back to stats average when summary is null', () => {
+    // avg = 3 -> 60%
+    expect(computeMasteryPct(null, [3, 3, 3])).toBe(60);
+  });
+
+  it('handles max rating correctly', () => {
+    expect(computeMasteryPct(null, [5, 5, 5, 5])).toBe(100);
+  });
+
+  it('handles mixed ratings correctly', () => {
+    // [1,2,3,4,5] avg = 3 -> 60%
+    expect(computeMasteryPct(null, [1, 2, 3, 4, 5])).toBe(60);
+  });
+});
+
+// ================================================================
+// computeDeltaStats
+// ================================================================
+
+describe('computeDeltaStats', () => {
+  it('returns null for empty array', () => {
+    expect(computeDeltaStats([])).toBeNull();
+  });
+
+  it('counts improved when after > before', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.2, after: 0.4, grade: 4 },
+      { cardId: 'b', before: 0.5, after: 0.6, grade: 3 },
+    ]);
+    expect(result).toEqual({ improved: 2, declined: 0, newlyMastered: 0, total: 2 });
+  });
+
+  it('counts declined when after < before', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.8, after: 0.5, grade: 1 },
+    ]);
+    expect(result).toEqual({ improved: 0, declined: 1, newlyMastered: 0, total: 1 });
+  });
+
+  it('does not count equal before/after as improved or declined', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.5, after: 0.5, grade: 3 },
+    ]);
+    expect(result).toEqual({ improved: 0, declined: 0, newlyMastered: 0, total: 1 });
+  });
+
+  it('counts newlyMastered when crossing 0.75 threshold', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.5, after: 0.8, grade: 5 },
+      { cardId: 'b', before: 0.74, after: 0.75, grade: 4 },
+    ]);
+    expect(result?.newlyMastered).toBe(2);
+  });
+
+  it('does not count as newlyMastered when already above 0.75 before', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.8, after: 0.9, grade: 5 },
+    ]);
+    expect(result?.newlyMastered).toBe(0);
+    expect(result?.improved).toBe(1);
+  });
+
+  it('does not count as newlyMastered when after stays below 0.75', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.5, after: 0.7, grade: 4 },
+    ]);
+    expect(result?.newlyMastered).toBe(0);
+    expect(result?.improved).toBe(1);
+  });
+
+  it('aggregates mixed deltas correctly', () => {
+    const result = computeDeltaStats([
+      { cardId: 'a', before: 0.2, after: 0.8, grade: 5 }, // improved + newlyMastered
+      { cardId: 'b', before: 0.9, after: 0.3, grade: 1 }, // declined
+      { cardId: 'c', before: 0.5, after: 0.5, grade: 3 }, // nothing
+      { cardId: 'd', before: 0.4, after: 0.6, grade: 4 }, // improved only
+    ]);
+    expect(result).toEqual({ improved: 2, declined: 1, newlyMastered: 1, total: 4 });
+  });
+});

--- a/src/app/lib/__tests__/sessionAnalytics.test.ts
+++ b/src/app/lib/__tests__/sessionAnalytics.test.ts
@@ -1,0 +1,273 @@
+// ============================================================
+// Axon -- Tests for sessionAnalytics.ts
+//
+// postSessionAnalytics() reads current stats/daily-activities
+// then writes back accumulated + session values.
+// Module-level promise chain serializes concurrent calls.
+//
+// Approach: mock apiCall and inspect sequence of GET/POST calls
+// and the bodies posted.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock apiCall BEFORE importing the module under test.
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+}));
+
+import { postSessionAnalytics } from '@/app/lib/sessionAnalytics';
+
+// Helper: parse the body of a POST call
+function bodyOf(call: unknown[]): Record<string, unknown> {
+  const opts = call[1] as { body: string };
+  return JSON.parse(opts.body);
+}
+
+// Categorize mock calls by URL fragment + method
+function findCalls(urlFragment: string, method?: string) {
+  return mockApiCall.mock.calls.filter((c) => {
+    const url = c[0] as string;
+    if (!url.includes(urlFragment)) return false;
+    const opts = c[1] as { method?: string } | undefined;
+    const m = opts?.method ?? 'GET';
+    return method ? m === method : true;
+  });
+}
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ================================================================
+
+describe('postSessionAnalytics — happy path (no prior data)', () => {
+  it('reads student-stats and daily-activities, then posts accumulated values', async () => {
+    // GETs return nothing (first-time user)
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return null;
+        if (url.startsWith('/daily-activities?')) return [];
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 10, correctReviews: 8, durationSeconds: 300 });
+
+    const statsGets = findCalls('/student-stats', 'GET');
+    const statsPosts = findCalls('/student-stats', 'POST');
+    const dailyGets = findCalls('/daily-activities', 'GET');
+    const dailyPosts = findCalls('/daily-activities', 'POST');
+
+    expect(statsGets.length).toBe(1);
+    expect(statsPosts.length).toBe(1);
+    expect(dailyGets.length).toBe(1);
+    expect(dailyPosts.length).toBe(1);
+
+    // student-stats POST body reflects session values
+    const statsBody = bodyOf(statsPosts[0]);
+    expect(statsBody.total_reviews).toBe(10);
+    expect(statsBody.total_time_seconds).toBe(300);
+    expect(statsBody.total_sessions).toBe(1);
+    expect(statsBody.current_streak).toBe(1);
+    expect(statsBody.longest_streak).toBe(1);
+    expect(typeof statsBody.last_study_date).toBe('string');
+
+    // daily-activities POST body
+    const dailyBody = bodyOf(dailyPosts[0]);
+    expect(dailyBody.reviews_count).toBe(10);
+    expect(dailyBody.correct_count).toBe(8);
+    expect(dailyBody.time_spent_seconds).toBe(300);
+    expect(dailyBody.sessions_count).toBe(1);
+    expect(typeof dailyBody.activity_date).toBe('string');
+  });
+});
+
+describe('postSessionAnalytics — increment existing values', () => {
+  it('adds session values on top of accumulated totals', async () => {
+    const existingStats = {
+      total_reviews: 100,
+      total_time_seconds: 3600,
+      total_sessions: 5,
+      current_streak: 3,
+      longest_streak: 7,
+      last_study_date: '1999-01-01', // far in the past -> streak resets to 1
+    };
+    const existingDaily = {
+      reviews_count: 4,
+      correct_count: 3,
+      time_spent_seconds: 60,
+      sessions_count: 1,
+    };
+
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return existingStats;
+        if (url.startsWith('/daily-activities?')) return [existingDaily];
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 10, correctReviews: 7, durationSeconds: 200 });
+
+    const statsPosts = findCalls('/student-stats', 'POST');
+    const dailyPosts = findCalls('/daily-activities', 'POST');
+
+    const statsBody = bodyOf(statsPosts[0]);
+    expect(statsBody.total_reviews).toBe(110);
+    expect(statsBody.total_time_seconds).toBe(3800);
+    expect(statsBody.total_sessions).toBe(6);
+
+    const dailyBody = bodyOf(dailyPosts[0]);
+    expect(dailyBody.reviews_count).toBe(14);
+    expect(dailyBody.correct_count).toBe(10);
+    expect(dailyBody.time_spent_seconds).toBe(260);
+    expect(dailyBody.sessions_count).toBe(2);
+  });
+
+  it('keeps streak stable when already studied today (no double increment)', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const existingStats = {
+      total_reviews: 50,
+      total_time_seconds: 1000,
+      total_sessions: 2,
+      current_streak: 5,
+      longest_streak: 10,
+      last_study_date: today,
+    };
+
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return existingStats;
+        if (url.startsWith('/daily-activities?')) return [];
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 1, correctReviews: 1, durationSeconds: 10 });
+
+    const statsPosts = findCalls('/student-stats', 'POST');
+    const statsBody = bodyOf(statsPosts[0]);
+    expect(statsBody.current_streak).toBe(5);
+    expect(statsBody.longest_streak).toBe(10);
+  });
+
+  it('increments streak when last study was yesterday', async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+    const existingStats = {
+      total_reviews: 0,
+      total_time_seconds: 0,
+      total_sessions: 0,
+      current_streak: 4,
+      longest_streak: 4,
+      last_study_date: yesterdayStr,
+    };
+
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return existingStats;
+        if (url.startsWith('/daily-activities?')) return [];
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 1, correctReviews: 1, durationSeconds: 10 });
+
+    const statsPosts = findCalls('/student-stats', 'POST');
+    const statsBody = bodyOf(statsPosts[0]);
+    expect(statsBody.current_streak).toBe(5);
+    expect(statsBody.longest_streak).toBe(5);
+  });
+});
+
+describe('postSessionAnalytics — error resilience', () => {
+  it('does not throw when student-stats GET fails', async () => {
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (url === '/student-stats' && (!opts || opts.method === 'GET' || !opts.method)) {
+        throw new Error('server down');
+      }
+      if (url.startsWith('/daily-activities?')) return [];
+      return null;
+    });
+
+    await expect(
+      postSessionAnalytics({ totalReviews: 1, correctReviews: 1, durationSeconds: 5 })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not throw when POSTs fail', async () => {
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (opts?.method === 'POST') throw new Error('write failed');
+      if (url === '/student-stats') return null;
+      if (url.startsWith('/daily-activities?')) return [];
+      return null;
+    });
+
+    await expect(
+      postSessionAnalytics({ totalReviews: 3, correctReviews: 2, durationSeconds: 30 })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('postSessionAnalytics — daily-activities GET response shape handling', () => {
+  it('handles array response with first element', async () => {
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return null;
+        if (url.startsWith('/daily-activities?')) {
+          return [{ reviews_count: 5, correct_count: 4, time_spent_seconds: 100, sessions_count: 1 }];
+        }
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 2, correctReviews: 1, durationSeconds: 20 });
+
+    const dailyPosts = findCalls('/daily-activities', 'POST');
+    const dailyBody = bodyOf(dailyPosts[0]);
+    expect(dailyBody.reviews_count).toBe(7);
+    expect(dailyBody.correct_count).toBe(5);
+    expect(dailyBody.time_spent_seconds).toBe(120);
+    expect(dailyBody.sessions_count).toBe(2);
+  });
+
+  it('handles object (non-array) response from daily-activities GET', async () => {
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return null;
+        if (url.startsWith('/daily-activities?')) {
+          return { reviews_count: 3, correct_count: 2, time_spent_seconds: 50, sessions_count: 1 };
+        }
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 2, correctReviews: 1, durationSeconds: 20 });
+
+    const dailyPosts = findCalls('/daily-activities', 'POST');
+    const dailyBody = bodyOf(dailyPosts[0]);
+    expect(dailyBody.reviews_count).toBe(5);
+    expect(dailyBody.correct_count).toBe(3);
+  });
+
+  it('handles empty array response (new day)', async () => {
+    mockApiCall.mockImplementation(async (url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET' || !opts.method) {
+        if (url === '/student-stats') return null;
+        if (url.startsWith('/daily-activities?')) return [];
+      }
+      return null;
+    });
+
+    await postSessionAnalytics({ totalReviews: 3, correctReviews: 2, durationSeconds: 30 });
+
+    const dailyPosts = findCalls('/daily-activities', 'POST');
+    const dailyBody = bodyOf(dailyPosts[0]);
+    expect(dailyBody.reviews_count).toBe(3);
+    expect(dailyBody.sessions_count).toBe(1);
+  });
+});

--- a/src/app/lib/__tests__/studyQueueApi.test.ts
+++ b/src/app/lib/__tests__/studyQueueApi.test.ts
@@ -1,0 +1,139 @@
+// ============================================================
+// Axon -- Tests for studyQueueApi.ts (GET /study-queue wrapper)
+//
+// Coverage: query-string builder correctness (course_id, limit,
+//           include_future), no-params case, response pass-through.
+//
+// Mocks: @/app/lib/api apiCall
+//
+// NOTE (memory: URLSearchParams omits falsy values by design).
+// `limit: 0` and `include_future: false` are intentionally NOT emitted
+// because the implementation uses `if (params.limit)` / `if (include_future)`.
+//
+// Run: npx vitest run src/app/lib/__tests__/studyQueueApi.test.ts
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import { getStudyQueue, type StudyQueueResponse } from '@/app/lib/studyQueueApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+function emptyResponse(): StudyQueueResponse {
+  return {
+    queue: [],
+    meta: {
+      total_due: 0,
+      total_new: 0,
+      total_in_queue: 0,
+      returned: 0,
+      limit: 20,
+      include_future: false,
+      course_id: null,
+      generated_at: '2026-04-18T00:00:00Z',
+      algorithm: 'fsrs',
+      weights: {
+        overdueWeight: 0.4,
+        masteryWeight: 0.3,
+        fragilityWeight: 0.2,
+        noveltyWeight: 0.1,
+        graceDays: 1,
+      },
+    },
+  };
+}
+
+describe('getStudyQueue', () => {
+  beforeEach(() => {
+    mockApiCall.mockReset();
+  });
+
+  it('calls /study-queue with no query string when no params provided', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue();
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue');
+  });
+
+  it('calls /study-queue with no query string when params is empty object', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({});
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue');
+  });
+
+  it('appends course_id when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ course_id: 'course-123' });
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue?course_id=course-123');
+  });
+
+  it('appends limit when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ limit: 50 });
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue?limit=50');
+  });
+
+  it('appends include_future=1 when true', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ include_future: true });
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue?include_future=1');
+  });
+
+  it('does NOT append include_future when false (truthy-check behaviour)', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ include_future: false });
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue');
+  });
+
+  it('does NOT append limit when zero (falsy-check behaviour)', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ limit: 0 });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).not.toContain('limit=');
+  });
+
+  it('combines all three params in canonical order', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({
+      course_id: 'c1',
+      limit: 20,
+      include_future: true,
+    });
+    // URLSearchParams preserves insertion order: course_id, limit, include_future
+    expect(mockApiCall).toHaveBeenCalledWith(
+      '/study-queue?course_id=c1&limit=20&include_future=1',
+    );
+  });
+
+  it('url-encodes special characters in course_id', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ course_id: 'course id/1+2' });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    // URLSearchParams encodes ' ' as '+' (form encoding)
+    expect(url).toContain('course_id=course+id%2F1%2B2');
+  });
+
+  it('returns the apiCall result unchanged', async () => {
+    const resp = emptyResponse();
+    resp.meta.returned = 5;
+    mockApiCall.mockResolvedValueOnce(resp);
+    const out = await getStudyQueue({ course_id: 'c1' });
+    expect(out).toBe(resp);
+    expect(out.meta.returned).toBe(5);
+  });
+
+  it('propagates apiCall rejection', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('500 Internal'));
+    await expect(getStudyQueue({ course_id: 'c1' })).rejects.toThrow('500 Internal');
+  });
+
+  it('ignores empty-string course_id (falsy)', async () => {
+    mockApiCall.mockResolvedValueOnce(emptyResponse());
+    await getStudyQueue({ course_id: '' });
+    expect(mockApiCall).toHaveBeenCalledWith('/study-queue');
+  });
+});

--- a/src/app/lib/__tests__/xp-constants.test.ts
+++ b/src/app/lib/__tests__/xp-constants.test.ts
@@ -1,0 +1,185 @@
+// ============================================================
+// Axon -- Tests for xp-constants.ts
+//
+// Client-side mirror of backend xp-engine.ts.
+// Pure functions + constants — no mocks required.
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+import {
+  XP_TABLE,
+  LEVEL_THRESHOLDS,
+  DAILY_CAP,
+  LEVEL_NAMES,
+  AVG_READING_WPM,
+  MAX_TIME_BASED_PROGRESS,
+  READER_PAGE_KEY_PREFIX,
+  calculateLevel,
+  xpForNextLevel,
+  xpForCurrentLevel,
+  estimateReviewXP,
+} from '@/app/lib/xp-constants';
+
+describe('XP_TABLE constants', () => {
+  it('exposes review_flashcard = 5', () => {
+    expect(XP_TABLE.review_flashcard).toBe(5);
+  });
+
+  it('exposes review_correct = 10', () => {
+    expect(XP_TABLE.review_correct).toBe(10);
+  });
+
+  it('exposes quiz_correct = 15', () => {
+    expect(XP_TABLE.quiz_correct).toBe(15);
+  });
+
+  it('exposes complete_plan = 100', () => {
+    expect(XP_TABLE.complete_plan).toBe(100);
+  });
+
+  it('exposes complete_session = 25', () => {
+    expect(XP_TABLE.complete_session).toBe(25);
+  });
+});
+
+describe('constants', () => {
+  it('DAILY_CAP is 500', () => {
+    expect(DAILY_CAP).toBe(500);
+  });
+
+  it('AVG_READING_WPM is 200', () => {
+    expect(AVG_READING_WPM).toBe(200);
+  });
+
+  it('MAX_TIME_BASED_PROGRESS caps at 0.9', () => {
+    expect(MAX_TIME_BASED_PROGRESS).toBe(0.9);
+  });
+
+  it('READER_PAGE_KEY_PREFIX starts with axon-', () => {
+    expect(READER_PAGE_KEY_PREFIX).toMatch(/^axon-/);
+  });
+});
+
+describe('LEVEL_THRESHOLDS', () => {
+  it('is sorted descending by threshold (largest first)', () => {
+    for (let i = 1; i < LEVEL_THRESHOLDS.length; i += 1) {
+      expect(LEVEL_THRESHOLDS[i][0]).toBeLessThan(LEVEL_THRESHOLDS[i - 1][0]);
+    }
+  });
+
+  it('covers levels 2-12', () => {
+    const levels = LEVEL_THRESHOLDS.map(([, lvl]) => lvl).sort((a, b) => a - b);
+    expect(levels).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+});
+
+describe('calculateLevel', () => {
+  it('returns 1 for 0 XP', () => {
+    expect(calculateLevel(0)).toBe(1);
+  });
+
+  it('returns 1 for XP below 100', () => {
+    expect(calculateLevel(99)).toBe(1);
+  });
+
+  it('returns 2 at exactly 100 XP', () => {
+    expect(calculateLevel(100)).toBe(2);
+  });
+
+  it('returns 3 at 300 XP', () => {
+    expect(calculateLevel(300)).toBe(3);
+  });
+
+  it('returns 5 at 1000 XP', () => {
+    expect(calculateLevel(1000)).toBe(5);
+  });
+
+  it('returns 12 at 10000+ XP (max level)', () => {
+    expect(calculateLevel(10000)).toBe(12);
+    expect(calculateLevel(999999)).toBe(12);
+  });
+
+  it('returns lower level when just below a threshold', () => {
+    expect(calculateLevel(9999)).toBe(11);
+    expect(calculateLevel(7499)).toBe(10);
+  });
+});
+
+describe('xpForNextLevel', () => {
+  it('returns 100 for level 1 (next is level 2)', () => {
+    expect(xpForNextLevel(1)).toBe(100);
+  });
+
+  it('returns 300 for level 2 (next is level 3)', () => {
+    expect(xpForNextLevel(2)).toBe(300);
+  });
+
+  it('returns 10000 for level 11 (next is level 12)', () => {
+    expect(xpForNextLevel(11)).toBe(10000);
+  });
+
+  it('returns the max threshold when already at top (level 12)', () => {
+    expect(xpForNextLevel(12)).toBe(10000);
+  });
+});
+
+describe('xpForCurrentLevel', () => {
+  it('returns 0 for level 1', () => {
+    expect(xpForCurrentLevel(1)).toBe(0);
+  });
+
+  it('returns 100 for level 2', () => {
+    expect(xpForCurrentLevel(2)).toBe(100);
+  });
+
+  it('returns 10000 for level 12', () => {
+    expect(xpForCurrentLevel(12)).toBe(10000);
+  });
+
+  it('returns 0 for an unknown level', () => {
+    expect(xpForCurrentLevel(99)).toBe(0);
+  });
+});
+
+describe('estimateReviewXP', () => {
+  it('returns base 5 XP for grade 0 (fail)', () => {
+    expect(estimateReviewXP(0)).toBe(5);
+  });
+
+  it('returns base 5 XP for grade 1', () => {
+    expect(estimateReviewXP(1)).toBe(5);
+  });
+
+  it('returns base 5 XP for grade 2', () => {
+    expect(estimateReviewXP(2)).toBe(5);
+  });
+
+  it('returns 5+10=15 XP for grade 3', () => {
+    expect(estimateReviewXP(3)).toBe(15);
+  });
+
+  it('returns 15 XP for grade 4', () => {
+    expect(estimateReviewXP(4)).toBe(15);
+  });
+
+  it('returns 15 XP for grade 5', () => {
+    expect(estimateReviewXP(5)).toBe(15);
+  });
+});
+
+describe('LEVEL_NAMES', () => {
+  it('has entries for levels 1 through 12', () => {
+    for (let l = 1; l <= 12; l += 1) {
+      expect(typeof LEVEL_NAMES[l]).toBe('string');
+      expect(LEVEL_NAMES[l].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('level 1 is "Novato"', () => {
+    expect(LEVEL_NAMES[1]).toBe('Novato');
+  });
+
+  it('level 12 is "Iluminado"', () => {
+    expect(LEVEL_NAMES[12]).toBe('Iluminado');
+  });
+});

--- a/src/app/services/__tests__/adaptiveGenerationApi.test.ts
+++ b/src/app/services/__tests__/adaptiveGenerationApi.test.ts
@@ -1,0 +1,360 @@
+/**
+ * adaptiveGenerationApi.test.ts — Tests for adaptive AI flashcard batch generation (Fase 2)
+ *
+ * Coverage:
+ *   - generateAdaptiveBatch (count=0, happy path, failures, aborted signal,
+ *     progress callback, summaryIds rotation, stats computation)
+ *   - mapToFlashcard / mapBatchToFlashcards (field mapping, image urls)
+ *   - getReasonText (all primary_reason values, p_know→pct rounding)
+ *
+ * NOTE (MASTERY-SYSTEMS.md): getReasonText's `p_know` belongs to Sistema A
+ * (rating INPUT / BKT target score). We test it as a pure formatter —
+ * no threshold classification lives here.
+ *
+ * Mocks: @/app/services/aiService (generateSmart)
+ *
+ * Run: npx vitest run src/app/services/__tests__/adaptiveGenerationApi.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (must be declared before import of SUT) ─────────
+
+const mockGenerateSmart = vi.fn();
+
+vi.mock('@/app/services/aiService', () => ({
+  generateSmart: (...args: unknown[]) => mockGenerateSmart(...args),
+}));
+
+// ── SUT ───────────────────────────────────────────────────
+
+import {
+  generateAdaptiveBatch,
+  mapToFlashcard,
+  mapBatchToFlashcards,
+  getReasonText,
+  type AdaptiveFlashcard,
+  type AdaptiveGenerationResult,
+} from '../adaptiveGenerationApi';
+
+// ── Helpers ───────────────────────────────────────────────
+
+function makeAdaptiveCard(id: string, overrides: Partial<AdaptiveFlashcard> = {}): AdaptiveFlashcard {
+  return {
+    id,
+    summary_id: `sum-${id}`,
+    keyword_id: `kw-${id}`,
+    subtopic_id: `sub-${id}`,
+    front: `Q-${id}`,
+    back: `A-${id}`,
+    source: 'ai',
+    created_by: 'user-1',
+    created_at: '2026-04-18T10:00:00Z',
+    is_active: true,
+    deleted_at: null,
+    front_image_url: null,
+    back_image_url: null,
+    _smart: {
+      target_keyword: `kw-${id}`,
+      target_summary: `sum-${id}`,
+      target_subtopic: `sub-${id}`,
+      p_know: 0.35,
+      need_score: 0.7,
+      primary_reason: 'low_mastery',
+    },
+    _meta: {
+      model: 'gemini-2.0-flash',
+      tokens: { input: 100, output: 50 },
+    },
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe('adaptiveGenerationApi', () => {
+  beforeEach(() => {
+    // mockReset drains mockResolvedValueOnce queues — clearAllMocks only clears call history.
+    mockGenerateSmart.mockReset();
+  });
+
+  // ── generateAdaptiveBatch ──
+
+  describe('generateAdaptiveBatch', () => {
+    it('returns empty batch immediately when count=0 (no calls made)', async () => {
+      const result = await generateAdaptiveBatch({ count: 0 });
+      expect(mockGenerateSmart).not.toHaveBeenCalled();
+      expect(result.cards).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.stats).toEqual({
+        requested: 0,
+        generated: 0,
+        failed: 0,
+        uniqueKeywords: 0,
+        avgPKnow: 0,
+        totalTokens: 0,
+        elapsedMs: 0,
+      });
+    });
+
+    it('returns empty batch for negative count without calling generateSmart', async () => {
+      const result = await generateAdaptiveBatch({ count: -3 });
+      expect(mockGenerateSmart).not.toHaveBeenCalled();
+      expect(result.cards).toHaveLength(0);
+    });
+
+    it('generates the requested number of cards (happy path)', async () => {
+      mockGenerateSmart.mockImplementation(async () => makeAdaptiveCard(`c-${Math.random()}`));
+      const result = await generateAdaptiveBatch({ count: 3 });
+      expect(mockGenerateSmart).toHaveBeenCalledTimes(3);
+      expect(result.cards).toHaveLength(3);
+      expect(result.errors).toHaveLength(0);
+      expect(result.stats.requested).toBe(3);
+      expect(result.stats.generated).toBe(3);
+      expect(result.stats.failed).toBe(0);
+    });
+
+    it('forwards institutionId and related flag to generateSmart', async () => {
+      mockGenerateSmart.mockResolvedValue(makeAdaptiveCard('c-1'));
+      await generateAdaptiveBatch({ count: 1, institutionId: 'inst-1', related: false });
+      expect(mockGenerateSmart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'flashcard',
+          institutionId: 'inst-1',
+          related: false,
+        })
+      );
+    });
+
+    it('defaults related to true when not provided', async () => {
+      mockGenerateSmart.mockResolvedValue(makeAdaptiveCard('c-1'));
+      await generateAdaptiveBatch({ count: 1 });
+      const args = mockGenerateSmart.mock.calls[0][0];
+      expect(args.related).toBe(true);
+    });
+
+    it('rotates through summaryIds using index % length', async () => {
+      const seen: (string | undefined)[] = [];
+      mockGenerateSmart.mockImplementation(async (args: any) => {
+        seen.push(args.summaryId);
+        return makeAdaptiveCard(`c-${seen.length}`);
+      });
+      await generateAdaptiveBatch({ count: 5, summaryIds: ['A', 'B'] });
+      // parallelWithLimit runs tasks in order by `nextIndex`, and since
+      // generateSmart resolves synchronously here, the order equals 0..4.
+      expect(seen).toEqual(['A', 'B', 'A', 'B', 'A']);
+    });
+
+    it('uses summaryId=undefined when summaryIds is empty array', async () => {
+      mockGenerateSmart.mockResolvedValue(makeAdaptiveCard('c-1'));
+      await generateAdaptiveBatch({ count: 1, summaryIds: [] });
+      const args = mockGenerateSmart.mock.calls[0][0];
+      expect(args.summaryId).toBeUndefined();
+    });
+
+    it('captures errors from generateSmart and continues others', async () => {
+      mockGenerateSmart
+        .mockResolvedValueOnce(makeAdaptiveCard('c-1'))
+        .mockRejectedValueOnce(new Error('429 rate limit'))
+        .mockResolvedValueOnce(makeAdaptiveCard('c-3'));
+      const result = await generateAdaptiveBatch({ count: 3 });
+      expect(result.cards).toHaveLength(2);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].index).toBe(1);
+      expect(result.errors[0].message).toBe('429 rate limit');
+      expect(result.errors[0].error).toBeInstanceOf(Error);
+      expect(result.stats.generated).toBe(2);
+      expect(result.stats.failed).toBe(1);
+    });
+
+    it('rejects response missing id/front/back as invalid (captured as error)', async () => {
+      mockGenerateSmart.mockResolvedValueOnce({ id: 'x', front: '' });
+      const result = await generateAdaptiveBatch({ count: 1 });
+      expect(result.cards).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toBe('Invalid generate-smart response');
+    });
+
+    it('handles non-Error thrown values by stringifying (fallback message)', async () => {
+      mockGenerateSmart.mockRejectedValueOnce('boom-as-string');
+      const result = await generateAdaptiveBatch({ count: 1 });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toBe('boom-as-string');
+    });
+
+    it('invokes onProgress after each completion with cumulative counters', async () => {
+      mockGenerateSmart
+        .mockResolvedValueOnce(makeAdaptiveCard('c-1'))
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce(makeAdaptiveCard('c-3'));
+
+      const progressCalls: Array<{ completed: number; generated: number; failed: number }> = [];
+      await generateAdaptiveBatch({
+        count: 3,
+        onProgress: (p) => progressCalls.push({
+          completed: p.completed,
+          generated: p.generated,
+          failed: p.failed,
+        }),
+      });
+
+      // 3 callbacks (one per completion), last should be terminal
+      expect(progressCalls.length).toBe(3);
+      const last = progressCalls[progressCalls.length - 1];
+      expect(last.completed).toBe(3);
+      expect(last.generated).toBe(2);
+      expect(last.failed).toBe(1);
+    });
+
+    it('respects already-aborted signal: skips all generateSmart calls', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const result = await generateAdaptiveBatch({ count: 4, signal: controller.signal });
+      expect(mockGenerateSmart).not.toHaveBeenCalled();
+      expect(result.cards).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+      expect(result.stats.generated).toBe(0);
+    });
+
+    it('computes stats.uniqueKeywords correctly when multiple cards share a keyword', async () => {
+      mockGenerateSmart
+        .mockResolvedValueOnce(makeAdaptiveCard('c-1', { keyword_id: 'kwA' }))
+        .mockResolvedValueOnce(makeAdaptiveCard('c-2', { keyword_id: 'kwA' }))
+        .mockResolvedValueOnce(makeAdaptiveCard('c-3', { keyword_id: 'kwB' }));
+      const result = await generateAdaptiveBatch({ count: 3 });
+      expect(result.stats.uniqueKeywords).toBe(2);
+    });
+
+    it('computes avgPKnow as mean of _smart.p_know across generated cards', async () => {
+      const c1 = makeAdaptiveCard('1', { _smart: { ...makeAdaptiveCard('1')._smart, p_know: 0.2 } });
+      const c2 = makeAdaptiveCard('2', { _smart: { ...makeAdaptiveCard('2')._smart, p_know: 0.8 } });
+      mockGenerateSmart.mockResolvedValueOnce(c1).mockResolvedValueOnce(c2);
+      const result = await generateAdaptiveBatch({ count: 2 });
+      expect(result.stats.avgPKnow).toBeCloseTo(0.5, 5);
+    });
+
+    it('computes totalTokens from object {input,output} and numeric tokens shapes', async () => {
+      const c1 = makeAdaptiveCard('1', { _meta: { model: 'm', tokens: { input: 10, output: 20 } } });
+      const c2 = makeAdaptiveCard('2', { _meta: { model: 'm', tokens: 50 as unknown as number } });
+      mockGenerateSmart.mockResolvedValueOnce(c1).mockResolvedValueOnce(c2);
+      const result = await generateAdaptiveBatch({ count: 2 });
+      expect(result.stats.totalTokens).toBe(30 + 50);
+    });
+
+    it('handles missing/partial token shapes as 0 contribution', async () => {
+      const c1 = makeAdaptiveCard('1', { _meta: { model: 'm', tokens: {} as unknown as { input: number; output: number } } });
+      mockGenerateSmart.mockResolvedValueOnce(c1);
+      const result = await generateAdaptiveBatch({ count: 1 });
+      expect(result.stats.totalTokens).toBe(0);
+    });
+  });
+
+  // ── mapToFlashcard ──
+
+  describe('mapToFlashcard', () => {
+    it('maps core fields and sets mastery=0 / fsrs_state=new', () => {
+      const card = makeAdaptiveCard('c-1');
+      const fc = mapToFlashcard(card);
+      expect(fc.id).toBe('c-1');
+      expect(fc.front).toBe('Q-c-1');
+      expect(fc.back).toBe('A-c-1');
+      expect(fc.question).toBe('Q-c-1');
+      expect(fc.answer).toBe('A-c-1');
+      expect(fc.mastery).toBe(0);
+      expect(fc.summary_id).toBe('sum-c-1');
+      expect(fc.keyword_id).toBe('kw-c-1');
+      expect(fc.subtopic_id).toBe('sub-c-1');
+      expect(fc.source).toBe('ai');
+      expect(fc.fsrs_state).toBe('new');
+    });
+
+    it('maps image URLs when present', () => {
+      const card = makeAdaptiveCard('c-1', {
+        front_image_url: 'https://img.test/f.png',
+        back_image_url: 'https://img.test/b.png',
+      });
+      const fc = mapToFlashcard(card);
+      expect(fc.frontImageUrl).toBe('https://img.test/f.png');
+      expect(fc.backImageUrl).toBe('https://img.test/b.png');
+    });
+
+    it('coerces undefined image URLs to null', () => {
+      const card = makeAdaptiveCard('c-1');
+      delete (card as any).front_image_url;
+      delete (card as any).back_image_url;
+      const fc = mapToFlashcard(card);
+      expect(fc.frontImageUrl).toBeNull();
+      expect(fc.backImageUrl).toBeNull();
+    });
+
+    it('preserves null subtopic_id', () => {
+      const card = makeAdaptiveCard('c-1', { subtopic_id: null });
+      const fc = mapToFlashcard(card);
+      expect(fc.subtopic_id).toBeNull();
+    });
+  });
+
+  // ── mapBatchToFlashcards ──
+
+  describe('mapBatchToFlashcards', () => {
+    it('returns empty array for empty cards list', () => {
+      const result: AdaptiveGenerationResult = {
+        cards: [],
+        errors: [],
+        stats: { requested: 0, generated: 0, failed: 0, uniqueKeywords: 0, avgPKnow: 0, totalTokens: 0, elapsedMs: 0 },
+      };
+      expect(mapBatchToFlashcards(result)).toEqual([]);
+    });
+
+    it('maps each card in the batch preserving order', () => {
+      const cards = [makeAdaptiveCard('a'), makeAdaptiveCard('b'), makeAdaptiveCard('c')];
+      const result: AdaptiveGenerationResult = {
+        cards,
+        errors: [],
+        stats: { requested: 3, generated: 3, failed: 0, uniqueKeywords: 3, avgPKnow: 0.35, totalTokens: 450, elapsedMs: 1200 },
+      };
+      const mapped = mapBatchToFlashcards(result);
+      expect(mapped.map((f) => f.id)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  // ── getReasonText ──
+
+  describe('getReasonText', () => {
+    // Sistema A (rating INPUT): p_know used only to format user-facing %
+    it('returns new_concept message ignoring p_know', () => {
+      expect(getReasonText('new_concept', 0.0)).toBe('Es un concepto nuevo que aun no has estudiado.');
+      expect(getReasonText('new_concept', 0.9)).toBe('Es un concepto nuevo que aun no has estudiado.');
+    });
+
+    it('formats low_mastery with rounded percentage', () => {
+      expect(getReasonText('low_mastery', 0.23)).toBe('Tu dominio es bajo (23%). Necesitas reforzar este concepto.');
+    });
+
+    it('formats needs_review with rounded percentage', () => {
+      expect(getReasonText('needs_review', 0.456)).toContain('46%');
+      expect(getReasonText('needs_review', 0.456)).toMatch(/moderado-bajo/);
+    });
+
+    it('formats moderate_mastery', () => {
+      expect(getReasonText('moderate_mastery', 0.6)).toBe('Tu dominio es intermedio (60%). Puedes profundizar con ejercicios más desafiantes.');
+    });
+
+    it('formats reinforcement for high p_know', () => {
+      expect(getReasonText('reinforcement', 0.95)).toBe('Tu dominio es alto (95%). Este ejercicio te ayudará a mantener el conocimiento.');
+    });
+
+    it('returns default message for unknown reason', () => {
+      // Cast since TS would normally block unknown literals — we test runtime default.
+      const result = getReasonText('unknown_reason' as any, 0.5);
+      expect(result).toBe('Concepto seleccionado para estudio (dominio: 50%).');
+    });
+
+    it('rounds p_know=0.995 up to 100% (Math.round edge)', () => {
+      expect(getReasonText('reinforcement', 0.995)).toContain('100%');
+    });
+
+    it('handles p_know=0 as 0%', () => {
+      expect(getReasonText('low_mastery', 0)).toContain('(0%)');
+    });
+  });
+});

--- a/src/app/services/__tests__/aiApi.test.ts
+++ b/src/app/services/__tests__/aiApi.test.ts
@@ -1,0 +1,409 @@
+// ============================================================
+// Unit tests for aiApi service (/ai/generate, /ai/generate-smart,
+// /ai/pre-generate endpoints + type guards + getReasonLabel utility).
+//
+// Mocks: @/app/lib/api (apiCall)
+//
+// RUN: npx vitest run src/app/services/__tests__/aiApi.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock apiCall BEFORE importing the service ───────────────
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import {
+  aiGenerate,
+  aiGenerateSmart,
+  aiPreGenerate,
+  isAiQuizResult,
+  isAiSmartQuizResult,
+  isAiFlashcardResult,
+  isAiSmartFlashcardResult,
+  getReasonLabel,
+  type AiGenerateQuizResult,
+  type AiGenerateFlashcardResult,
+  type AiGenerateSmartQuizResult,
+  type AiGenerateSmartFlashcardResult,
+  type AiPreGenerateResult,
+  type AiSmartInfo,
+} from '@/app/services/aiApi';
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const SAMPLE_QUIZ_RESULT: AiGenerateQuizResult = {
+  id: 'q-1',
+  summary_id: 'sum-1',
+  keyword_id: 'kw-1',
+  subtopic_id: null,
+  question: 'What is foo?',
+  options: ['a', 'b', 'c', 'd'],
+  correct_answer: 'a',
+  explanation: 'because',
+  difficulty: 'medium',
+  question_type: 'multiple_choice',
+  source: 'ai',
+  created_by: 'u-1',
+  created_at: '2026-04-18T00:00:00Z',
+  _meta: {
+    model: 'gemini-2.0',
+    tokens: { input: 100, output: 50 },
+    had_wrong_answer: false,
+  },
+} as unknown as AiGenerateQuizResult;
+
+const SAMPLE_FC_RESULT: AiGenerateFlashcardResult = {
+  id: 'f-1',
+  summary_id: 'sum-1',
+  keyword_id: 'kw-1',
+  subtopic_id: null,
+  front: 'front text',
+  back: 'back text',
+  source: 'ai',
+  created_by: 'u-1',
+  created_at: '2026-04-18T00:00:00Z',
+  _meta: {
+    model: 'gemini-2.0',
+    tokens: { input: 100, output: 50 },
+    related: false,
+  },
+};
+
+const SAMPLE_SMART_INFO: AiSmartInfo = {
+  target_keyword: 'mitosis',
+  target_summary: 'Cell Biology',
+  target_subtopic: null,
+  p_know: 0.35,
+  need_score: 0.65,
+  primary_reason: 'low_mastery',
+  was_deduped: false,
+  candidates_evaluated: 5,
+};
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// aiGenerate — POST /ai/generate
+// ══════════════════════════════════════════════════════════════
+
+describe('aiGenerate', () => {
+  it('calls POST /ai/generate with correct URL and method', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_QUIZ_RESULT);
+    await aiGenerate({ action: 'quiz_question', summary_id: 'sum-1' });
+    expect(mockApiCall).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/ai/generate');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('serializes full body including optional fields', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_QUIZ_RESULT);
+    await aiGenerate({
+      action: 'quiz_question',
+      summary_id: 'sum-1',
+      keyword_id: 'kw-1',
+      subtopic_id: 'sub-1',
+      block_id: 'blk-1',
+      wrong_answer: 'opt-a',
+      related: true,
+    });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'quiz_question',
+      summary_id: 'sum-1',
+      keyword_id: 'kw-1',
+      subtopic_id: 'sub-1',
+      block_id: 'blk-1',
+      wrong_answer: 'opt-a',
+      related: true,
+    });
+  });
+
+  it('serializes minimal body with only required fields', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_FC_RESULT);
+    await aiGenerate({ action: 'flashcard', summary_id: 'sum-1' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({ action: 'flashcard', summary_id: 'sum-1' });
+    expect(body.keyword_id).toBeUndefined();
+    expect(body.block_id).toBeUndefined();
+  });
+
+  it('returns quiz result when action=quiz_question', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_QUIZ_RESULT);
+    const out = await aiGenerate({ action: 'quiz_question', summary_id: 'sum-1' });
+    expect(out).toEqual(SAMPLE_QUIZ_RESULT);
+  });
+
+  it('returns flashcard result when action=flashcard', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_FC_RESULT);
+    const out = await aiGenerate({ action: 'flashcard', summary_id: 'sum-1' });
+    expect(out).toEqual(SAMPLE_FC_RESULT);
+  });
+
+  it('propagates backend errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 500: AI generation failed'));
+    await expect(
+      aiGenerate({ action: 'quiz_question', summary_id: 'sum-1' })
+    ).rejects.toThrow('AI generation failed');
+  });
+
+  it('propagates rate-limit 429 errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 429: rate limit'));
+    await expect(
+      aiGenerate({ action: 'flashcard', summary_id: 'sum-1' })
+    ).rejects.toThrow('429');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// aiGenerateSmart — POST /ai/generate-smart
+// ══════════════════════════════════════════════════════════════
+
+describe('aiGenerateSmart', () => {
+  it('calls POST /ai/generate-smart with correct URL and method', async () => {
+    const smartQuiz: AiGenerateSmartQuizResult = {
+      ...SAMPLE_QUIZ_RESULT,
+      _smart: SAMPLE_SMART_INFO,
+    } as unknown as AiGenerateSmartQuizResult;
+    mockApiCall.mockResolvedValueOnce(smartQuiz);
+    await aiGenerateSmart({ action: 'quiz_question' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/ai/generate-smart');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('serializes body with institution_id and related flag', async () => {
+    mockApiCall.mockResolvedValueOnce({} as any);
+    await aiGenerateSmart({
+      action: 'flashcard',
+      institution_id: 'inst-1',
+      related: true,
+    });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'flashcard',
+      institution_id: 'inst-1',
+      related: true,
+    });
+  });
+
+  it('serializes minimal body with only action', async () => {
+    mockApiCall.mockResolvedValueOnce({} as any);
+    await aiGenerateSmart({ action: 'quiz_question' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({ action: 'quiz_question' });
+  });
+
+  it('returns smart quiz result with _smart metadata', async () => {
+    const smartQuiz: AiGenerateSmartQuizResult = {
+      ...SAMPLE_QUIZ_RESULT,
+      _smart: SAMPLE_SMART_INFO,
+    } as unknown as AiGenerateSmartQuizResult;
+    mockApiCall.mockResolvedValueOnce(smartQuiz);
+    const out = await aiGenerateSmart({ action: 'quiz_question' });
+    expect((out as AiGenerateSmartQuizResult)._smart).toEqual(SAMPLE_SMART_INFO);
+  });
+
+  it('returns smart flashcard result with _smart metadata', async () => {
+    const smartFc: AiGenerateSmartFlashcardResult = {
+      ...SAMPLE_FC_RESULT,
+      _smart: SAMPLE_SMART_INFO,
+    };
+    mockApiCall.mockResolvedValueOnce(smartFc);
+    const out = await aiGenerateSmart({ action: 'flashcard' });
+    expect((out as AiGenerateSmartFlashcardResult)._smart).toEqual(SAMPLE_SMART_INFO);
+  });
+
+  it('propagates errors (no candidates available)', async () => {
+    mockApiCall.mockRejectedValueOnce(
+      new Error('HTTP 400: No keywords available for smart generation')
+    );
+    await expect(aiGenerateSmart({ action: 'flashcard' })).rejects.toThrow(
+      'No keywords available'
+    );
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// aiPreGenerate — POST /ai/pre-generate
+// ══════════════════════════════════════════════════════════════
+
+describe('aiPreGenerate', () => {
+  const SAMPLE_PRE: AiPreGenerateResult = {
+    generated: [
+      { type: 'quiz_question', id: 'q-1', keyword_id: 'kw-1', keyword_name: 'mitosis' },
+      { type: 'quiz_question', id: 'q-2', keyword_id: 'kw-2', keyword_name: 'meiosis' },
+    ],
+    errors: [],
+    _meta: {
+      model: 'gemini-2.0',
+      summary_id: 'sum-1',
+      summary_title: 'Cell Biology',
+      action: 'quiz_question',
+      total_attempted: 2,
+      total_generated: 2,
+      total_failed: 0,
+      total_keywords_in_summary: 10,
+      tokens: { input: 200, output: 100 },
+    },
+  };
+
+  it('calls POST /ai/pre-generate with correct URL', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_PRE);
+    await aiPreGenerate({ summary_id: 'sum-1', action: 'quiz_question' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/ai/pre-generate');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('serializes body including count when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_PRE);
+    await aiPreGenerate({ summary_id: 'sum-1', action: 'flashcard', count: 5 });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({ summary_id: 'sum-1', action: 'flashcard', count: 5 });
+  });
+
+  it('serializes body without count when not provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_PRE);
+    await aiPreGenerate({ summary_id: 'sum-1', action: 'quiz_question' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({ summary_id: 'sum-1', action: 'quiz_question' });
+    expect(body.count).toBeUndefined();
+  });
+
+  it('returns generated items + empty errors when all succeed', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_PRE);
+    const out = await aiPreGenerate({ summary_id: 'sum-1', action: 'quiz_question' });
+    expect(out.generated).toHaveLength(2);
+    expect(out.errors).toHaveLength(0);
+    expect(out._meta.total_generated).toBe(2);
+  });
+
+  it('returns partial success with errors array populated', async () => {
+    const partial: AiPreGenerateResult = {
+      ...SAMPLE_PRE,
+      generated: [SAMPLE_PRE.generated[0]],
+      errors: [{ keyword_id: 'kw-2', keyword_name: 'meiosis', error: 'timeout' }],
+      _meta: { ...SAMPLE_PRE._meta, total_generated: 1, total_failed: 1 },
+    };
+    mockApiCall.mockResolvedValueOnce(partial);
+    const out = await aiPreGenerate({ summary_id: 'sum-1', action: 'quiz_question' });
+    expect(out.generated).toHaveLength(1);
+    expect(out.errors[0].error).toBe('timeout');
+    expect(out._meta.total_failed).toBe(1);
+  });
+
+  it('propagates a network/server error', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('Network timeout'));
+    await expect(
+      aiPreGenerate({ summary_id: 'sum-1', action: 'quiz_question' })
+    ).rejects.toThrow('Network timeout');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Type Guards
+// ══════════════════════════════════════════════════════════════
+
+describe('isAiQuizResult', () => {
+  it('returns true for quiz result (has question + correct_answer)', () => {
+    expect(isAiQuizResult(SAMPLE_QUIZ_RESULT)).toBe(true);
+  });
+
+  it('returns false for flashcard result', () => {
+    expect(isAiQuizResult(SAMPLE_FC_RESULT as unknown as AiGenerateQuizResult)).toBe(false);
+  });
+});
+
+describe('isAiFlashcardResult', () => {
+  it('returns true for flashcard result (has front + back)', () => {
+    expect(isAiFlashcardResult(SAMPLE_FC_RESULT)).toBe(true);
+  });
+
+  it('returns false for quiz result', () => {
+    expect(isAiFlashcardResult(SAMPLE_QUIZ_RESULT as unknown as AiGenerateFlashcardResult)).toBe(false);
+  });
+});
+
+describe('isAiSmartQuizResult', () => {
+  it('returns true for smart quiz result', () => {
+    const smartQuiz = { ...SAMPLE_QUIZ_RESULT, _smart: SAMPLE_SMART_INFO } as AiGenerateSmartQuizResult;
+    expect(isAiSmartQuizResult(smartQuiz)).toBe(true);
+  });
+
+  it('returns false for smart flashcard result', () => {
+    const smartFc = { ...SAMPLE_FC_RESULT, _smart: SAMPLE_SMART_INFO } as AiGenerateSmartFlashcardResult;
+    expect(isAiSmartQuizResult(smartFc as unknown as AiGenerateSmartQuizResult)).toBe(false);
+  });
+});
+
+describe('isAiSmartFlashcardResult', () => {
+  it('returns true for smart flashcard result', () => {
+    const smartFc = { ...SAMPLE_FC_RESULT, _smart: SAMPLE_SMART_INFO } as AiGenerateSmartFlashcardResult;
+    expect(isAiSmartFlashcardResult(smartFc)).toBe(true);
+  });
+
+  it('returns false for smart quiz result', () => {
+    const smartQuiz = { ...SAMPLE_QUIZ_RESULT, _smart: SAMPLE_SMART_INFO } as AiGenerateSmartQuizResult;
+    expect(isAiSmartFlashcardResult(smartQuiz as unknown as AiGenerateSmartFlashcardResult)).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getReasonLabel — Utility for Spanish labels
+// ══════════════════════════════════════════════════════════════
+
+describe('getReasonLabel', () => {
+  it('returns Spanish label for new_concept', () => {
+    const label = getReasonLabel('new_concept');
+    expect(label).toContain('Concepto nuevo');
+  });
+
+  it('returns Spanish label for low_mastery', () => {
+    expect(getReasonLabel('low_mastery')).toContain('Dominio bajo');
+  });
+
+  it('returns Spanish label for needs_review', () => {
+    expect(getReasonLabel('needs_review')).toContain('Dominio moderado-bajo');
+  });
+
+  it('returns Spanish label for moderate_mastery', () => {
+    expect(getReasonLabel('moderate_mastery')).toContain('Dominio intermedio');
+  });
+
+  it('returns Spanish label for reinforcement', () => {
+    expect(getReasonLabel('reinforcement')).toContain('Dominio alto');
+  });
+
+  it('appends rounded percentage when pKnow provided', () => {
+    expect(getReasonLabel('low_mastery', 0.35)).toContain('(35%)');
+    expect(getReasonLabel('moderate_mastery', 0.67)).toContain('(67%)');
+  });
+
+  it('rounds 0 pKnow correctly (edge case, not skipped by != null)', () => {
+    // 0 is not null → should be appended
+    expect(getReasonLabel('new_concept', 0)).toContain('(0%)');
+  });
+
+  it('omits percentage when pKnow is undefined', () => {
+    const label = getReasonLabel('reinforcement');
+    expect(label).not.toMatch(/\(\d+%\)/);
+  });
+
+  it('rounds to nearest integer for fractional pKnow', () => {
+    // 0.456 * 100 = 45.6 → 46
+    expect(getReasonLabel('low_mastery', 0.456)).toContain('(46%)');
+    // 0.444 * 100 = 44.4 → 44
+    expect(getReasonLabel('low_mastery', 0.444)).toContain('(44%)');
+  });
+
+  it('falls back to generic label for unknown reason (defensive)', () => {
+    // Cast to bypass TS check — we simulate a future/unknown primary_reason
+    const label = getReasonLabel('unknown_reason' as AiSmartInfo['primary_reason']);
+    expect(label).toBe('Concepto seleccionado para estudio');
+  });
+});

--- a/src/app/services/__tests__/aiReportApi.test.ts
+++ b/src/app/services/__tests__/aiReportApi.test.ts
@@ -1,0 +1,448 @@
+// ============================================================
+// Unit tests for aiReportApi service.
+//
+// Covers:
+//   - createAiReport (POST /ai/report)
+//   - resolveAiReport (PATCH /ai/report/:id)
+//   - getAiReportStats (GET /ai/report-stats)
+//   - getAiReports (GET /ai/reports with filters)
+//   - Display constants integrity
+//
+// Mocks: @/app/lib/api (apiCall)
+//
+// RUN: npx vitest run src/app/services/__tests__/aiReportApi.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock apiCall BEFORE importing the service ───────────────
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import {
+  createAiReport,
+  resolveAiReport,
+  getAiReportStats,
+  getAiReports,
+  REPORT_REASON_LABELS,
+  REPORT_STATUS_LABELS,
+  REPORT_STATUS_COLORS,
+  type AiContentReport,
+  type AiReportStats,
+  type AiReportsListResponse,
+} from '@/app/services/aiReportApi';
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+const SAMPLE_REPORT: AiContentReport = {
+  id: 'rep-1',
+  content_type: 'quiz_question',
+  content_id: 'q-1',
+  reported_by: 'stu-1',
+  institution_id: 'inst-1',
+  reason: 'incorrect',
+  description: 'La respuesta correcta es A no B',
+  status: 'pending',
+  resolved_by: null,
+  resolved_at: null,
+  resolution_note: null,
+  created_at: '2026-04-18T10:00:00Z',
+};
+
+const SAMPLE_STATS: AiReportStats = {
+  total_reports: 42,
+  pending_count: 12,
+  reviewed_count: 5,
+  resolved_count: 20,
+  dismissed_count: 5,
+  reason_incorrect: 30,
+  reason_inappropriate: 2,
+  reason_low_quality: 5,
+  reason_irrelevant: 3,
+  reason_other: 2,
+  type_quiz_question: 30,
+  type_flashcard: 12,
+  avg_resolution_hours: 4.2,
+  resolution_rate: 0.68,
+};
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// createAiReport — POST /ai/report
+// ══════════════════════════════════════════════════════════════
+
+describe('createAiReport', () => {
+  it('calls POST /ai/report with correct URL and method', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_REPORT);
+    await createAiReport({
+      content_type: 'quiz_question',
+      content_id: 'q-1',
+      reason: 'incorrect',
+    });
+    expect(mockApiCall).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/ai/report');
+    expect(opts.method).toBe('POST');
+  });
+
+  it('serializes full body including description', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_REPORT);
+    await createAiReport({
+      content_type: 'flashcard',
+      content_id: 'f-1',
+      reason: 'low_quality',
+      description: 'muy vago',
+    });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({
+      content_type: 'flashcard',
+      content_id: 'f-1',
+      reason: 'low_quality',
+      description: 'muy vago',
+    });
+  });
+
+  it('serializes minimal body without description', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_REPORT);
+    await createAiReport({
+      content_type: 'quiz_question',
+      content_id: 'q-1',
+      reason: 'irrelevant',
+    });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body.description).toBeUndefined();
+  });
+
+  it('returns the created report', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_REPORT);
+    const out = await createAiReport({
+      content_type: 'quiz_question',
+      content_id: 'q-1',
+      reason: 'incorrect',
+    });
+    expect(out).toEqual(SAMPLE_REPORT);
+  });
+
+  it('propagates 409 duplicate error', async () => {
+    mockApiCall.mockRejectedValueOnce(
+      new Error('HTTP 409: duplicate key value violates unique constraint')
+    );
+    await expect(
+      createAiReport({
+        content_type: 'quiz_question',
+        content_id: 'q-1',
+        reason: 'incorrect',
+      })
+    ).rejects.toThrow('409');
+  });
+
+  it('propagates 404 content-not-found error', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 404: Content not found'));
+    await expect(
+      createAiReport({
+        content_type: 'flashcard',
+        content_id: 'nope',
+        reason: 'incorrect',
+      })
+    ).rejects.toThrow('not found');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// resolveAiReport — PATCH /ai/report/:id
+// ══════════════════════════════════════════════════════════════
+
+describe('resolveAiReport', () => {
+  it('builds PATCH URL with reportId', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SAMPLE_REPORT, status: 'resolved' });
+    await resolveAiReport('rep-abc', { status: 'resolved' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/ai/report/rep-abc');
+    expect(opts.method).toBe('PATCH');
+  });
+
+  it('serializes body with status and resolution_note', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SAMPLE_REPORT, status: 'dismissed' });
+    await resolveAiReport('rep-1', {
+      status: 'dismissed',
+      resolution_note: 'not a valid complaint',
+    });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body).toEqual({
+      status: 'dismissed',
+      resolution_note: 'not a valid complaint',
+    });
+  });
+
+  it('serializes body with status only (optional resolution_note)', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SAMPLE_REPORT, status: 'reviewed' });
+    await resolveAiReport('rep-1', { status: 'reviewed' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body.resolution_note).toBeUndefined();
+    expect(body.status).toBe('reviewed');
+  });
+
+  it('accepts re-opening (any → pending) as a valid transition in the surface', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SAMPLE_REPORT, status: 'pending' });
+    await resolveAiReport('rep-1', { status: 'pending' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body.status).toBe('pending');
+  });
+
+  it('returns the updated report', async () => {
+    const updated = {
+      ...SAMPLE_REPORT,
+      status: 'resolved' as const,
+      resolved_by: 'prof-1',
+      resolved_at: '2026-04-18T12:00:00Z',
+      resolution_note: 'Fixed the question',
+    };
+    mockApiCall.mockResolvedValueOnce(updated);
+    const out = await resolveAiReport('rep-1', {
+      status: 'resolved',
+      resolution_note: 'Fixed the question',
+    });
+    expect(out).toEqual(updated);
+  });
+
+  it('propagates 403 (non-content-writer attempts PATCH)', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 403: forbidden'));
+    await expect(
+      resolveAiReport('rep-1', { status: 'resolved' })
+    ).rejects.toThrow('forbidden');
+  });
+
+  it('propagates 404 when reportId does not exist', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 404: report not found'));
+    await expect(
+      resolveAiReport('nope', { status: 'reviewed' })
+    ).rejects.toThrow('not found');
+  });
+
+  it('encodes reportId into URL path as-is (no double encoding by service)', async () => {
+    // Service passes the id directly in template literal; this documents behavior.
+    mockApiCall.mockResolvedValueOnce(SAMPLE_REPORT);
+    await resolveAiReport('uuid-with-dashes-1234', { status: 'reviewed' });
+    expect(mockApiCall.mock.calls[0][0]).toBe('/ai/report/uuid-with-dashes-1234');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getAiReportStats — GET /ai/report-stats
+// ══════════════════════════════════════════════════════════════
+
+describe('getAiReportStats', () => {
+  it('builds URL with institution_id query param', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1');
+    expect(mockApiCall).toHaveBeenCalledTimes(1);
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url.startsWith('/ai/report-stats?')).toBe(true);
+    expect(url).toContain('institution_id=inst-1');
+  });
+
+  it('appends from date when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1', '2026-01-01');
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('from=2026-01-01');
+  });
+
+  it('appends both from and to when both provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1', '2026-01-01', '2026-04-01');
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('from=2026-01-01');
+    expect(url).toContain('to=2026-04-01');
+  });
+
+  it('omits from/to when not provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1');
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).not.toContain('from=');
+    expect(url).not.toContain('to=');
+  });
+
+  it('appends only to when from is undefined and to is provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1', undefined, '2026-04-01');
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('to=2026-04-01');
+    expect(url).not.toContain('from=');
+  });
+
+  it('percent-encodes special chars in institution_id', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst with space');
+    const url = mockApiCall.mock.calls[0][0] as string;
+    // URLSearchParams uses + for spaces
+    expect(url).toMatch(/institution_id=inst(\+|%20)with(\+|%20)space/);
+  });
+
+  it('returns the stats object', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    const out = await getAiReportStats('inst-1');
+    expect(out).toEqual(SAMPLE_STATS);
+  });
+
+  it('uses GET (no method option → apiCall default)', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_STATS);
+    await getAiReportStats('inst-1');
+    // No second argument means no init → GET default in apiCall
+    expect(mockApiCall.mock.calls[0].length).toBe(1);
+  });
+
+  it('propagates errors from the RPC', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 500: RPC failed'));
+    await expect(getAiReportStats('inst-1')).rejects.toThrow('RPC failed');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getAiReports — GET /ai/reports (filters + pagination)
+// ══════════════════════════════════════════════════════════════
+
+describe('getAiReports', () => {
+  const EMPTY_LIST: AiReportsListResponse = { items: [], total: 0, limit: 20, offset: 0 };
+  const LIST_WITH_ITEM: AiReportsListResponse = {
+    items: [SAMPLE_REPORT],
+    total: 1,
+    limit: 20,
+    offset: 0,
+  };
+
+  it('builds URL with just institution_id when no filters', async () => {
+    mockApiCall.mockResolvedValueOnce(EMPTY_LIST);
+    await getAiReports({ institution_id: 'inst-1' });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url.startsWith('/ai/reports?')).toBe(true);
+    expect(url).toContain('institution_id=inst-1');
+    expect(url).not.toContain('status=');
+    expect(url).not.toContain('reason=');
+    expect(url).not.toContain('content_type=');
+    expect(url).not.toContain('limit=');
+    expect(url).not.toContain('offset=');
+  });
+
+  it('includes status filter when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', status: 'pending' });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('status=pending');
+  });
+
+  it('includes reason filter when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', reason: 'incorrect' });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('reason=incorrect');
+  });
+
+  it('includes content_type filter when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', content_type: 'flashcard' });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('content_type=flashcard');
+  });
+
+  it('includes limit and offset when provided', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', limit: 50, offset: 100 });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=100');
+  });
+
+  it('combines all filters in a single URL', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({
+      institution_id: 'inst-1',
+      status: 'resolved',
+      reason: 'low_quality',
+      content_type: 'quiz_question',
+      limit: 10,
+      offset: 20,
+    });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).toContain('institution_id=inst-1');
+    expect(url).toContain('status=resolved');
+    expect(url).toContain('reason=low_quality');
+    expect(url).toContain('content_type=quiz_question');
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=20');
+  });
+
+  it('omits offset=0 because falsy (documents current behavior)', async () => {
+    // The service uses `if (params.offset)` which is falsy for 0 → NOT appended.
+    // This test locks that behavior so a refactor that changes it is visible.
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', offset: 0 });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).not.toContain('offset=');
+  });
+
+  it('omits limit=0 because falsy (documents current behavior)', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    await getAiReports({ institution_id: 'inst-1', limit: 0 });
+    const url = mockApiCall.mock.calls[0][0] as string;
+    expect(url).not.toContain('limit=');
+  });
+
+  it('returns empty list when backend returns no items', async () => {
+    mockApiCall.mockResolvedValueOnce(EMPTY_LIST);
+    const out = await getAiReports({ institution_id: 'inst-1' });
+    expect(out.items).toEqual([]);
+    expect(out.total).toBe(0);
+  });
+
+  it('returns paginated response with items', async () => {
+    mockApiCall.mockResolvedValueOnce(LIST_WITH_ITEM);
+    const out = await getAiReports({ institution_id: 'inst-1' });
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]).toEqual(SAMPLE_REPORT);
+  });
+
+  it('propagates backend errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 500: database error'));
+    await expect(
+      getAiReports({ institution_id: 'inst-1' })
+    ).rejects.toThrow('database error');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Display Constants — sanity checks
+// ══════════════════════════════════════════════════════════════
+
+describe('Display Constants', () => {
+  it('REPORT_REASON_LABELS covers all 5 reasons', () => {
+    expect(Object.keys(REPORT_REASON_LABELS)).toHaveLength(5);
+    expect(REPORT_REASON_LABELS.incorrect).toBeTruthy();
+    expect(REPORT_REASON_LABELS.inappropriate).toBeTruthy();
+    expect(REPORT_REASON_LABELS.low_quality).toBeTruthy();
+    expect(REPORT_REASON_LABELS.irrelevant).toBeTruthy();
+    expect(REPORT_REASON_LABELS.other).toBeTruthy();
+  });
+
+  it('REPORT_STATUS_LABELS covers all 4 statuses', () => {
+    expect(Object.keys(REPORT_STATUS_LABELS)).toHaveLength(4);
+    expect(REPORT_STATUS_LABELS.pending).toBeTruthy();
+    expect(REPORT_STATUS_LABELS.reviewed).toBeTruthy();
+    expect(REPORT_STATUS_LABELS.resolved).toBeTruthy();
+    expect(REPORT_STATUS_LABELS.dismissed).toBeTruthy();
+  });
+
+  it('REPORT_STATUS_COLORS covers all 4 statuses with tailwind classes', () => {
+    expect(Object.keys(REPORT_STATUS_COLORS)).toHaveLength(4);
+    // Each value should be a tailwind-ish class string
+    expect(REPORT_STATUS_COLORS.pending).toContain('amber');
+    expect(REPORT_STATUS_COLORS.reviewed).toContain('blue');
+    expect(REPORT_STATUS_COLORS.resolved).toContain('emerald');
+    expect(REPORT_STATUS_COLORS.dismissed).toContain('zinc');
+  });
+});

--- a/src/app/services/__tests__/apiConfig.test.ts
+++ b/src/app/services/__tests__/apiConfig.test.ts
@@ -1,0 +1,297 @@
+// ============================================================
+// Axon -- Tests for apiConfig.ts
+//
+// Bridge module that re-exports API_BASE_URL / ANON / getRealToken
+// plus realRequest (GET dedup + unwrap { data }) and figmaRequest
+// (no user JWT). Fetch is mocked via global.fetch.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Silence the logger side-effects.
+vi.mock('@/app/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  API_BASE_URL,
+  publicAnonKey,
+  getAnonKey,
+  getRealToken,
+  ApiError,
+  realRequest,
+  figmaRequest,
+} from '@/app/services/apiConfig';
+import { setAccessToken, API_BASE, ANON_KEY } from '@/app/lib/api';
+
+// ── Helpers ──────────────────────────────────────────────
+
+function mockFetchOnce(body: unknown, init: Partial<Response> = {}) {
+  const res = {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(res);
+}
+
+beforeEach(() => {
+  // Stub global fetch
+  globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  setAccessToken(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Re-exports
+// ══════════════════════════════════════════════════════════════
+
+describe('re-exports', () => {
+  it('API_BASE_URL mirrors API_BASE from lib/api', () => {
+    expect(API_BASE_URL).toBe(API_BASE);
+  });
+
+  it('publicAnonKey mirrors ANON_KEY', () => {
+    expect(publicAnonKey).toBe(ANON_KEY);
+  });
+
+  it('getAnonKey() returns ANON_KEY', () => {
+    expect(getAnonKey()).toBe(ANON_KEY);
+  });
+
+  it('getRealToken() returns null when no token set', () => {
+    expect(getRealToken()).toBeNull();
+  });
+
+  it('getRealToken() returns the token after setAccessToken', () => {
+    setAccessToken('abc.def.ghi');
+    expect(getRealToken()).toBe('abc.def.ghi');
+    setAccessToken(null);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// ApiError
+// ══════════════════════════════════════════════════════════════
+
+describe('ApiError', () => {
+  it('is an Error subclass with code + status', () => {
+    const e = new ApiError('oops', 'BOOM', 500);
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(ApiError);
+    expect(e.message).toBe('oops');
+    expect(e.code).toBe('BOOM');
+    expect(e.status).toBe(500);
+    expect(e.name).toBe('ApiError');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// realRequest — URL + headers
+// ══════════════════════════════════════════════════════════════
+
+describe('realRequest — URL construction', () => {
+  it('fetches from API_BASE + path', async () => {
+    mockFetchOnce({ data: { ok: true } });
+    await realRequest('/hello');
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(url).toBe(`${API_BASE}/hello`);
+  });
+
+  it('sends Authorization Bearer <ANON_KEY> always', async () => {
+    mockFetchOnce({ data: {} });
+    await realRequest('/x');
+    const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${ANON_KEY}`);
+  });
+
+  it('sends Content-Type: application/json', async () => {
+    mockFetchOnce({ data: {} });
+    await realRequest('/x');
+    const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('adds X-Access-Token only when a user token is set', async () => {
+    mockFetchOnce({ data: {} });
+    await realRequest('/x');
+    let init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as RequestInit;
+    let headers = init.headers as Record<string, string>;
+    expect(headers['X-Access-Token']).toBeUndefined();
+
+    setAccessToken('jwt-xyz');
+    mockFetchOnce({ data: {} });
+    await realRequest('/y');
+    init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[1][1] as RequestInit;
+    headers = init.headers as Record<string, string>;
+    expect(headers['X-Access-Token']).toBe('jwt-xyz');
+    setAccessToken(null);
+  });
+
+  it('forwards caller-provided headers (and caller wins over defaults for same key)', async () => {
+    mockFetchOnce({ data: {} });
+    await realRequest('/x', {
+      headers: { 'X-Custom': 'v1', Authorization: 'override' },
+    });
+    const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Custom']).toBe('v1');
+    expect(headers.Authorization).toBe('override');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// realRequest — response parsing
+// ══════════════════════════════════════════════════════════════
+
+describe('realRequest — response unwrapping', () => {
+  // NOTE: error-path tests use POST to bypass the GET deduplication branch
+  // (realRequest attaches a fire-and-forget `.finally` to the in-flight
+  // promise, which surfaces as an unhandled-rejection under jsdom when the
+  // underlying promise rejects).
+
+  it('unwraps { data: T } to T', async () => {
+    mockFetchOnce({ data: { id: 'abc' } });
+    const result = await realRequest<{ id: string }>('/y');
+    expect(result).toEqual({ id: 'abc' });
+  });
+
+  it('returns the body as-is when no "data" wrapper', async () => {
+    mockFetchOnce({ id: 'raw' });
+    const result = await realRequest<{ id: string }>('/y');
+    expect(result).toEqual({ id: 'raw' });
+  });
+
+  it('throws ApiError on non-OK response with error message', async () => {
+    mockFetchOnce({ error: 'nope' }, { ok: false, status: 400 });
+    await expect(
+      realRequest('/z', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 400,
+      message: 'nope',
+    });
+  });
+
+  it('throws ApiError on non-OK response without error message', async () => {
+    mockFetchOnce({}, { ok: false, status: 500 });
+    await expect(
+      realRequest('/z', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 500,
+    });
+  });
+
+  it('throws ApiError when body contains top-level { error } on a 200', async () => {
+    mockFetchOnce({ error: 'soft-fail' });
+    await expect(
+      realRequest('/z', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'soft-fail',
+    });
+  });
+
+  it('throws PARSE_ERROR on non-JSON body', async () => {
+    mockFetchOnce('<<not json>>' as unknown as object);
+    await expect(
+      realRequest('/z', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({
+      code: 'PARSE_ERROR',
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// realRequest — GET dedup (PERF-S2)
+// ══════════════════════════════════════════════════════════════
+
+describe('realRequest — GET deduplication', () => {
+  it('reuses the in-flight promise for the same GET URL', async () => {
+    let resolveFetch: (v: Response) => void = () => {};
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const p1 = realRequest('/dedup-path');
+    const p2 = realRequest('/dedup-path');
+
+    // Only one fetch fired even though two calls were issued
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ data: { hit: true } }),
+    } as Response);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ hit: true });
+    expect(r2).toEqual({ hit: true });
+  });
+
+  it('does NOT dedup POST requests', async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetchOnce({ data: 1 });
+    mockFetchOnce({ data: 2 });
+    await realRequest('/same', { method: 'POST', body: '{}' });
+    await realRequest('/same', { method: 'POST', body: '{}' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// figmaRequest
+// ══════════════════════════════════════════════════════════════
+
+describe('figmaRequest', () => {
+  it('never sends X-Access-Token', async () => {
+    setAccessToken('should-not-leak');
+    mockFetchOnce({ data: {} });
+    await figmaRequest('/ai/ping');
+    const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Access-Token']).toBeUndefined();
+    expect(headers.Authorization).toBe(`Bearer ${ANON_KEY}`);
+    setAccessToken(null);
+  });
+
+  it('unwraps { data: T }', async () => {
+    mockFetchOnce({ data: { summary: 'x' } });
+    const result = await figmaRequest<{ summary: string }>('/ai/x');
+    expect(result).toEqual({ summary: 'x' });
+  });
+
+  it('throws FIGMA_ERROR on non-OK response', async () => {
+    mockFetchOnce({ error: 'denied' }, { ok: false, status: 403 });
+    await expect(figmaRequest('/ai/x')).rejects.toMatchObject({
+      code: 'FIGMA_ERROR',
+      status: 403,
+      message: 'denied',
+    });
+  });
+
+  it('throws PARSE_ERROR on non-JSON', async () => {
+    mockFetchOnce('boom' as unknown as object);
+    await expect(figmaRequest('/ai/x')).rejects.toMatchObject({
+      code: 'PARSE_ERROR',
+    });
+  });
+});

--- a/src/app/services/__tests__/bktApi.test.ts
+++ b/src/app/services/__tests__/bktApi.test.ts
@@ -1,0 +1,255 @@
+/**
+ * bktApi.test.ts — Tests for the BKT states API service.
+ *
+ * Covers:
+ *   - upsertBktState: POST /bkt-states with serialized body
+ *   - getBktStates: query-string assembly for single/batch/limit/offset filters
+ *     (including the `offset=0` falsy-skip quirk)
+ *   - getAllBktStates: success + graceful fallback to [] on failure
+ *
+ * NOTE (MASTERY-SYSTEMS.md): BKT p_know is consumed by Sistemas B and C
+ * downstream, but THIS file is pure API plumbing — no thresholds are
+ * compared against p_know here. We only assert HTTP wiring (method, URL,
+ * body). No mastery-system classification happens in bktApi.ts.
+ *
+ * Mocks: apiCall from @/app/lib/api
+ *
+ * Run: npx vitest run src/app/services/__tests__/bktApi.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import {
+  upsertBktState,
+  getBktStates,
+  getAllBktStates,
+  type BktState,
+  type BktStatePayload,
+} from '../bktApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Fixtures ──────────────────────────────────────────────
+
+function makePayload(overrides: Partial<BktStatePayload> = {}): BktStatePayload {
+  return {
+    subtopic_id: 'sub-1',
+    p_know: 0.62,
+    p_transit: 0.1,
+    p_slip: 0.1,
+    p_guess: 0.2,
+    delta: 0.05,
+    total_attempts: 4,
+    correct_attempts: 3,
+    last_attempt_at: '2026-04-18T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<BktState> = {}): BktState {
+  return {
+    id: 'bkt-1',
+    student_id: 'stu-1',
+    subtopic_id: 'sub-1',
+    p_know: 0.62,
+    p_transit: 0.1,
+    p_slip: 0.1,
+    p_guess: 0.2,
+    delta: 0.05,
+    total_attempts: 4,
+    correct_attempts: 3,
+    last_attempt_at: '2026-04-18T10:00:00Z',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-18T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('bktApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // upsertBktState
+  // ─────────────────────────────────────────────────────────
+
+  describe('upsertBktState', () => {
+    it('calls apiCall with POST /bkt-states', async () => {
+      mockApiCall.mockResolvedValueOnce(makeState());
+      await upsertBktState(makePayload());
+      expect(mockApiCall).toHaveBeenCalledTimes(1);
+      const [url, opts] = mockApiCall.mock.calls[0];
+      expect(url).toBe('/bkt-states');
+      expect(opts).toMatchObject({ method: 'POST' });
+    });
+
+    it('serializes the payload as JSON body', async () => {
+      mockApiCall.mockResolvedValueOnce(makeState());
+      const payload = makePayload({ p_know: 0.91, total_attempts: 10 });
+      await upsertBktState(payload);
+      const opts = mockApiCall.mock.calls[0][1] as RequestInit;
+      expect(typeof opts.body).toBe('string');
+      expect(JSON.parse(opts.body as string)).toEqual(payload);
+    });
+
+    it('returns the BktState from apiCall', async () => {
+      const state = makeState({ p_know: 0.77 });
+      mockApiCall.mockResolvedValueOnce(state);
+      const result = await upsertBktState(makePayload({ p_know: 0.77 }));
+      expect(result).toBe(state);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('network'));
+      await expect(upsertBktState(makePayload())).rejects.toThrow('network');
+    });
+
+    it('sends extreme p_know values (0 and 1) unchanged', async () => {
+      mockApiCall.mockResolvedValue(makeState());
+      await upsertBktState(makePayload({ p_know: 0 }));
+      await upsertBktState(makePayload({ p_know: 1 }));
+      const first = JSON.parse(mockApiCall.mock.calls[0][1]!.body as string);
+      const second = JSON.parse(mockApiCall.mock.calls[1][1]!.body as string);
+      expect(first.p_know).toBe(0);
+      expect(second.p_know).toBe(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // getBktStates
+  // ─────────────────────────────────────────────────────────
+
+  describe('getBktStates', () => {
+    it('calls apiCall with /bkt-states (no query string) when no filters', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates();
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states');
+    });
+
+    it('calls apiCall with /bkt-states (no query string) when filters object is empty', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({});
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states');
+    });
+
+    it('appends subtopic_id as query param', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ subtopic_id: 'sub-42' });
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states?subtopic_id=sub-42');
+    });
+
+    it('appends subtopic_ids as comma-joined list', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ subtopic_ids: ['a', 'b', 'c'] });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      // URLSearchParams encodes commas as %2C
+      expect(url).toBe('/bkt-states?subtopic_ids=a%2Cb%2Cc');
+    });
+
+    it('skips subtopic_ids when array is empty', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ subtopic_ids: [] });
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states');
+    });
+
+    it('appends limit when truthy', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ limit: 50 });
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states?limit=50');
+    });
+
+    it('appends offset when truthy', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ offset: 25 });
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states?offset=25');
+    });
+
+    it('skips offset=0 because the guard uses falsy check', async () => {
+      // Documented quirk: `if (filters?.offset)` means 0 is treated as absent.
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ offset: 0, limit: 100 });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('limit=100');
+      expect(url).not.toContain('offset=');
+    });
+
+    it('skips limit=0 because the guard uses falsy check', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ limit: 0, subtopic_id: 'x' });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('subtopic_id=x');
+      expect(url).not.toContain('limit=');
+    });
+
+    it('combines subtopic_ids + limit + offset in one URL', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getBktStates({ subtopic_ids: ['u1', 'u2'], limit: 200, offset: 10 });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('subtopic_ids=u1%2Cu2');
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=10');
+    });
+
+    it('returns the array of BktState records', async () => {
+      const states = [makeState(), makeState({ id: 'bkt-2', subtopic_id: 'sub-2' })];
+      mockApiCall.mockResolvedValueOnce(states);
+      const result = await getBktStates({ subtopic_id: 'sub-1' });
+      expect(result).toBe(states);
+      expect(result.length).toBe(2);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('boom'));
+      await expect(getBktStates({ subtopic_id: 'x' })).rejects.toThrow('boom');
+    });
+
+    it('handles undefined filters argument identically to empty object', async () => {
+      mockApiCall.mockResolvedValue([]);
+      await getBktStates();
+      await getBktStates({});
+      expect(mockApiCall.mock.calls[0][0]).toBe('/bkt-states');
+      expect(mockApiCall.mock.calls[1][0]).toBe('/bkt-states');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // getAllBktStates
+  // ─────────────────────────────────────────────────────────
+
+  describe('getAllBktStates', () => {
+    it('calls apiCall with /bkt-states?limit=1000', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getAllBktStates();
+      expect(mockApiCall).toHaveBeenCalledWith('/bkt-states?limit=1000');
+    });
+
+    it('returns the array on success', async () => {
+      const states = [makeState(), makeState({ id: 'bkt-2' })];
+      mockApiCall.mockResolvedValueOnce(states);
+      const result = await getAllBktStates();
+      expect(result).toEqual(states);
+    });
+
+    it('returns [] on apiCall failure (graceful degradation)', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('network down'));
+      const result = await getAllBktStates();
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] when apiCall rejects with non-Error value', async () => {
+      mockApiCall.mockRejectedValueOnce('string-error');
+      const result = await getAllBktStates();
+      expect(result).toEqual([]);
+    });
+
+    it('does NOT throw when the backend errors — callers treat as zero data', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('500'));
+      await expect(getAllBktStates()).resolves.toEqual([]);
+    });
+  });
+});

--- a/src/app/services/__tests__/flashcardMappingApi.test.ts
+++ b/src/app/services/__tests__/flashcardMappingApi.test.ts
@@ -1,0 +1,195 @@
+/**
+ * flashcardMappingApi.test.ts — Tests for flashcard mapping API service (T-01)
+ *
+ * Coverage: getFlashcardMappings (querystring building, pagination), getAllFlashcardMappings (auto-pagination, Map building)
+ * Mocks: apiCall
+ *
+ * Run: npx vitest run src/app/services/__tests__/flashcardMappingApi.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import {
+  getFlashcardMappings,
+  getAllFlashcardMappings,
+  type FlashcardMapping,
+  type FlashcardMappingResponse,
+} from '../flashcardMappingApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+function makeMapping(id: string, overrides: Partial<FlashcardMapping> = {}): FlashcardMapping {
+  return {
+    id,
+    subtopic_id: `sub-${id}`,
+    keyword_id: `kw-${id}`,
+    ...overrides,
+  };
+}
+
+function makeResponse(data: FlashcardMapping[], opts: Partial<FlashcardMappingResponse> = {}): FlashcardMappingResponse {
+  return {
+    data,
+    total: data.length,
+    limit: 500,
+    offset: 0,
+    ...opts,
+  };
+}
+
+describe('flashcardMappingApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── getFlashcardMappings ──
+
+  describe('getFlashcardMappings', () => {
+    it('calls /flashcard-mappings without querystring when no opts', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings();
+      expect(mockApiCall).toHaveBeenCalledWith('/flashcard-mappings');
+    });
+
+    it('calls /flashcard-mappings without querystring when opts is empty object', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings({});
+      expect(mockApiCall).toHaveBeenCalledWith('/flashcard-mappings');
+    });
+
+    it('includes status param when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings({ status: 'published' });
+      expect(mockApiCall).toHaveBeenCalledWith('/flashcard-mappings?status=published');
+    });
+
+    it('includes limit and offset params when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings({ limit: 100, offset: 50 });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('limit=100');
+      expect(url).toContain('offset=50');
+    });
+
+    it('combines all params in querystring', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings({ status: 'published', limit: 250, offset: 10 });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toMatch(/^\/flashcard-mappings\?/);
+      expect(url).toContain('status=published');
+      expect(url).toContain('limit=250');
+      expect(url).toContain('offset=10');
+    });
+
+    it('does NOT include limit when limit=0 (falsy)', async () => {
+      // Source uses `if (opts?.limit)` — 0 is falsy and excluded. Documents current contract.
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getFlashcardMappings({ limit: 0, offset: 5 });
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).not.toContain('limit=');
+      expect(url).toContain('offset=5');
+    });
+
+    it('returns the response unchanged from apiCall', async () => {
+      const resp = makeResponse([makeMapping('fc-1')], { total: 1 });
+      mockApiCall.mockResolvedValueOnce(resp);
+      const result = await getFlashcardMappings();
+      expect(result).toEqual(resp);
+    });
+
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('Network error'));
+      await expect(getFlashcardMappings()).rejects.toThrow('Network error');
+    });
+  });
+
+  // ── getAllFlashcardMappings (auto-pagination) ──
+
+  describe('getAllFlashcardMappings', () => {
+    it('returns empty Map when backend returns no items', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      const result = await getAllFlashcardMappings();
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('returns Map keyed by flashcard id (single page)', async () => {
+      mockApiCall.mockResolvedValueOnce(
+        makeResponse([makeMapping('a'), makeMapping('b', { subtopic_id: null })])
+      );
+      const result = await getAllFlashcardMappings();
+      expect(result.size).toBe(2);
+      expect(result.get('a')).toEqual({ subtopic_id: 'sub-a', keyword_id: 'kw-a' });
+      expect(result.get('b')).toEqual({ subtopic_id: null, keyword_id: 'kw-b' });
+    });
+
+    it('uses limit=1000 per page (matches source)', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse([]));
+      await getAllFlashcardMappings();
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('limit=1000');
+      // offset=0 is falsy and intentionally omitted by the URLSearchParams builder
+      expect(url).not.toContain('offset=0');
+    });
+
+    it('paginates across multiple pages until partial page indicates end', async () => {
+      // 1000 items page → go again; 500 items → stop (< limit)
+      const page1 = Array.from({ length: 1000 }, (_, i) => makeMapping(`p1-${i}`));
+      const page2 = Array.from({ length: 500 }, (_, i) => makeMapping(`p2-${i}`));
+      mockApiCall
+        .mockResolvedValueOnce(makeResponse(page1, { limit: 1000, offset: 0 }))
+        .mockResolvedValueOnce(makeResponse(page2, { limit: 1000, offset: 1000 }));
+
+      const result = await getAllFlashcardMappings();
+
+      expect(mockApiCall).toHaveBeenCalledTimes(2);
+      expect(result.size).toBe(1500);
+      // Second call should request next offset
+      const secondUrl = mockApiCall.mock.calls[1][0] as string;
+      expect(secondUrl).toContain('offset=1000');
+      expect(result.get('p1-0')).toEqual({ subtopic_id: 'sub-p1-0', keyword_id: 'kw-p1-0' });
+      expect(result.get('p2-499')).toEqual({ subtopic_id: 'sub-p2-499', keyword_id: 'kw-p2-499' });
+    });
+
+    it('stops after first page if exactly < limit items returned', async () => {
+      mockApiCall.mockResolvedValueOnce(
+        makeResponse([makeMapping('only-1'), makeMapping('only-2')], { limit: 1000, offset: 0 })
+      );
+      const result = await getAllFlashcardMappings();
+      expect(mockApiCall).toHaveBeenCalledTimes(1);
+      expect(result.size).toBe(2);
+    });
+
+    it('handles missing data array gracefully (treats as empty)', async () => {
+      // Defensive: source uses `response.data || []`
+      mockApiCall.mockResolvedValueOnce({ total: 0, limit: 1000, offset: 0 } as unknown as FlashcardMappingResponse);
+      const result = await getAllFlashcardMappings();
+      expect(result.size).toBe(0);
+      expect(mockApiCall).toHaveBeenCalledTimes(1);
+    });
+
+    it('later duplicate id overwrites earlier entry in Map', async () => {
+      const dup = [
+        makeMapping('dup', { keyword_id: 'kw-first' }),
+        makeMapping('other'),
+        makeMapping('dup', { keyword_id: 'kw-second' }),
+      ];
+      mockApiCall.mockResolvedValueOnce(makeResponse(dup));
+      const result = await getAllFlashcardMappings();
+      expect(result.size).toBe(2);
+      expect(result.get('dup')).toEqual({ subtopic_id: 'sub-dup', keyword_id: 'kw-second' });
+    });
+
+    it('propagates error from mid-pagination', async () => {
+      const page1 = Array.from({ length: 1000 }, (_, i) => makeMapping(`p1-${i}`));
+      mockApiCall
+        .mockResolvedValueOnce(makeResponse(page1, { limit: 1000, offset: 0 }))
+        .mockRejectedValueOnce(new Error('500 Internal'));
+      await expect(getAllFlashcardMappings()).rejects.toThrow('500 Internal');
+    });
+  });
+});

--- a/src/app/services/__tests__/keywordConnectionsApi.test.ts
+++ b/src/app/services/__tests__/keywordConnectionsApi.test.ts
@@ -1,0 +1,200 @@
+// ============================================================
+// Axon -- Tests for keywordConnectionsApi.ts
+//
+// GET    /keyword-connections?keyword_id=xxx
+// POST   /keyword-connections
+// DELETE /keyword-connections/:id
+// GET    /keyword-search?q=xxx&exclude_summary_id=yyy
+//
+// Mocks: @/app/lib/api (apiCall)
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import {
+  getConnections,
+  createConnection,
+  deleteConnection,
+  searchKeywords,
+} from '@/app/services/keywordConnectionsApi';
+import type { CreateConnectionInput } from '@/app/types/keyword-connections';
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// getConnections
+// ══════════════════════════════════════════════════════════════
+
+describe('getConnections', () => {
+  it('builds URL with keyword_id query param', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await getConnections('kw-1');
+    expect(mockApiCall.mock.calls[0][0]).toBe(
+      '/keyword-connections?keyword_id=kw-1',
+    );
+  });
+
+  it('returns array as-is when apiCall resolves to T[]', async () => {
+    const rows = [{ id: 'c1' }, { id: 'c2' }];
+    mockApiCall.mockResolvedValueOnce(rows);
+    expect(await getConnections('kw-1')).toEqual(rows);
+  });
+
+  it('extracts .items when apiCall resolves to { items }', async () => {
+    const rows = [{ id: 'c1' }];
+    mockApiCall.mockResolvedValueOnce({ items: rows });
+    expect(await getConnections('kw-1')).toEqual(rows);
+  });
+
+  it('returns [] when response is null', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    expect(await getConnections('kw-1')).toEqual([]);
+  });
+
+  it('returns [] when response is an object with no items key', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    expect(await getConnections('kw-1')).toEqual([]);
+  });
+
+  it('propagates errors from apiCall', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('oops'));
+    await expect(getConnections('kw-1')).rejects.toThrow('oops');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// createConnection
+// ══════════════════════════════════════════════════════════════
+
+describe('createConnection', () => {
+  const baseInput: CreateConnectionInput = {
+    keyword_a_id: 'A',
+    keyword_b_id: 'B',
+    relationship: 'causa de',
+    connection_type: 'related',
+    source_keyword_id: null,
+  };
+
+  it('POSTs to /keyword-connections with JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'conn-1' });
+
+    const result = await createConnection(baseInput);
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/keyword-connections');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(baseInput);
+    expect(result).toEqual({ id: 'conn-1' });
+  });
+
+  it('does NOT enforce canonical order (caller is responsible)', async () => {
+    // Caller passes keyword_b_id < keyword_a_id; we still forward verbatim.
+    const input: CreateConnectionInput = {
+      ...baseInput,
+      keyword_a_id: 'Z',
+      keyword_b_id: 'A',
+    };
+    mockApiCall.mockResolvedValueOnce({ id: 'x' });
+    await createConnection(input);
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body.keyword_a_id).toBe('Z');
+    expect(body.keyword_b_id).toBe('A');
+  });
+
+  it('propagates errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('409 conflict'));
+    await expect(createConnection(baseInput)).rejects.toThrow('409 conflict');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// deleteConnection
+// ══════════════════════════════════════════════════════════════
+
+describe('deleteConnection', () => {
+  it('DELETEs /keyword-connections/:id', async () => {
+    mockApiCall.mockResolvedValueOnce(undefined);
+    await deleteConnection('conn-42');
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/keyword-connections/conn-42');
+    expect(opts).toEqual({ method: 'DELETE' });
+  });
+
+  it('resolves to void even when apiCall returns a body', async () => {
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    const result = await deleteConnection('conn-42');
+    expect(result).toBeUndefined();
+  });
+
+  it('propagates errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('404'));
+    await expect(deleteConnection('c')).rejects.toThrow('404');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// searchKeywords
+// ══════════════════════════════════════════════════════════════
+
+describe('searchKeywords', () => {
+  it('builds /keyword-search?q=... URL', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await searchKeywords('pneumo');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('/keyword-search?');
+    expect(url).toContain('q=pneumo');
+  });
+
+  it('trims whitespace in q', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await searchKeywords('  pneumo  ');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('q=pneumo');
+    expect(url).not.toContain('%20%20');
+  });
+
+  it('appends exclude_summary_id when provided', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await searchKeywords('pneumo', 'sum-9');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('q=pneumo');
+    expect(url).toContain('exclude_summary_id=sum-9');
+  });
+
+  it('does NOT include exclude_summary_id when undefined', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await searchKeywords('pneumo');
+    expect(mockApiCall.mock.calls[0][0]).not.toContain('exclude_summary_id');
+  });
+
+  it('percent-encodes query values', async () => {
+    mockApiCall.mockResolvedValueOnce([]);
+    await searchKeywords('a b&c');
+    const url: string = mockApiCall.mock.calls[0][0];
+    // URLSearchParams uses '+' for spaces, and percent-encodes ampersands
+    expect(url).toMatch(/q=a\+b%26c|q=a%20b%26c/);
+  });
+
+  it('returns array when apiCall resolves to T[]', async () => {
+    const rows = [{ id: 'k1' }, { id: 'k2' }];
+    mockApiCall.mockResolvedValueOnce(rows);
+    expect(await searchKeywords('x')).toEqual(rows);
+  });
+
+  it('extracts .items when apiCall returns { items }', async () => {
+    const rows = [{ id: 'k1' }];
+    mockApiCall.mockResolvedValueOnce({ items: rows });
+    expect(await searchKeywords('x')).toEqual(rows);
+  });
+
+  it('returns [] when response is null', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    expect(await searchKeywords('x')).toEqual([]);
+  });
+});

--- a/src/app/services/__tests__/platformApi.test.ts
+++ b/src/app/services/__tests__/platformApi.test.ts
@@ -1,0 +1,505 @@
+// ============================================================
+// Axon -- Tests for platformApi.ts (barrel re-exporter)
+//
+// Exercises a representative slice of functions from each sub-module:
+//   - pa-institutions
+//   - pa-plans
+//   - pa-content
+//   - pa-flashcards
+//
+// Mocks apiCall to inspect URL, method, and body. Does NOT perform
+// real network I/O.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+}));
+
+import {
+  // institutions
+  getInstitutions,
+  getInstitution,
+  getInstitutionBySlug,
+  checkSlugAvailability,
+  createInstitution,
+  updateInstitution,
+  deleteInstitution,
+  getMembers,
+  createMember,
+  changeMemberRole,
+  changeMemberPlan,
+  toggleMemberActive,
+  deleteMember,
+  healthCheck,
+  getInstitutionDashboardStats,
+  PlatformApiError,
+  // plans
+  getPlatformPlans,
+  getPlatformPlan,
+  createPlatformPlan,
+  updatePlatformPlan,
+  deletePlatformPlan,
+  getInstitutionPlans,
+  createInstitutionPlan,
+  setDefaultInstitutionPlan,
+  getInstitutionSubscription,
+  createSubscription,
+  updateSubscription,
+  cancelSubscription,
+  // content
+  getCourses,
+  createCourse,
+  updateCourse,
+  deleteCourse,
+  getTopicSummaries,
+  createSummary,
+  updateSummary,
+  deleteSummary,
+  getKeywords,
+  createKeyword,
+  updateKeyword,
+  deleteKeyword,
+  // flashcards
+  getFlashcards,
+  getFlashcardsBySummary,
+  getFlashcardsByKeyword,
+  getFlashcard,
+  createFlashcard,
+  updateFlashcard,
+  deleteFlashcard,
+} from '@/app/services/platformApi';
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+  mockApiCall.mockResolvedValue([]);
+});
+
+function lastCall() {
+  return mockApiCall.mock.calls[mockApiCall.mock.calls.length - 1];
+}
+function lastUrl(): string {
+  return lastCall()[0] as string;
+}
+function lastOpts(): { method?: string; body?: string } | undefined {
+  return lastCall()[1] as any;
+}
+
+// ================================================================
+// MISC RE-EXPORTS
+// ================================================================
+
+describe('platformApi — PlatformApiError re-export', () => {
+  it('exports an error class', () => {
+    expect(typeof PlatformApiError).toBe('function');
+  });
+});
+
+// ================================================================
+// INSTITUTIONS
+// ================================================================
+
+describe('platformApi — institutions', () => {
+  it('getInstitutions calls GET /institutions and extracts items', async () => {
+    mockApiCall.mockResolvedValueOnce([{ id: 'a' }, { id: 'b' }]);
+    const result = await getInstitutions();
+    expect(lastUrl()).toBe('/institutions');
+    expect(result).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
+
+  it('getInstitutions extracts items when wrapped in { items: [] }', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [{ id: 'x' }] });
+    const result = await getInstitutions();
+    expect(result).toEqual([{ id: 'x' }]);
+  });
+
+  it('getInstitution calls GET /institutions/:id', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'inst-1', name: 'Test' });
+    const result = await getInstitution('inst-1');
+    expect(lastUrl()).toBe('/institutions/inst-1');
+    expect(result).toEqual({ id: 'inst-1', name: 'Test' });
+  });
+
+  it('getInstitutionBySlug calls GET /institutions/by-slug/:slug', async () => {
+    await getInstitutionBySlug('my-org');
+    expect(lastUrl()).toBe('/institutions/by-slug/my-org');
+  });
+
+  it('checkSlugAvailability calls GET /institutions/check-slug/:slug', async () => {
+    mockApiCall.mockResolvedValueOnce({ available: true });
+    const result = await checkSlugAvailability('fresh-slug');
+    expect(lastUrl()).toBe('/institutions/check-slug/fresh-slug');
+    expect(result).toEqual({ available: true });
+  });
+
+  it('createInstitution sends POST with JSON body', async () => {
+    await createInstitution({ name: 'Org', slug: 'org' });
+    expect(lastUrl()).toBe('/institutions');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ name: 'Org', slug: 'org' });
+  });
+
+  it('updateInstitution sends PUT with partial JSON body', async () => {
+    await updateInstitution('inst-1', { name: 'Renamed' } as any);
+    expect(lastUrl()).toBe('/institutions/inst-1');
+    expect(lastOpts()?.method).toBe('PUT');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ name: 'Renamed' });
+  });
+
+  it('deleteInstitution sends DELETE and no body', async () => {
+    await deleteInstitution('inst-1');
+    expect(lastUrl()).toBe('/institutions/inst-1');
+    expect(lastOpts()?.method).toBe('DELETE');
+    expect(lastOpts()?.body).toBeUndefined();
+  });
+
+  it('getMembers calls GET /memberships?institution_id=', async () => {
+    mockApiCall.mockResolvedValueOnce([{ id: 'm1' }]);
+    await getMembers('inst-1');
+    expect(lastUrl()).toBe('/memberships?institution_id=inst-1');
+  });
+
+  it('createMember sends POST /members with payload', async () => {
+    await createMember({ institution_id: 'inst-1', role: 'student', email: 'a@b.c' } as any);
+    expect(lastUrl()).toBe('/members');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!).email).toBe('a@b.c');
+  });
+
+  it('changeMemberRole sends PATCH /members/:id/role with { role }', async () => {
+    await changeMemberRole('m1', 'professor' as any);
+    expect(lastUrl()).toBe('/members/m1/role');
+    expect(lastOpts()?.method).toBe('PATCH');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ role: 'professor' });
+  });
+
+  it('changeMemberPlan sends PATCH /members/:id/plan with institution_plan_id', async () => {
+    await changeMemberPlan('m1', 'plan-xyz');
+    expect(lastUrl()).toBe('/members/m1/plan');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ institution_plan_id: 'plan-xyz' });
+  });
+
+  it('changeMemberPlan accepts null for removing plan', async () => {
+    await changeMemberPlan('m1', null);
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ institution_plan_id: null });
+  });
+
+  it('toggleMemberActive sends PATCH with { is_active }', async () => {
+    await toggleMemberActive('m1', false);
+    expect(lastUrl()).toBe('/members/m1/toggle-active');
+    expect(lastOpts()?.method).toBe('PATCH');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ is_active: false });
+  });
+
+  it('deleteMember sends DELETE /members/:id', async () => {
+    await deleteMember('m1');
+    expect(lastUrl()).toBe('/members/m1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+
+  it('healthCheck calls GET /health', async () => {
+    mockApiCall.mockResolvedValueOnce({ status: 'ok' });
+    const result = await healthCheck();
+    expect(lastUrl()).toBe('/health');
+    expect(result).toEqual({ status: 'ok' });
+  });
+});
+
+// ================================================================
+// DASHBOARD STATS (aggregator — exercises both getMembers and getInstitution)
+// ================================================================
+
+describe('platformApi — getInstitutionDashboardStats', () => {
+  it('returns aggregated stats from memberships + institution', async () => {
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/memberships')) {
+        return [
+          { id: 'm1', role: 'student', is_active: true },
+          { id: 'm2', role: 'student', is_active: false },
+          { id: 'm3', role: 'professor', is_active: true },
+        ];
+      }
+      if (url.startsWith('/institutions/')) return { id: 'inst-1', name: 'Test Inst' };
+      return null;
+    });
+
+    const stats = await getInstitutionDashboardStats('inst-1');
+    expect(stats.institutionName).toBe('Test Inst');
+    expect(stats.hasInstitution).toBe(true);
+    expect(stats.totalMembers).toBe(3);
+    expect(stats.activeStudents).toBe(1);
+    expect(stats.inactiveMembers).toBe(1);
+    expect(stats.membersByRole).toEqual({ student: 2, professor: 1 });
+  });
+
+  it('returns fallback shape when both requests fail', async () => {
+    // Make the *top-level* function behave as if the try/catch triggers.
+    // Since Promise.allSettled never throws, the try/catch path only runs
+    // if something inside it throws. extractItems throws on non-array-like,
+    // but it handles null gracefully, so set members to raw null/undefined
+    // and pretend it's an exception via mockImplementation throwing.
+    // Simpler: make extractItems return [] by returning null -> falsy, then
+    // institution null. The function returns a valid empty shape with
+    // institutionName ''.
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/memberships')) return null;
+      if (url.startsWith('/institutions/')) return null;
+      return null;
+    });
+
+    const stats = await getInstitutionDashboardStats('inst-1');
+    expect(stats.totalMembers).toBe(0);
+    expect(stats.activeStudents).toBe(0);
+    expect(stats.inactiveMembers).toBe(0);
+    expect(stats.membersByRole).toEqual({});
+  });
+});
+
+// ================================================================
+// PLATFORM PLANS + INSTITUTION PLANS + SUBSCRIPTIONS
+// ================================================================
+
+describe('platformApi — plans & subscriptions', () => {
+  it('getPlatformPlans without includeInactive omits query', async () => {
+    await getPlatformPlans();
+    expect(lastUrl()).toBe('/platform-plans');
+  });
+
+  it('getPlatformPlans with includeInactive=true appends ?include_inactive=true', async () => {
+    await getPlatformPlans(true);
+    expect(lastUrl()).toBe('/platform-plans?include_inactive=true');
+  });
+
+  it('getPlatformPlan calls GET /platform-plans/:id', async () => {
+    await getPlatformPlan('plan-1');
+    expect(lastUrl()).toBe('/platform-plans/plan-1');
+  });
+
+  it('createPlatformPlan sends POST with JSON body', async () => {
+    await createPlatformPlan({ name: 'Starter' } as any);
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ name: 'Starter' });
+  });
+
+  it('updatePlatformPlan sends PUT with JSON body', async () => {
+    await updatePlatformPlan('plan-1', { name: 'Pro' } as any);
+    expect(lastUrl()).toBe('/platform-plans/plan-1');
+    expect(lastOpts()?.method).toBe('PUT');
+  });
+
+  it('deletePlatformPlan sends DELETE', async () => {
+    await deletePlatformPlan('plan-1');
+    expect(lastUrl()).toBe('/platform-plans/plan-1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+
+  it('getInstitutionPlans builds URL with institution_id and optional include_inactive', async () => {
+    await getInstitutionPlans('inst-1');
+    expect(lastUrl()).toBe('/institution-plans?institution_id=inst-1');
+
+    await getInstitutionPlans('inst-1', true);
+    expect(lastUrl()).toContain('institution_id=inst-1');
+    expect(lastUrl()).toContain('include_inactive=true');
+  });
+
+  it('createInstitutionPlan posts to /institution-plans with payload', async () => {
+    await createInstitutionPlan({ institution_id: 'inst-1', name: 'Basic' });
+    expect(lastUrl()).toBe('/institution-plans');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!).name).toBe('Basic');
+  });
+
+  it('setDefaultInstitutionPlan sends PATCH /:id/set-default with no body', async () => {
+    await setDefaultInstitutionPlan('plan-1');
+    expect(lastUrl()).toBe('/institution-plans/plan-1/set-default');
+    expect(lastOpts()?.method).toBe('PATCH');
+    expect(lastOpts()?.body).toBeUndefined();
+  });
+
+  it('getInstitutionSubscription calls GET /institution-subscriptions?institution_id=', async () => {
+    await getInstitutionSubscription('inst-1');
+    expect(lastUrl()).toBe('/institution-subscriptions?institution_id=inst-1');
+  });
+
+  it('createSubscription posts JSON body to /institution-subscriptions', async () => {
+    await createSubscription({ institution_id: 'inst-1', plan_id: 'plan-1' });
+    expect(lastUrl()).toBe('/institution-subscriptions');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ institution_id: 'inst-1', plan_id: 'plan-1' });
+  });
+
+  it('updateSubscription sends PUT /institution-subscriptions/:id', async () => {
+    await updateSubscription('sub-1', { status: 'active' } as any);
+    expect(lastUrl()).toBe('/institution-subscriptions/sub-1');
+    expect(lastOpts()?.method).toBe('PUT');
+  });
+
+  it('cancelSubscription sends DELETE /institution-subscriptions/:id', async () => {
+    await cancelSubscription('sub-1');
+    expect(lastUrl()).toBe('/institution-subscriptions/sub-1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+});
+
+// ================================================================
+// CONTENT (courses, summaries, keywords)
+// ================================================================
+
+describe('platformApi — content (courses/summaries/keywords)', () => {
+  it('getCourses without institutionId omits query', async () => {
+    await getCourses();
+    expect(lastUrl()).toBe('/courses');
+  });
+
+  it('getCourses with institutionId appends query param', async () => {
+    await getCourses('inst-1');
+    expect(lastUrl()).toBe('/courses?institution_id=inst-1');
+  });
+
+  it('createCourse posts JSON body to /courses', async () => {
+    await createCourse({ name: 'Math', institution_id: 'inst-1' });
+    expect(lastUrl()).toBe('/courses');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ name: 'Math', institution_id: 'inst-1' });
+  });
+
+  it('updateCourse sends PUT /courses/:id', async () => {
+    await updateCourse('c1', { name: 'New' });
+    expect(lastUrl()).toBe('/courses/c1');
+    expect(lastOpts()?.method).toBe('PUT');
+  });
+
+  it('deleteCourse sends DELETE /courses/:id', async () => {
+    await deleteCourse('c1');
+    expect(lastUrl()).toBe('/courses/c1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+
+  it('getTopicSummaries calls GET /summaries?topic_id=', async () => {
+    await getTopicSummaries('topic-1');
+    expect(lastUrl()).toBe('/summaries?topic_id=topic-1');
+  });
+
+  it('createSummary merges topic_id into body', async () => {
+    await createSummary('topic-1', { content_markdown: 'body' });
+    expect(lastUrl()).toBe('/summaries');
+    const body = JSON.parse(lastOpts()!.body!);
+    expect(body.topic_id).toBe('topic-1');
+    expect(body.content_markdown).toBe('body');
+  });
+
+  it('updateSummary sends PUT /summaries/:id', async () => {
+    await updateSummary('sum-1', { title: 'Renamed' });
+    expect(lastUrl()).toBe('/summaries/sum-1');
+    expect(lastOpts()?.method).toBe('PUT');
+  });
+
+  it('deleteSummary sends DELETE /summaries/:id', async () => {
+    await deleteSummary('sum-1');
+    expect(lastUrl()).toBe('/summaries/sum-1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+
+  it('getKeywords without institutionId omits query', async () => {
+    await getKeywords();
+    expect(lastUrl()).toBe('/keywords');
+  });
+
+  it('getKeywords with institutionId appends query', async () => {
+    await getKeywords('inst-1');
+    expect(lastUrl()).toBe('/keywords?institution_id=inst-1');
+  });
+
+  it('createKeyword posts JSON body to /keywords', async () => {
+    await createKeyword({ institution_id: 'inst-1', term: 'Mitosis' });
+    expect(lastUrl()).toBe('/keywords');
+    const body = JSON.parse(lastOpts()!.body!);
+    expect(body.institution_id).toBe('inst-1');
+    expect(body.term).toBe('Mitosis');
+  });
+
+  it('updateKeyword sends PUT /keywords/:id', async () => {
+    await updateKeyword('k1', { term: 'Meiosis' });
+    expect(lastUrl()).toBe('/keywords/k1');
+    expect(lastOpts()?.method).toBe('PUT');
+  });
+
+  it('deleteKeyword sends DELETE /keywords/:id', async () => {
+    await deleteKeyword('k1');
+    expect(lastUrl()).toBe('/keywords/k1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+});
+
+// ================================================================
+// FLASHCARDS
+// ================================================================
+
+describe('platformApi — flashcards', () => {
+  it('getFlashcardsBySummary filters by summary_id', async () => {
+    mockApiCall.mockResolvedValueOnce([{ id: 'c1' }, { id: 'c2' }]);
+    const result = await getFlashcardsBySummary('sum-1');
+    expect(lastUrl()).toBe('/flashcards?summary_id=sum-1');
+    expect(result).toEqual([{ id: 'c1' }, { id: 'c2' }]);
+  });
+
+  it('getFlashcardsByKeyword filters by keyword_id', async () => {
+    await getFlashcardsByKeyword('k1');
+    expect(lastUrl()).toBe('/flashcards?keyword_id=k1');
+  });
+
+  it('getFlashcards without options hits /flashcards (no query)', async () => {
+    await getFlashcards();
+    expect(lastUrl()).toBe('/flashcards');
+  });
+
+  it('getFlashcards builds query string from options', async () => {
+    await getFlashcards({
+      subtopic_id: 'sub-1',
+      status: 'published',
+      limit: 50,
+      offset: 10,
+    });
+    const url = lastUrl();
+    expect(url.startsWith('/flashcards?')).toBe(true);
+    expect(url).toContain('subtopic_id=sub-1');
+    expect(url).toContain('status=published');
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=10');
+  });
+
+  it('getFlashcards returns [] when response is not an items array', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    const result = await getFlashcards();
+    expect(result).toEqual([]);
+  });
+
+  it('getFlashcard calls GET /flashcards/:id', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'card-1' });
+    const result = await getFlashcard('card-1');
+    expect(lastUrl()).toBe('/flashcards/card-1');
+    expect(result).toEqual({ id: 'card-1' });
+  });
+
+  it('createFlashcard posts JSON body to /flashcards', async () => {
+    await createFlashcard({ front: 'Q', back: 'A' } as any);
+    expect(lastUrl()).toBe('/flashcards');
+    expect(lastOpts()?.method).toBe('POST');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ front: 'Q', back: 'A' });
+  });
+
+  it('updateFlashcard sends PUT /flashcards/:id', async () => {
+    await updateFlashcard('card-1', { front: 'NewQ' });
+    expect(lastUrl()).toBe('/flashcards/card-1');
+    expect(lastOpts()?.method).toBe('PUT');
+    expect(JSON.parse(lastOpts()!.body!)).toEqual({ front: 'NewQ' });
+  });
+
+  it('deleteFlashcard sends DELETE /flashcards/:id', async () => {
+    await deleteFlashcard('card-1');
+    expect(lastUrl()).toBe('/flashcards/card-1');
+    expect(lastOpts()?.method).toBe('DELETE');
+  });
+});

--- a/src/app/services/__tests__/quizApi.test.ts
+++ b/src/app/services/__tests__/quizApi.test.ts
@@ -1,0 +1,134 @@
+// ============================================================
+// quizApi.test.ts — Tests for the quizApi barrel re-exporter.
+//
+// quizApi.ts is a thin barrel that re-exports functions and types
+// from domain-specific modules:
+//   - quizQuestionsApi
+//   - quizzesEntityApi
+//   - quizAttemptsApi
+//   - reviewsApi
+//   - smartGenerateApi
+//   - studySessionApi
+//   - bktApi
+//   - quizConstants (types only)
+//
+// These tests guard the public API surface so consumers keep
+// importing from '@/app/services/quizApi' without surprises.
+// ============================================================
+
+import { describe, it, expect } from 'vitest';
+
+import * as quizApi from '@/app/services/quizApi';
+
+describe('quizApi barrel', () => {
+  describe('Quiz Questions re-exports', () => {
+    it('re-exports getQuizQuestions as a function', () => {
+      expect(typeof quizApi.getQuizQuestions).toBe('function');
+    });
+
+    it('re-exports getQuizQuestion as a function', () => {
+      expect(typeof quizApi.getQuizQuestion).toBe('function');
+    });
+
+    it('re-exports createQuizQuestion as a function', () => {
+      expect(typeof quizApi.createQuizQuestion).toBe('function');
+    });
+
+    it('re-exports updateQuizQuestion as a function', () => {
+      expect(typeof quizApi.updateQuizQuestion).toBe('function');
+    });
+
+    it('re-exports deleteQuizQuestion as a function', () => {
+      expect(typeof quizApi.deleteQuizQuestion).toBe('function');
+    });
+
+    it('re-exports restoreQuizQuestion as a function', () => {
+      expect(typeof quizApi.restoreQuizQuestion).toBe('function');
+    });
+  });
+
+  describe('Quiz Entity re-exports', () => {
+    it('re-exports getQuizzes', () => {
+      expect(typeof quizApi.getQuizzes).toBe('function');
+    });
+
+    it('re-exports createQuiz', () => {
+      expect(typeof quizApi.createQuiz).toBe('function');
+    });
+
+    it('re-exports updateQuiz', () => {
+      expect(typeof quizApi.updateQuiz).toBe('function');
+    });
+
+    it('re-exports deleteQuiz', () => {
+      expect(typeof quizApi.deleteQuiz).toBe('function');
+    });
+
+    it('re-exports restoreQuiz', () => {
+      expect(typeof quizApi.restoreQuiz).toBe('function');
+    });
+  });
+
+  describe('Quiz Attempt re-exports', () => {
+    it('re-exports createQuizAttempt', () => {
+      expect(typeof quizApi.createQuizAttempt).toBe('function');
+    });
+
+    it('re-exports getQuizAttempts', () => {
+      expect(typeof quizApi.getQuizAttempts).toBe('function');
+    });
+  });
+
+  describe('Review re-exports', () => {
+    it('re-exports createReview', () => {
+      expect(typeof quizApi.createReview).toBe('function');
+    });
+  });
+
+  describe('Smart Generation re-exports', () => {
+    it('re-exports generateSmartQuiz', () => {
+      expect(typeof quizApi.generateSmartQuiz).toBe('function');
+    });
+  });
+
+  describe('Study Session re-exports (P2-S01)', () => {
+    it('re-exports createStudySession', () => {
+      expect(typeof quizApi.createStudySession).toBe('function');
+    });
+
+    it('re-exports closeStudySession', () => {
+      expect(typeof quizApi.closeStudySession).toBe('function');
+    });
+
+    it('re-exports getStudySessions', () => {
+      expect(typeof quizApi.getStudySessions).toBe('function');
+    });
+  });
+
+  describe('BKT re-exports (P2-S01)', () => {
+    it('re-exports upsertBktState', () => {
+      expect(typeof quizApi.upsertBktState).toBe('function');
+    });
+
+    it('re-exports getBktStates', () => {
+      expect(typeof quizApi.getBktStates).toBe('function');
+    });
+  });
+
+  describe('Barrel identity (same function reference across imports)', () => {
+    it('getQuizQuestions from barrel is the same reference as from quizQuestionsApi', async () => {
+      const mod = await import('@/app/services/quizQuestionsApi');
+      expect(quizApi.getQuizQuestions).toBe(mod.getQuizQuestions);
+    });
+
+    it('createQuiz from barrel is the same reference as from quizzesEntityApi', async () => {
+      const mod = await import('@/app/services/quizzesEntityApi');
+      expect(quizApi.createQuiz).toBe(mod.createQuiz);
+    });
+
+    it('createQuizAttempt from barrel is the same reference as from quizAttemptsApi', async () => {
+      const mod = await import('@/app/services/quizAttemptsApi');
+      expect(quizApi.createQuizAttempt).toBe(mod.createQuizAttempt);
+    });
+  });
+});

--- a/src/app/services/__tests__/quizAttemptsApi.test.ts
+++ b/src/app/services/__tests__/quizAttemptsApi.test.ts
@@ -1,0 +1,182 @@
+// ============================================================
+// quizAttemptsApi.test.ts — POST/GET /quiz-attempts
+//
+// Covers:
+//   - createQuizAttempt: POST with JSON body, optional fields
+//   - getQuizAttempts: URL query construction, filters, edge cases
+//
+// Mocks @/app/lib/api apiCall; checks URL, method, body.
+//
+// Table map reminder:
+//   quiz_attempts stores each student answer. It references
+//   quiz_question_id and study_sessions.session_id. It does NOT
+//   hold block_id — block_id only lives on quiz_questions.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import { createQuizAttempt, getQuizAttempts } from '../quizAttemptsApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Fixtures ─────────────────────────────────────────────
+
+const baseAttempt = {
+  quiz_question_id: 'qq-100',
+  answer: 'B',
+  is_correct: true,
+};
+
+const fullAttempt = {
+  ...baseAttempt,
+  session_id: 'sess-42',
+  time_taken_ms: 1234,
+};
+
+const attemptFromServer = {
+  id: 'qa-001',
+  quiz_question_id: 'qq-100',
+  student_id: 'stu-1',
+  answer: 'B',
+  is_correct: true,
+  session_id: 'sess-42',
+  time_taken_ms: 1234,
+  created_at: '2026-04-18T12:00:00.000Z',
+};
+
+// ── Tests ────────────────────────────────────────────────
+
+describe('quizAttemptsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createQuizAttempt', () => {
+    it('POSTs to /quiz-attempts with stringified body', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      await createQuizAttempt(fullAttempt);
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-attempts', {
+        method: 'POST',
+        body: JSON.stringify(fullAttempt),
+      });
+    });
+
+    it('includes is_correct: true when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      await createQuizAttempt({ ...baseAttempt, is_correct: true });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.is_correct).toBe(true);
+    });
+
+    it('includes is_correct: false when provided', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...attemptFromServer, is_correct: false });
+      await createQuizAttempt({ ...baseAttempt, is_correct: false });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.is_correct).toBe(false);
+    });
+
+    it('omits session_id/time_taken_ms when not provided', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      await createQuizAttempt(baseAttempt);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).not.toHaveProperty('session_id');
+      expect(body).not.toHaveProperty('time_taken_ms');
+    });
+
+    it('does NOT include student_id in the payload (server derives it from the token)', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      await createQuizAttempt(fullAttempt);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).not.toHaveProperty('student_id');
+      expect(body).not.toHaveProperty('created_by');
+    });
+
+    it('returns the attempt from the server', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      const out = await createQuizAttempt(fullAttempt);
+      expect(out).toEqual(attemptFromServer);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('400 Bad Request'));
+      await expect(createQuizAttempt(baseAttempt)).rejects.toThrow('400 Bad Request');
+    });
+
+    it('supports time_taken_ms = 0 (instant answer)', async () => {
+      mockApiCall.mockResolvedValueOnce(attemptFromServer);
+      await createQuizAttempt({ ...baseAttempt, time_taken_ms: 0 });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.time_taken_ms).toBe(0);
+    });
+  });
+
+  describe('getQuizAttempts', () => {
+    it('GETs /quiz-attempts with empty query string when no filters set', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getQuizAttempts({});
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toBe('/quiz-attempts?');
+      // No method specified → defaults to GET in apiCall
+      expect(mockApiCall.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it('includes session_id filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce([attemptFromServer]);
+      await getQuizAttempts({ session_id: 'sess-42' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('session_id=sess-42');
+    });
+
+    it('includes quiz_question_id filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce([attemptFromServer]);
+      await getQuizAttempts({ quiz_question_id: 'qq-100' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('quiz_question_id=qq-100');
+    });
+
+    it('combines both filters when provided', async () => {
+      mockApiCall.mockResolvedValueOnce([attemptFromServer]);
+      await getQuizAttempts({ session_id: 'sess-42', quiz_question_id: 'qq-100' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('session_id=sess-42');
+      expect(url).toContain('quiz_question_id=qq-100');
+    });
+
+    it('returns the flat array from apiCall', async () => {
+      const arr = [attemptFromServer, { ...attemptFromServer, id: 'qa-002' }];
+      mockApiCall.mockResolvedValueOnce(arr);
+
+      const out = await getQuizAttempts({ session_id: 'sess-42' });
+      expect(out).toEqual(arr);
+      expect(Array.isArray(out)).toBe(true);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('Network error'));
+      await expect(getQuizAttempts({ session_id: 'sess-1' })).rejects.toThrow('Network error');
+    });
+
+    it('URL-encodes special characters in filter values', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getQuizAttempts({ session_id: 'sess with spaces' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('session_id=sess+with+spaces');
+    });
+  });
+});

--- a/src/app/services/__tests__/quizQuestionsApi.test.ts
+++ b/src/app/services/__tests__/quizQuestionsApi.test.ts
@@ -1,0 +1,394 @@
+// ============================================================
+// quizQuestionsApi.test.ts — CRUD for /quiz-questions
+//
+// Covers:
+//   - getQuizQuestions: URL construction, filters, difficulty
+//     normalization, pagination
+//   - getQuizQuestion: single fetch
+//   - createQuizQuestion, updateQuizQuestion: POST/PUT payloads
+//   - deleteQuizQuestion (soft), restoreQuizQuestion
+//
+// Table map reminder:
+//   quiz_questions is the ONLY quiz table with block_id. Per-block
+//   filtering MUST go through quiz_questions.block_id. The quizzes
+//   entity table does not expose block_id.
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import {
+  getQuizQuestions,
+  getQuizQuestion,
+  createQuizQuestion,
+  updateQuizQuestion,
+  deleteQuizQuestion,
+  restoreQuizQuestion,
+} from '../quizQuestionsApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Fixtures ─────────────────────────────────────────────
+
+const baseListResponse = {
+  items: [],
+  total: 0,
+  limit: 100,
+  offset: 0,
+};
+
+const sampleQuestion = {
+  id: 'qq-1',
+  summary_id: 'sum-1',
+  keyword_id: 'kw-1',
+  block_id: 'blk-1',
+  subtopic_id: null,
+  question_type: 'mcq' as const,
+  question: 'What is 2+2?',
+  options: ['3', '4', '5', '6'],
+  correct_answer: '4',
+  explanation: 'basic arithmetic',
+  difficulty: 1,
+  source: 'manual' as const,
+  is_active: true,
+  created_by: 'user-1',
+  created_at: '2026-04-18T12:00:00.000Z',
+  updated_at: '2026-04-18T12:00:00.000Z',
+};
+
+// ── Tests ────────────────────────────────────────────────
+
+describe('quizQuestionsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ══════════════════════════════════════════════════════
+  // getQuizQuestions
+  // ══════════════════════════════════════════════════════
+
+  describe('getQuizQuestions', () => {
+    it('builds a flat /quiz-questions URL with summary_id query param', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1');
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toMatch(/^\/quiz-questions\?/);
+      expect(url).toContain('summary_id=sum-1');
+      expect(url).not.toMatch(/\/summaries\//);
+    });
+
+    it('appends keyword_id filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { keyword_id: 'kw-9' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('keyword_id=kw-9');
+    });
+
+    it('appends block_id filter for per-block quiz scoping (ADR-001)', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { block_id: 'blk-42' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('block_id=blk-42');
+    });
+
+    it('appends question_type filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { question_type: 'true_false' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('question_type=true_false');
+    });
+
+    it('appends quiz_id filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { quiz_id: 'quiz-xyz' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('quiz_id=quiz-xyz');
+    });
+
+    it('normalizes string difficulty → integer (easy → 1)', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { difficulty: 'easy' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('difficulty=1');
+      expect(url).not.toContain('difficulty=easy');
+    });
+
+    it('normalizes string difficulty → integer (medium → 2)', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { difficulty: 'medium' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('difficulty=2');
+    });
+
+    it('normalizes string difficulty → integer (hard → 3)', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { difficulty: 'hard' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('difficulty=3');
+    });
+
+    it('passes integer difficulty through as-is', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', { difficulty: 2 });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('difficulty=2');
+    });
+
+    it('appends limit/offset for pagination', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...baseListResponse, limit: 25, offset: 50 });
+      await getQuizQuestions('sum-1', { limit: 25, offset: 50 });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('limit=25');
+      expect(url).toContain('offset=50');
+    });
+
+    it('combines multiple filters in one request', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizQuestions('sum-1', {
+        keyword_id: 'kw-1',
+        block_id: 'blk-1',
+        question_type: 'mcq',
+        difficulty: 3,
+        quiz_id: 'quiz-1',
+        limit: 10,
+        offset: 0,
+      });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('summary_id=sum-1');
+      expect(url).toContain('keyword_id=kw-1');
+      expect(url).toContain('block_id=blk-1');
+      expect(url).toContain('question_type=mcq');
+      expect(url).toContain('difficulty=3');
+      expect(url).toContain('quiz_id=quiz-1');
+      expect(url).toContain('limit=10');
+      // offset=0 is falsy and is intentionally NOT appended by the
+      // current implementation. This is the observed behaviour.
+      expect(url).not.toContain('offset=0');
+    });
+
+    it('returns the list response from apiCall', async () => {
+      const full = {
+        items: [sampleQuestion],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      };
+      mockApiCall.mockResolvedValueOnce(full);
+
+      const out = await getQuizQuestions('sum-1');
+      expect(out).toEqual(full);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('500 Server Error'));
+      await expect(getQuizQuestions('sum-1')).rejects.toThrow('500 Server Error');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // getQuizQuestion
+  // ══════════════════════════════════════════════════════
+
+  describe('getQuizQuestion', () => {
+    it('fetches by id at /quiz-questions/:id', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      await getQuizQuestion('qq-1');
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-questions/qq-1');
+    });
+
+    it('returns the question from the server', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      const out = await getQuizQuestion('qq-1');
+      expect(out).toEqual(sampleQuestion);
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // createQuizQuestion
+  // ══════════════════════════════════════════════════════
+
+  describe('createQuizQuestion', () => {
+    it('POSTs to /quiz-questions with a JSON body', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        keyword_id: 'kw-1',
+        question_type: 'mcq' as const,
+        question: 'What?',
+        correct_answer: 'A',
+        options: ['A', 'B'],
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, ...payload });
+
+      await createQuizQuestion(payload);
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-questions', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    });
+
+    it('includes block_id in the payload when provided (per-block link)', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        block_id: 'blk-99',
+        question_type: 'mcq' as const,
+        question: 'Q',
+        correct_answer: 'A',
+        options: ['A', 'B', 'C', 'D'],
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, ...payload });
+
+      await createQuizQuestion(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.block_id).toBe('blk-99');
+    });
+
+    it('supports AI-source questions', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        keyword_id: 'kw-1',
+        question_type: 'open' as const,
+        question: 'Describe X',
+        correct_answer: 'answer',
+        source: 'ai' as const,
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, ...payload });
+
+      await createQuizQuestion(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.source).toBe('ai');
+    });
+
+    it('does NOT inject student_id or created_by (server derives them)', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        question_type: 'mcq' as const,
+        question: 'Q',
+        correct_answer: 'A',
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, ...payload });
+
+      await createQuizQuestion(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).not.toHaveProperty('student_id');
+      expect(body).not.toHaveProperty('created_by');
+    });
+
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('422 Unprocessable'));
+      await expect(
+        createQuizQuestion({
+          summary_id: 'sum-1',
+          question_type: 'mcq',
+          question: 'Q',
+          correct_answer: 'A',
+        })
+      ).rejects.toThrow('422 Unprocessable');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // updateQuizQuestion
+  // ══════════════════════════════════════════════════════
+
+  describe('updateQuizQuestion', () => {
+    it('PUTs to /quiz-questions/:id with a JSON body', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      await updateQuizQuestion('qq-1', { question: 'Edited?' });
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-questions/qq-1', {
+        method: 'PUT',
+        body: JSON.stringify({ question: 'Edited?' }),
+      });
+    });
+
+    it('can toggle is_active', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, is_active: false });
+      await updateQuizQuestion('qq-1', { is_active: false });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.is_active).toBe(false);
+    });
+
+    it('accepts quiz_id and subtopic_id (BA-05 update fields)', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      await updateQuizQuestion('qq-1', { quiz_id: 'new-quiz', subtopic_id: 'sub-1' });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.quiz_id).toBe('new-quiz');
+      expect(body.subtopic_id).toBe('sub-1');
+    });
+
+    it('accepts options: null to clear MCQ options', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuestion, options: null });
+      await updateQuizQuestion('qq-1', { options: null });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.options).toBeNull();
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // deleteQuizQuestion
+  // ══════════════════════════════════════════════════════
+
+  describe('deleteQuizQuestion', () => {
+    it('issues DELETE /quiz-questions/:id', async () => {
+      mockApiCall.mockResolvedValueOnce(undefined);
+      await deleteQuizQuestion('qq-1');
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-questions/qq-1', { method: 'DELETE' });
+    });
+
+    it('resolves to undefined (soft-delete, no body returned)', async () => {
+      mockApiCall.mockResolvedValueOnce(undefined);
+      const out = await deleteQuizQuestion('qq-1');
+      expect(out).toBeUndefined();
+    });
+
+    it('propagates 404 errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('404 Not Found'));
+      await expect(deleteQuizQuestion('missing')).rejects.toThrow('404 Not Found');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // restoreQuizQuestion
+  // ══════════════════════════════════════════════════════
+
+  describe('restoreQuizQuestion', () => {
+    it('issues PUT /quiz-questions/:id/restore', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      await restoreQuizQuestion('qq-1');
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quiz-questions/qq-1/restore', {
+        method: 'PUT',
+      });
+    });
+
+    it('returns the restored question', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuestion);
+      const out = await restoreQuizQuestion('qq-1');
+      expect(out).toEqual(sampleQuestion);
+    });
+  });
+});

--- a/src/app/services/__tests__/quizzesEntityApi.test.ts
+++ b/src/app/services/__tests__/quizzesEntityApi.test.ts
@@ -1,0 +1,315 @@
+// ============================================================
+// quizzesEntityApi.test.ts — CRUD for /quizzes entity (container)
+//
+// The `quizzes` table is a container/grouper (title + optional
+// time_limit_seconds). Per-block scoping is done at the
+// `quiz_questions.block_id` level, NOT here.
+//
+// Covers:
+//   - getQuizzes: URL construction, filters, pagination
+//   - createQuiz: POST payload shape
+//   - updateQuiz: PUT payload (title, description, is_active,
+//     time_limit_seconds)
+//   - deleteQuiz (soft) / restoreQuiz
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import {
+  getQuizzes,
+  createQuiz,
+  updateQuiz,
+  deleteQuiz,
+  restoreQuiz,
+} from '../quizzesEntityApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Fixtures ─────────────────────────────────────────────
+
+const baseListResponse = {
+  items: [],
+  total: 0,
+  limit: 100,
+  offset: 0,
+};
+
+const sampleQuiz = {
+  id: 'quiz-1',
+  summary_id: 'sum-1',
+  title: 'Sample Quiz',
+  description: 'A quiz for testing',
+  source: 'manual' as const,
+  is_active: true,
+  block_id: null,
+  time_limit_seconds: 30,
+  created_by: 'user-1',
+  created_at: '2026-04-18T12:00:00.000Z',
+  updated_at: '2026-04-18T12:00:00.000Z',
+};
+
+// ── Tests ────────────────────────────────────────────────
+
+describe('quizzesEntityApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ══════════════════════════════════════════════════════
+  // getQuizzes
+  // ══════════════════════════════════════════════════════
+
+  describe('getQuizzes', () => {
+    it('builds a flat /quizzes URL with summary_id query param', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1');
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toMatch(/^\/quizzes\?/);
+      expect(url).toContain('summary_id=sum-1');
+      expect(url).not.toMatch(/\/summaries\//);
+    });
+
+    it('does NOT expose block_id at the quiz entity level (table map)', async () => {
+      // The `quizzes` table has no block_id column. Even if a caller
+      // tried to pass one, the API signature should not accept it.
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1', { source: 'manual' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).not.toContain('block_id=');
+    });
+
+    it('appends source filter when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1', { source: 'ai' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('source=ai');
+    });
+
+    it('appends is_active=true when provided', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1', { is_active: true });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('is_active=true');
+    });
+
+    it('appends is_active=false when provided (distinguishes from undefined)', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1', { is_active: false });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('is_active=false');
+    });
+
+    it('does NOT append is_active when filter is undefined', async () => {
+      mockApiCall.mockResolvedValueOnce(baseListResponse);
+      await getQuizzes('sum-1', { source: 'manual' });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).not.toContain('is_active=');
+    });
+
+    it('appends limit/offset for pagination', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...baseListResponse, limit: 5, offset: 10 });
+      await getQuizzes('sum-1', { limit: 5, offset: 10 });
+
+      const url = mockApiCall.mock.calls[0][0] as string;
+      expect(url).toContain('limit=5');
+      expect(url).toContain('offset=10');
+    });
+
+    it('returns the list response from apiCall', async () => {
+      const full = {
+        items: [sampleQuiz],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      };
+      mockApiCall.mockResolvedValueOnce(full);
+
+      const out = await getQuizzes('sum-1');
+      expect(out).toEqual(full);
+    });
+
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('Timeout'));
+      await expect(getQuizzes('sum-1')).rejects.toThrow('Timeout');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // createQuiz
+  // ══════════════════════════════════════════════════════
+
+  describe('createQuiz', () => {
+    it('POSTs to /quizzes with JSON body', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        title: 'My Quiz',
+        source: 'manual' as const,
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, ...payload });
+
+      await createQuiz(payload);
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quizzes', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    });
+
+    it('supports description and time_limit_seconds', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        title: 'Timed Quiz',
+        description: 'With a per-question time limit',
+        source: 'manual' as const,
+        time_limit_seconds: 60,
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, ...payload });
+
+      await createQuiz(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.description).toBe('With a per-question time limit');
+      expect(body.time_limit_seconds).toBe(60);
+    });
+
+    it('accepts source: "ai"', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        title: 'AI Quiz',
+        source: 'ai' as const,
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, ...payload });
+
+      await createQuiz(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.source).toBe('ai');
+    });
+
+    it('allows null time_limit_seconds (no limit)', async () => {
+      const payload = {
+        summary_id: 'sum-1',
+        title: 'Unlimited Quiz',
+        source: 'manual' as const,
+        time_limit_seconds: null,
+      };
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, ...payload, time_limit_seconds: null });
+
+      await createQuiz(payload);
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.time_limit_seconds).toBeNull();
+    });
+
+    it('does NOT inject created_by (server derives from token)', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuiz);
+      await createQuiz({
+        summary_id: 'sum-1',
+        title: 'Q',
+        source: 'manual',
+      });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).not.toHaveProperty('created_by');
+      expect(body).not.toHaveProperty('student_id');
+    });
+
+    it('propagates validation errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('400 Missing title'));
+      await expect(
+        createQuiz({ summary_id: 'sum-1', title: '', source: 'manual' })
+      ).rejects.toThrow('400 Missing title');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // updateQuiz
+  // ══════════════════════════════════════════════════════
+
+  describe('updateQuiz', () => {
+    it('PUTs to /quizzes/:id with partial JSON body', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuiz);
+      await updateQuiz('quiz-1', { title: 'Renamed' });
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quizzes/quiz-1', {
+        method: 'PUT',
+        body: JSON.stringify({ title: 'Renamed' }),
+      });
+    });
+
+    it('supports toggling is_active', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, is_active: false });
+      await updateQuiz('quiz-1', { is_active: false });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.is_active).toBe(false);
+    });
+
+    it('supports updating time_limit_seconds', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, time_limit_seconds: 120 });
+      await updateQuiz('quiz-1', { time_limit_seconds: 120 });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.time_limit_seconds).toBe(120);
+    });
+
+    it('supports clearing description to null', async () => {
+      mockApiCall.mockResolvedValueOnce({ ...sampleQuiz, description: null });
+      await updateQuiz('quiz-1', { description: null });
+
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.description).toBeNull();
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // deleteQuiz
+  // ══════════════════════════════════════════════════════
+
+  describe('deleteQuiz', () => {
+    it('issues DELETE /quizzes/:id', async () => {
+      mockApiCall.mockResolvedValueOnce(undefined);
+      await deleteQuiz('quiz-1');
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quizzes/quiz-1', { method: 'DELETE' });
+    });
+
+    it('resolves to undefined (soft-delete)', async () => {
+      mockApiCall.mockResolvedValueOnce(undefined);
+      const out = await deleteQuiz('quiz-1');
+      expect(out).toBeUndefined();
+    });
+  });
+
+  // ══════════════════════════════════════════════════════
+  // restoreQuiz
+  // ══════════════════════════════════════════════════════
+
+  describe('restoreQuiz', () => {
+    it('issues PUT /quizzes/:id/restore', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuiz);
+      await restoreQuiz('quiz-1');
+
+      expect(mockApiCall).toHaveBeenCalledWith('/quizzes/quiz-1/restore', {
+        method: 'PUT',
+      });
+    });
+
+    it('returns the restored quiz', async () => {
+      mockApiCall.mockResolvedValueOnce(sampleQuiz);
+      const out = await restoreQuiz('quiz-1');
+      expect(out).toEqual(sampleQuiz);
+    });
+  });
+});

--- a/src/app/services/__tests__/reviewsApi.test.ts
+++ b/src/app/services/__tests__/reviewsApi.test.ts
@@ -1,0 +1,121 @@
+/**
+ * reviewsApi.test.ts — Tests for reviews API service (R1 domain extraction)
+ *
+ * Coverage: createReview (payload forwarding, method, headers-less call through apiCall)
+ * Mocks: apiCall
+ *
+ * Run: npx vitest run src/app/services/__tests__/reviewsApi.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import { createReview, type Review, type ReviewPayload } from '../reviewsApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('reviewsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createReview', () => {
+    it('calls apiCall with POST /reviews', async () => {
+      const payload: ReviewPayload = {
+        session_id: 'sess-1',
+        item_id: 'item-1',
+        instrument_type: 'flashcard',
+        grade: 4,
+      };
+      mockApiCall.mockResolvedValueOnce({ id: 'rev-1' } as Review);
+      await createReview(payload);
+      expect(mockApiCall).toHaveBeenCalledWith('/reviews', expect.objectContaining({ method: 'POST' }));
+    });
+
+    it('serializes the payload as JSON body', async () => {
+      const payload: ReviewPayload = {
+        session_id: 'sess-1',
+        item_id: 'item-1',
+        instrument_type: 'flashcard',
+        grade: 4,
+        response_time_ms: 1500,
+      };
+      mockApiCall.mockResolvedValueOnce({ id: 'rev-1' } as Review);
+      await createReview(payload);
+      const options = mockApiCall.mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(options.body as string);
+      expect(body).toEqual(payload);
+    });
+
+    it('works without optional response_time_ms', async () => {
+      const payload: ReviewPayload = {
+        session_id: 'sess-1',
+        item_id: 'item-1',
+        instrument_type: 'quiz',
+        grade: 2,
+      };
+      mockApiCall.mockResolvedValueOnce({ id: 'rev-2' } as Review);
+      await createReview(payload);
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual(payload);
+      expect(body.response_time_ms).toBeUndefined();
+    });
+
+    it('returns the created Review from apiCall', async () => {
+      const review: Review = {
+        id: 'rev-1',
+        session_id: 'sess-1',
+        item_id: 'item-1',
+        instrument_type: 'flashcard',
+        grade: 5,
+        response_time_ms: 800,
+        created_at: '2026-04-18T10:00:00Z',
+      };
+      mockApiCall.mockResolvedValueOnce(review);
+      const result = await createReview({
+        session_id: 'sess-1',
+        item_id: 'item-1',
+        instrument_type: 'flashcard',
+        grade: 5,
+        response_time_ms: 800,
+      });
+      expect(result).toEqual(review);
+    });
+
+    it('propagates network / API errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('403 Forbidden: session not owned'));
+      await expect(
+        createReview({ session_id: 's', item_id: 'i', instrument_type: 'flashcard', grade: 3 })
+      ).rejects.toThrow('403 Forbidden: session not owned');
+    });
+
+    it('forwards grade=0 (Again) without coercion', async () => {
+      // grade: 0-5 — ensure value 0 is not dropped accidentally.
+      mockApiCall.mockResolvedValueOnce({ id: 'rev-3' } as Review);
+      await createReview({
+        session_id: 's',
+        item_id: 'i',
+        instrument_type: 'flashcard',
+        grade: 0,
+      });
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.grade).toBe(0);
+    });
+
+    it('forwards response_time_ms=0 explicitly (edge case)', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'rev-4' } as Review);
+      await createReview({
+        session_id: 's',
+        item_id: 'i',
+        instrument_type: 'flashcard',
+        grade: 4,
+        response_time_ms: 0,
+      });
+      const body = JSON.parse((mockApiCall.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.response_time_ms).toBe(0);
+    });
+  });
+});

--- a/src/app/services/__tests__/searchApi.test.ts
+++ b/src/app/services/__tests__/searchApi.test.ts
@@ -1,0 +1,132 @@
+// ============================================================
+// Axon -- Tests for searchApi.ts (search service)
+//
+// search(q, type) builds URL with q and optional type param,
+// and returns response.results (or [] if missing).
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+}));
+
+import { search } from '@/app/services/searchApi';
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ================================================================
+
+describe('search — short-circuit on invalid input', () => {
+  it('returns [] when q is empty string', async () => {
+    const result = await search('');
+    expect(result).toEqual([]);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when q is a single character', async () => {
+    const result = await search('a');
+    expect(result).toEqual([]);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when q is whitespace only', async () => {
+    const result = await search('   ');
+    expect(result).toEqual([]);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when q is undefined (guarded)', async () => {
+    // TypeScript forbids this, but JavaScript callers may pass it.
+    const result = await search(undefined as unknown as string);
+    expect(result).toEqual([]);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+});
+
+describe('search — URL construction', () => {
+  beforeEach(() => {
+    mockApiCall.mockResolvedValue({ results: [] });
+  });
+
+  it('builds URL with q param for default type (no type param emitted)', async () => {
+    await search('hola');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('/search?');
+    expect(url).toContain('q=hola');
+    expect(url).not.toContain('type=');
+  });
+
+  it('trims leading and trailing whitespace in q', async () => {
+    await search('  world  ');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('q=world');
+    expect(url).not.toContain('q=+world');
+    expect(url).not.toContain('q=++');
+  });
+
+  it('includes type param when not "all"', async () => {
+    await search('chem', 'summaries');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('q=chem');
+    expect(url).toContain('type=summaries');
+  });
+
+  it('includes type=keywords', async () => {
+    await search('photo', 'keywords');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('type=keywords');
+  });
+
+  it('includes type=videos', async () => {
+    await search('lecture', 'videos');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('type=videos');
+  });
+
+  it('URL-encodes special characters in q', async () => {
+    await search('hello world!');
+    const url: string = mockApiCall.mock.calls[0][0];
+    // URLSearchParams encodes space as '+' and '!' stays as-is
+    expect(url).toContain('q=hello+world');
+  });
+});
+
+describe('search — response handling', () => {
+  it('returns response.results when present', async () => {
+    const fakeResults = [
+      { type: 'summary', id: 's1', title: 'T1', snippet: 'sn', parent_path: 'a/b' },
+      { type: 'keyword', id: 'k1', title: 'K1', snippet: 'ss', parent_path: 'a/c' },
+    ];
+    mockApiCall.mockResolvedValue({ results: fakeResults });
+
+    const result = await search('anything');
+    expect(result).toEqual(fakeResults);
+  });
+
+  it('returns [] when results field is missing', async () => {
+    mockApiCall.mockResolvedValue({});
+    const result = await search('anything');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when results is undefined', async () => {
+    mockApiCall.mockResolvedValue({ results: undefined });
+    const result = await search('anything');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when results is null', async () => {
+    mockApiCall.mockResolvedValue({ results: null });
+    const result = await search('anything');
+    expect(result).toEqual([]);
+  });
+
+  it('propagates apiCall rejection', async () => {
+    mockApiCall.mockRejectedValue(new Error('network'));
+    await expect(search('anything')).rejects.toThrow('network');
+  });
+});

--- a/src/app/services/__tests__/smartGenerateApi.test.ts
+++ b/src/app/services/__tests__/smartGenerateApi.test.ts
@@ -1,0 +1,251 @@
+/**
+ * smartGenerateApi.test.ts — Tests for the smart (adaptive) quiz generation API.
+ *
+ * Covers:
+ *   - generateSmartQuiz: POST /ai/generate-smart with serialized params
+ *   - Signal plumbing: passes an AbortSignal to apiCall
+ *   - Timeout path: AbortError surfaces as a descriptive timeout message
+ *   - Error propagation: non-abort errors are rethrown as-is
+ *   - Timer cleanup: setTimeout is cleared in success and error paths
+ *
+ * NOTE (MASTERY-SYSTEMS.md): `_smart.p_know` returned by this endpoint is a
+ * BKT signal used by the backend to pick weakest subtopics. This test file
+ * never compares p_know against thresholds — it asserts HTTP wiring and
+ * timeout behaviour only. Consumers that render color codes belong to
+ * Sistemas B/C and live elsewhere.
+ *
+ * Mocks: apiCall from @/app/lib/api
+ *
+ * Run: npx vitest run src/app/services/__tests__/smartGenerateApi.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/app/lib/api', () => ({
+  apiCall: vi.fn(),
+}));
+
+import { apiCall } from '@/app/lib/api';
+import {
+  generateSmartQuiz,
+  type SmartGenerateParams,
+  type SmartGenerateResponse,
+} from '../smartGenerateApi';
+
+const mockApiCall = vi.mocked(apiCall);
+
+// ── Fixtures ──────────────────────────────────────────────
+
+function makeResponse(overrides: Partial<SmartGenerateResponse> = {}): SmartGenerateResponse {
+  return {
+    items: [
+      {
+        type: 'quiz_question',
+        id: 'q-1',
+        keyword_id: 'kw-1',
+        keyword_name: 'Cardio',
+        summary_id: 'sum-1',
+        _smart: {
+          p_know: 0.4,
+          need_score: 0.8,
+          primary_reason: 'low_mastery',
+          target_subtopic: 'sub-1',
+        },
+      },
+    ],
+    errors: [],
+    _meta: {
+      model: 'gpt-4',
+      action: 'quiz_question',
+      summary_id: 'sum-1',
+      quiz_id: 'qz-1',
+      total_attempted: 1,
+      total_generated: 1,
+      total_failed: 0,
+      total_targets_available: 5,
+    },
+    ...overrides,
+  };
+}
+
+function makeParams(overrides: Partial<SmartGenerateParams> = {}): SmartGenerateParams {
+  return {
+    action: 'quiz_question',
+    summary_id: 'sum-1',
+    count: 3,
+    ...overrides,
+  };
+}
+
+describe('smartGenerateApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Happy path
+  // ─────────────────────────────────────────────────────────
+
+  describe('generateSmartQuiz — happy path', () => {
+    it('calls apiCall with POST /ai/generate-smart', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz(makeParams());
+      expect(mockApiCall).toHaveBeenCalledTimes(1);
+      const [url, opts] = mockApiCall.mock.calls[0];
+      expect(url).toBe('/ai/generate-smart');
+      expect(opts).toMatchObject({ method: 'POST' });
+    });
+
+    it('serializes the params object as JSON body', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      const params = makeParams({ count: 10, quiz_id: 'qz-7' });
+      await generateSmartQuiz(params);
+      const opts = mockApiCall.mock.calls[0][1] as RequestInit;
+      expect(JSON.parse(opts.body as string)).toEqual(params);
+    });
+
+    it('passes an AbortSignal to apiCall', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz(makeParams());
+      const opts = mockApiCall.mock.calls[0][1] as RequestInit;
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+      // Success path should NOT leave the signal in aborted state
+      expect(opts.signal!.aborted).toBe(false);
+    });
+
+    it('returns the SmartGenerateResponse from apiCall', async () => {
+      const resp = makeResponse({
+        _meta: {
+          model: 'gpt-4o',
+          action: 'quiz_question',
+          total_attempted: 5,
+          total_generated: 5,
+          total_failed: 0,
+          total_targets_available: 20,
+        },
+      });
+      mockApiCall.mockResolvedValueOnce(resp);
+      const result = await generateSmartQuiz(makeParams({ count: 5 }));
+      expect(result).toBe(resp);
+    });
+
+    it('supports the flashcard action value', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz({ action: 'flashcard' });
+      const body = JSON.parse(mockApiCall.mock.calls[0][1]!.body as string);
+      expect(body.action).toBe('flashcard');
+    });
+
+    it('supports auto_create_quiz and quiz_title params', async () => {
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz(
+        makeParams({ auto_create_quiz: true, quiz_title: 'Repaso adaptativo' }),
+      );
+      const body = JSON.parse(mockApiCall.mock.calls[0][1]!.body as string);
+      expect(body.auto_create_quiz).toBe(true);
+      expect(body.quiz_title).toBe('Repaso adaptativo');
+    });
+
+    it('handles a response with errors but no items', async () => {
+      const resp = makeResponse({
+        items: [],
+        errors: [{ keyword_id: 'kw-x', keyword_name: 'X', error: 'openai_fail' }],
+        _meta: {
+          model: 'gpt-4',
+          action: 'quiz_question',
+          total_attempted: 1,
+          total_generated: 0,
+          total_failed: 1,
+          total_targets_available: 3,
+        },
+      });
+      mockApiCall.mockResolvedValueOnce(resp);
+      const result = await generateSmartQuiz(makeParams({ count: 1 }));
+      expect(result.items).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result._meta.total_failed).toBe(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Timeout / abort
+  // ─────────────────────────────────────────────────────────
+
+  describe('generateSmartQuiz — timeout path', () => {
+    it('throws a descriptive timeout Error when apiCall rejects with AbortError', async () => {
+      const abortErr = new DOMException('aborted', 'AbortError');
+      // Two invocations share the same queued rejection pattern — prime both.
+      mockApiCall.mockRejectedValueOnce(abortErr);
+      mockApiCall.mockRejectedValueOnce(abortErr);
+
+      await expect(generateSmartQuiz(makeParams())).rejects.toThrow(/Timeout/);
+      await expect(generateSmartQuiz(makeParams())).rejects.toThrow(/2 minutos/);
+    });
+
+    it('converts AbortError even when the signal was aborted by the controller', async () => {
+      // Simulate the controller aborting (the actual 120s path) by rejecting
+      // with an AbortError DOMException.
+      const abortErr = new DOMException('The operation was aborted.', 'AbortError');
+      mockApiCall.mockRejectedValueOnce(abortErr);
+      await expect(generateSmartQuiz(makeParams())).rejects.toThrow(
+        'Timeout: la generacion adaptativa tardo mas de 2 minutos. Intenta con menos preguntas.',
+      );
+    });
+
+    it('clears the timeout when apiCall resolves (no dangling aborts)', async () => {
+      vi.useFakeTimers();
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz(makeParams());
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('clears the timeout when apiCall rejects with a non-abort error', async () => {
+      vi.useFakeTimers();
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+      mockApiCall.mockRejectedValueOnce(new Error('500'));
+      await expect(generateSmartQuiz(makeParams())).rejects.toThrow('500');
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('installs a 120_000 ms timeout via setTimeout', async () => {
+      vi.useFakeTimers();
+      const setSpy = vi.spyOn(globalThis, 'setTimeout');
+      mockApiCall.mockResolvedValueOnce(makeResponse());
+      await generateSmartQuiz(makeParams());
+      const matching = setSpy.mock.calls.find(([, ms]) => ms === 120_000);
+      expect(matching).toBeDefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Error propagation (non-abort)
+  // ─────────────────────────────────────────────────────────
+
+  describe('generateSmartQuiz — error path', () => {
+    it('rethrows non-AbortError errors unchanged', async () => {
+      const err = new Error('401 Unauthorized');
+      mockApiCall.mockRejectedValueOnce(err);
+      await expect(generateSmartQuiz(makeParams())).rejects.toBe(err);
+    });
+
+    it('rethrows a non-DOMException even if name happens to be AbortError', async () => {
+      // The guard is `err instanceof DOMException && err.name === 'AbortError'`.
+      // A plain Error named 'AbortError' must NOT be converted.
+      const fake = new Error('pseudo abort');
+      fake.name = 'AbortError';
+      mockApiCall.mockRejectedValueOnce(fake);
+      await expect(generateSmartQuiz(makeParams())).rejects.toBe(fake);
+    });
+
+    it('rethrows a DOMException whose name is not AbortError', async () => {
+      const domErr = new DOMException('something else', 'SyntaxError');
+      mockApiCall.mockRejectedValueOnce(domErr);
+      await expect(generateSmartQuiz(makeParams())).rejects.toBe(domErr);
+    });
+  });
+});

--- a/src/app/services/__tests__/stickyNotesApi.test.ts
+++ b/src/app/services/__tests__/stickyNotesApi.test.ts
@@ -1,0 +1,148 @@
+// ============================================================
+// Unit tests for stickyNotesApi service (adjacent to source).
+//
+// NOTE: There's a broader contract test at
+// src/__tests__/sticky-notes-api-contracts.test.ts covering endpoint
+// surface + dead-code audit guards. THIS file is the focused adjacent
+// test for URL/body/method/error flows.
+//
+// Mocks: @/app/lib/api (apiCall)
+//
+// RUN: npx vitest run src/app/services/__tests__/stickyNotesApi.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import {
+  getStickyNote,
+  upsertStickyNote,
+  deleteStickyNote,
+  type StickyNote,
+} from '@/app/services/stickyNotesApi';
+
+const ROW: StickyNote = {
+  id: 'sn-1',
+  student_id: 'stu-1',
+  summary_id: 'sum-1',
+  content: 'hello',
+  created_at: '2026-04-18T09:00:00Z',
+  updated_at: '2026-04-18T09:00:00Z',
+};
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// getStickyNote
+// ══════════════════════════════════════════════════════════════
+
+describe('getStickyNote', () => {
+  it('builds URL with encoded summary_id query param', async () => {
+    mockApiCall.mockResolvedValueOnce(ROW);
+    await getStickyNote('sum-1');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toBe('/sticky-notes?summary_id=sum-1');
+  });
+
+  it('percent-encodes special chars in summary_id', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    await getStickyNote('a b/c?d&e');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent('a b/c?d&e'));
+  });
+
+  it('returns the row when apiCall resolves', async () => {
+    mockApiCall.mockResolvedValueOnce(ROW);
+    expect(await getStickyNote('sum-1')).toEqual(ROW);
+  });
+
+  it('returns null when apiCall resolves to null', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    expect(await getStickyNote('sum-1')).toBeNull();
+  });
+
+  it('returns null when apiCall resolves to undefined', async () => {
+    mockApiCall.mockResolvedValueOnce(undefined);
+    expect(await getStickyNote('sum-1')).toBeNull();
+  });
+
+  it('returns null on 404-message error', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 404: not found'));
+    expect(await getStickyNote('sum-1')).toBeNull();
+  });
+
+  it('returns null on status-404 error', async () => {
+    mockApiCall.mockRejectedValueOnce(Object.assign(new Error('nf'), { status: 404 }));
+    expect(await getStickyNote('sum-1')).toBeNull();
+  });
+
+  it('rethrows non-404 errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('500 server down'));
+    await expect(getStickyNote('sum-1')).rejects.toThrow('500 server down');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// upsertStickyNote
+// ══════════════════════════════════════════════════════════════
+
+describe('upsertStickyNote', () => {
+  it('POSTs /sticky-notes with JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce(ROW);
+    await upsertStickyNote({ summary_id: 'sum-1', content: 'hi' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/sticky-notes');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ summary_id: 'sum-1', content: 'hi' });
+  });
+
+  it('preserves empty content (clear-via-empty)', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...ROW, content: '' });
+    await upsertStickyNote({ summary_id: 'sum-1', content: '' });
+    const body = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(body.content).toBe('');
+  });
+
+  it('propagates server errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('413 too big'));
+    await expect(
+      upsertStickyNote({ summary_id: 'sum-1', content: 'x' }),
+    ).rejects.toThrow('413 too big');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// deleteStickyNote
+// ══════════════════════════════════════════════════════════════
+
+describe('deleteStickyNote', () => {
+  it('DELETEs /sticky-notes with encoded summary_id query', async () => {
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    await deleteStickyNote('sum-1');
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/sticky-notes?summary_id=sum-1');
+    expect(opts.method).toBe('DELETE');
+  });
+
+  it('encodes special chars on delete', async () => {
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    await deleteStickyNote('a/b?c');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent('a/b?c'));
+  });
+
+  it('returns {deleted:true} envelope from server', async () => {
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    expect(await deleteStickyNote('sum-1')).toEqual({ deleted: true });
+  });
+
+  it('propagates server errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('403 forbidden'));
+    await expect(deleteStickyNote('sum-1')).rejects.toThrow('403 forbidden');
+  });
+});

--- a/src/app/services/__tests__/studentSummariesApi.test.ts
+++ b/src/app/services/__tests__/studentSummariesApi.test.ts
@@ -1,0 +1,443 @@
+// ============================================================
+// Unit tests for studentSummariesApi service
+//
+// Covers URL construction, method, body, query params, error handling,
+// and special cases (404 fallback, paginated normalization, supabase RPC
+// branch for block_id annotations).
+//
+// Mocks:
+//   - @/app/lib/api (apiCall)
+//   - @/app/lib/supabase (for create_text_annotation RPC branch)
+//
+// RUN: npx vitest run src/app/services/__tests__/studentSummariesApi.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock apiCall BEFORE importing the service ───────────────
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+// Mock supabase (dynamic import inside createTextAnnotation when block_id provided)
+const mockSupabaseRpc = vi.fn();
+vi.mock('@/app/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockSupabaseRpc(...args),
+  },
+}));
+
+import {
+  getReadingState,
+  upsertReadingState,
+  getTextAnnotations,
+  createTextAnnotation,
+  updateTextAnnotation,
+  deleteTextAnnotation,
+  getKwStudentNotes,
+  createKwStudentNote,
+  updateKwStudentNote,
+  deleteKwStudentNote,
+  getVideoNotes,
+  createVideoNote,
+  updateVideoNote,
+  deleteVideoNote,
+  getBlockBookmarks,
+  createBlockBookmark,
+  deleteBlockBookmark,
+  getBlockNotes,
+  createBlockNote,
+  updateBlockNote,
+  deleteBlockNote,
+  getAllReadingStates,
+  type ReadingState,
+  type TextAnnotation,
+} from '@/app/services/studentSummariesApi';
+
+const SAMPLE_READING_STATE: ReadingState = {
+  id: 'rs-1',
+  student_id: 'stu-1',
+  summary_id: 'sum-1',
+  scroll_position: 50,
+  time_spent_seconds: 300,
+  completed: false,
+  last_read_at: '2026-04-18T10:00:00Z',
+  created_at: '2026-04-18T09:00:00Z',
+  updated_at: '2026-04-18T10:00:00Z',
+};
+
+const SAMPLE_ANNOTATION: TextAnnotation = {
+  id: 'ann-1',
+  student_id: 'stu-1',
+  summary_id: 'sum-1',
+  start_offset: 10,
+  end_offset: 20,
+  color: 'yellow',
+  note: 'important',
+  created_at: '2026-04-18T09:00:00Z',
+  updated_at: '2026-04-18T09:00:00Z',
+};
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+  mockSupabaseRpc.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// getReadingState
+// ══════════════════════════════════════════════════════════════
+
+describe('getReadingState', () => {
+  it('GETs /reading-states with summary_id query param', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [SAMPLE_READING_STATE], total: 1, limit: 10, offset: 0 });
+    await getReadingState('sum-1');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toBe('/reading-states?summary_id=sum-1');
+  });
+
+  it('returns first item of paginated response', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [SAMPLE_READING_STATE], total: 1, limit: 10, offset: 0 });
+    const result = await getReadingState('sum-1');
+    expect(result).toEqual(SAMPLE_READING_STATE);
+  });
+
+  it('returns null when items array is empty', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    const result = await getReadingState('sum-1');
+    expect(result).toBeNull();
+  });
+
+  it('handles plain array response', async () => {
+    mockApiCall.mockResolvedValueOnce([SAMPLE_READING_STATE]);
+    const result = await getReadingState('sum-1');
+    expect(result).toEqual(SAMPLE_READING_STATE);
+  });
+
+  it('handles direct object response', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_READING_STATE);
+    const result = await getReadingState('sum-1');
+    expect(result).toEqual(SAMPLE_READING_STATE);
+  });
+
+  it('returns null on 404 error (message-based)', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('HTTP 404: not found'));
+    const result = await getReadingState('sum-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on 404 error (status-based)', async () => {
+    const err = Object.assign(new Error('not found'), { status: 404 });
+    mockApiCall.mockRejectedValueOnce(err);
+    const result = await getReadingState('sum-1');
+    expect(result).toBeNull();
+  });
+
+  it('rethrows non-404 errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('Network down'));
+    await expect(getReadingState('sum-1')).rejects.toThrow('Network down');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// upsertReadingState
+// ══════════════════════════════════════════════════════════════
+
+describe('upsertReadingState', () => {
+  it('POSTs to /reading-states with JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_READING_STATE);
+    await upsertReadingState({
+      summary_id: 'sum-1',
+      scroll_position: 60,
+      time_spent_seconds: 400,
+      completed: true,
+      last_read_at: '2026-04-18T11:00:00Z',
+    });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/reading-states');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({
+      summary_id: 'sum-1',
+      scroll_position: 60,
+      time_spent_seconds: 400,
+      completed: true,
+      last_read_at: '2026-04-18T11:00:00Z',
+    });
+  });
+
+  it('propagates server errors', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('boom'));
+    await expect(upsertReadingState({ summary_id: 'sum-1' })).rejects.toThrow('boom');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Text Annotations
+// ══════════════════════════════════════════════════════════════
+
+describe('getTextAnnotations', () => {
+  it('GETs /text-annotations?summary_id=...', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [SAMPLE_ANNOTATION], total: 1, limit: 50, offset: 0 });
+    const result = await getTextAnnotations('sum-1');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/text-annotations?summary_id=sum-1');
+    expect(result.items).toHaveLength(1);
+  });
+});
+
+describe('createTextAnnotation', () => {
+  it('POSTs via apiCall when block_id is NOT provided', async () => {
+    mockApiCall.mockResolvedValueOnce(SAMPLE_ANNOTATION);
+    await createTextAnnotation({
+      summary_id: 'sum-1',
+      start_offset: 10,
+      end_offset: 20,
+      color: 'yellow',
+      note: 'hi',
+    });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/text-annotations');
+    expect(opts.method).toBe('POST');
+    expect(mockSupabaseRpc).not.toHaveBeenCalled();
+  });
+
+  it('uses supabase.rpc(create_text_annotation) when block_id is provided', async () => {
+    mockSupabaseRpc.mockResolvedValueOnce({ data: SAMPLE_ANNOTATION, error: null });
+    const result = await createTextAnnotation({
+      summary_id: 'sum-1',
+      start_offset: 10,
+      end_offset: 20,
+      color: 'red',
+      note: 'x',
+      block_id: 'blk-1',
+    });
+    expect(mockSupabaseRpc).toHaveBeenCalledWith('create_text_annotation', {
+      p_summary_id: 'sum-1',
+      p_start_offset: 10,
+      p_end_offset: 20,
+      p_color: 'red',
+      p_note: 'x',
+      p_block_id: 'blk-1',
+    });
+    expect(mockApiCall).not.toHaveBeenCalled();
+    expect(result).toEqual(SAMPLE_ANNOTATION);
+  });
+
+  it('defaults color=yellow and note=null in RPC when omitted', async () => {
+    mockSupabaseRpc.mockResolvedValueOnce({ data: SAMPLE_ANNOTATION, error: null });
+    await createTextAnnotation({
+      summary_id: 'sum-1',
+      start_offset: 0,
+      end_offset: 5,
+      block_id: 'blk-1',
+    });
+    const args = mockSupabaseRpc.mock.calls[0][1];
+    expect(args.p_color).toBe('yellow');
+    expect(args.p_note).toBeNull();
+  });
+
+  it('throws with RPC error message when supabase returns error', async () => {
+    mockSupabaseRpc.mockResolvedValueOnce({ data: null, error: { message: 'rpc failed' } });
+    await expect(
+      createTextAnnotation({
+        summary_id: 'sum-1',
+        start_offset: 0,
+        end_offset: 5,
+        block_id: 'blk-1',
+      }),
+    ).rejects.toThrow('rpc failed');
+  });
+});
+
+describe('updateTextAnnotation', () => {
+  it('PUTs /text-annotations/:id with JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SAMPLE_ANNOTATION, color: 'green' });
+    await updateTextAnnotation('ann-1', { color: 'green', note: 'updated' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/text-annotations/ann-1');
+    expect(opts.method).toBe('PUT');
+    expect(JSON.parse(opts.body)).toEqual({ color: 'green', note: 'updated' });
+  });
+});
+
+describe('deleteTextAnnotation', () => {
+  it('DELETEs /text-annotations/:id', async () => {
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    await deleteTextAnnotation('ann-1');
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/text-annotations/ann-1');
+    expect(opts.method).toBe('DELETE');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Keyword Student Notes
+// ══════════════════════════════════════════════════════════════
+
+describe('Keyword Student Notes', () => {
+  it('GETs /kw-student-notes with keyword_id query', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    await getKwStudentNotes('kw-1');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/kw-student-notes?keyword_id=kw-1');
+  });
+
+  it('POSTs a new kw note', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'kn-1' });
+    await createKwStudentNote({ keyword_id: 'kw-1', note: 'hello' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/kw-student-notes');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ keyword_id: 'kw-1', note: 'hello' });
+  });
+
+  it('PUTs an existing kw note by id', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'kn-1', note: 'new' });
+    await updateKwStudentNote('kn-1', { note: 'new' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/kw-student-notes/kn-1');
+    expect(opts.method).toBe('PUT');
+  });
+
+  it('DELETEs a kw note by id', async () => {
+    mockApiCall.mockResolvedValueOnce(undefined);
+    await deleteKwStudentNote('kn-1');
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/kw-student-notes/kn-1');
+    expect(opts.method).toBe('DELETE');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Video Notes
+// ══════════════════════════════════════════════════════════════
+
+describe('Video Notes', () => {
+  it('GETs /video-notes with video_id query', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    await getVideoNotes('vid-1');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/video-notes?video_id=vid-1');
+  });
+
+  it('POSTs a new video note with optional timestamp', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'vn-1' });
+    await createVideoNote({ video_id: 'vid-1', timestamp_seconds: 42, note: 'aha' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/video-notes');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({
+      video_id: 'vid-1',
+      timestamp_seconds: 42,
+      note: 'aha',
+    });
+  });
+
+  it('PUTs + DELETEs a video note by id', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'vn-1', note: 'u' });
+    await updateVideoNote('vn-1', { note: 'u' });
+    expect(mockApiCall.mock.calls[0][0]).toBe('/video-notes/vn-1');
+    expect(mockApiCall.mock.calls[0][1].method).toBe('PUT');
+
+    mockApiCall.mockResolvedValueOnce(undefined);
+    await deleteVideoNote('vn-1');
+    expect(mockApiCall.mock.calls[1][0]).toBe('/video-notes/vn-1');
+    expect(mockApiCall.mock.calls[1][1].method).toBe('DELETE');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Block Bookmarks & Notes
+// ══════════════════════════════════════════════════════════════
+
+describe('Block Bookmarks', () => {
+  it('GETs /block-bookmarks with summary_id', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    await getBlockBookmarks('sum-1');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/block-bookmarks?summary_id=sum-1');
+  });
+
+  it('POSTs a new bookmark and DELETEs by id', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'bm-1' });
+    await createBlockBookmark({ summary_id: 'sum-1', block_id: 'blk-1' });
+    expect(mockApiCall.mock.calls[0][0]).toBe('/block-bookmarks');
+    expect(JSON.parse(mockApiCall.mock.calls[0][1].body)).toEqual({
+      summary_id: 'sum-1',
+      block_id: 'blk-1',
+    });
+
+    mockApiCall.mockResolvedValueOnce({ deleted: true });
+    await deleteBlockBookmark('bm-1');
+    expect(mockApiCall.mock.calls[1][0]).toBe('/block-bookmarks/bm-1');
+    expect(mockApiCall.mock.calls[1][1].method).toBe('DELETE');
+  });
+});
+
+describe('Block Notes', () => {
+  it('GETs /block-notes with summary_id only when block_id omitted', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    await getBlockNotes('sum-1');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toBe('/block-notes?summary_id=sum-1');
+    expect(url).not.toContain('block_id=');
+  });
+
+  it('GETs /block-notes with summary_id AND block_id when both provided', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 });
+    await getBlockNotes('sum-1', 'blk-1');
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('summary_id=sum-1');
+    expect(url).toContain('block_id=blk-1');
+  });
+
+  it('POSTs, PUTs, DELETEs block notes correctly', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'bn-1' });
+    await createBlockNote({ summary_id: 'sum-1', block_id: 'blk-1', text: 't', color: 'blue' });
+    const postBody = JSON.parse(mockApiCall.mock.calls[0][1].body);
+    expect(postBody).toEqual({ summary_id: 'sum-1', block_id: 'blk-1', text: 't', color: 'blue' });
+
+    mockApiCall.mockResolvedValueOnce({ id: 'bn-1' });
+    await updateBlockNote('bn-1', { text: 'u' });
+    expect(mockApiCall.mock.calls[1][0]).toBe('/block-notes/bn-1');
+    expect(mockApiCall.mock.calls[1][1].method).toBe('PUT');
+
+    mockApiCall.mockResolvedValueOnce(undefined);
+    await deleteBlockNote('bn-1');
+    expect(mockApiCall.mock.calls[2][0]).toBe('/block-notes/bn-1');
+    expect(mockApiCall.mock.calls[2][1].method).toBe('DELETE');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getAllReadingStates — fan-out + Promise.allSettled
+// ══════════════════════════════════════════════════════════════
+
+describe('getAllReadingStates', () => {
+  it('returns empty array when summaryIds is empty', async () => {
+    const result = await getAllReadingStates([]);
+    expect(result).toEqual([]);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+
+  it('fans out one apiCall per summaryId', async () => {
+    mockApiCall
+      .mockResolvedValueOnce({ items: [SAMPLE_READING_STATE], total: 1, limit: 10, offset: 0 })
+      .mockResolvedValueOnce({ items: [{ ...SAMPLE_READING_STATE, summary_id: 'sum-2' }], total: 1, limit: 10, offset: 0 });
+    const result = await getAllReadingStates(['sum-1', 'sum-2']);
+    expect(mockApiCall).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips failed requests without throwing (Promise.allSettled behaviour)', async () => {
+    mockApiCall
+      .mockResolvedValueOnce({ items: [SAMPLE_READING_STATE], total: 1, limit: 10, offset: 0 })
+      .mockRejectedValueOnce(new Error('Network down'));
+    const result = await getAllReadingStates(['sum-1', 'sum-2']);
+    expect(result).toHaveLength(1);
+    expect(result[0].summary_id).toBe('sum-1');
+  });
+
+  it('skips null/missing items (404 converted to null by getReadingState)', async () => {
+    mockApiCall
+      .mockResolvedValueOnce({ items: [], total: 0, limit: 10, offset: 0 })
+      .mockResolvedValueOnce({ items: [SAMPLE_READING_STATE], total: 1, limit: 10, offset: 0 });
+    const result = await getAllReadingStates(['sum-1', 'sum-2']);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/app/services/__tests__/studySessionApi.test.ts
+++ b/src/app/services/__tests__/studySessionApi.test.ts
@@ -1,0 +1,315 @@
+// ============================================================
+// Unit tests for studySessionApi service
+//
+// Covers: createStudySession, closeStudySession, getStudySessions,
+// getFsrsStates, upsertFsrsState, submitReview, submitReviewBatch,
+// fallbackToIndividualPosts.
+//
+// Verifies URL, method, body, query-param serialization, paginated
+// response normalization, and fallback error-swallow semantics.
+//
+// Mocks: @/app/lib/api (apiCall)
+//
+// RUN: npx vitest run src/app/services/__tests__/studySessionApi.test.ts
+// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import {
+  createStudySession,
+  closeStudySession,
+  getStudySessions,
+  getFsrsStates,
+  upsertFsrsState,
+  submitReview,
+  submitReviewBatch,
+  fallbackToIndividualPosts,
+  type BatchReviewItem,
+  type StudySessionRecord,
+  type FsrsStateRow,
+} from '@/app/services/studySessionApi';
+
+const SESSION: StudySessionRecord = {
+  id: 'ses-1',
+  student_id: 'stu-1',
+  session_type: 'flashcard',
+  course_id: 'crs-1',
+  started_at: '2026-04-18T09:00:00Z',
+  completed_at: null,
+  total_reviews: 0,
+  correct_reviews: 0,
+};
+
+const FSRS_ROW: FsrsStateRow = {
+  id: 'fs-1',
+  student_id: 'stu-1',
+  flashcard_id: 'card-1',
+  stability: 1.5,
+  difficulty: 5,
+  due_at: '2026-04-19T09:00:00Z',
+  last_review_at: '2026-04-18T09:00:00Z',
+  reps: 1,
+  lapses: 0,
+  state: 'learning',
+};
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// Study Sessions
+// ══════════════════════════════════════════════════════════════
+
+describe('createStudySession', () => {
+  it('POSTs /study-sessions with JSON body', async () => {
+    mockApiCall.mockResolvedValueOnce(SESSION);
+    const result = await createStudySession({ session_type: 'flashcard', course_id: 'crs-1' });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/study-sessions');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ session_type: 'flashcard', course_id: 'crs-1' });
+    expect(result).toEqual(SESSION);
+  });
+
+  it('accepts all valid session_type values', async () => {
+    const types: Array<'flashcard' | 'quiz' | 'reading' | 'mixed'> = [
+      'flashcard',
+      'quiz',
+      'reading',
+      'mixed',
+    ];
+    for (const t of types) {
+      mockApiCall.mockResolvedValueOnce({ ...SESSION, session_type: t });
+      await createStudySession({ session_type: t });
+      const body = JSON.parse(mockApiCall.mock.calls[mockApiCall.mock.calls.length - 1][1].body);
+      expect(body.session_type).toBe(t);
+    }
+  });
+
+  it('propagates errors from backend', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('nope'));
+    await expect(createStudySession({ session_type: 'quiz' })).rejects.toThrow('nope');
+  });
+});
+
+describe('closeStudySession', () => {
+  it('PUTs /study-sessions/:id with completed_at body', async () => {
+    mockApiCall.mockResolvedValueOnce({ ...SESSION, completed_at: '2026-04-18T10:00:00Z' });
+    await closeStudySession('ses-1', {
+      completed_at: '2026-04-18T10:00:00Z',
+      total_reviews: 10,
+      correct_reviews: 7,
+    });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/study-sessions/ses-1');
+    expect(opts.method).toBe('PUT');
+    const body = JSON.parse(opts.body);
+    // RT-001: completed_at (not ended_at)
+    expect(body.completed_at).toBe('2026-04-18T10:00:00Z');
+    expect(body).not.toHaveProperty('ended_at');
+    // duration_seconds must NOT be added
+    expect(body).not.toHaveProperty('duration_seconds');
+    expect(body.total_reviews).toBe(10);
+    expect(body.correct_reviews).toBe(7);
+  });
+});
+
+describe('getStudySessions', () => {
+  it('GETs /study-sessions with no query when filters omitted', async () => {
+    mockApiCall.mockResolvedValueOnce([SESSION]);
+    await getStudySessions();
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toBe('/study-sessions');
+    expect(url).not.toContain('?');
+  });
+
+  it('serializes all filters into query string', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 20, offset: 0 });
+    await getStudySessions({ session_type: 'flashcard', course_id: 'crs-1', limit: 20 });
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('session_type=flashcard');
+    expect(url).toContain('course_id=crs-1');
+    expect(url).toContain('limit=20');
+  });
+
+  it('normalizes plain-array response to array', async () => {
+    mockApiCall.mockResolvedValueOnce([SESSION]);
+    const result = await getStudySessions();
+    expect(result).toEqual([SESSION]);
+  });
+
+  it('normalizes CRUD-factory paginated response to items[]', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [SESSION], total: 1, limit: 20, offset: 0 });
+    const result = await getStudySessions();
+    expect(result).toEqual([SESSION]);
+  });
+
+  it('returns [] when response is null/empty object', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    expect(await getStudySessions()).toEqual([]);
+    mockApiCall.mockResolvedValueOnce({});
+    expect(await getStudySessions()).toEqual([]);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// FSRS states
+// ══════════════════════════════════════════════════════════════
+
+describe('getFsrsStates', () => {
+  it('GETs /fsrs-states with no query when params omitted', async () => {
+    mockApiCall.mockResolvedValueOnce([FSRS_ROW]);
+    await getFsrsStates();
+    expect(mockApiCall.mock.calls[0][0]).toBe('/fsrs-states');
+  });
+
+  it('serializes due_before + state + limit', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [], total: 0, limit: 50, offset: 0 });
+    await getFsrsStates({ due_before: '2026-04-20T00:00:00Z', state: 'review', limit: 50 });
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toContain('/fsrs-states?');
+    expect(url).toContain('state=review');
+    expect(url).toContain('limit=50');
+    expect(url).toContain('due_before=');
+  });
+
+  it('returns items[] for paginated response', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [FSRS_ROW], total: 1, limit: 50, offset: 0 });
+    const result = await getFsrsStates();
+    expect(result).toEqual([FSRS_ROW]);
+  });
+
+  it('returns [] for null response', async () => {
+    mockApiCall.mockResolvedValueOnce(null);
+    expect(await getFsrsStates()).toEqual([]);
+  });
+});
+
+describe('upsertFsrsState', () => {
+  it('POSTs /fsrs-states with full FSRS payload', async () => {
+    mockApiCall.mockResolvedValueOnce(FSRS_ROW);
+    await upsertFsrsState({
+      flashcard_id: 'card-1',
+      stability: 1.5,
+      difficulty: 5,
+      due_at: '2026-04-19T09:00:00Z',
+      last_review_at: '2026-04-18T09:00:00Z',
+      reps: 1,
+      lapses: 0,
+      state: 'learning',
+    });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/fsrs-states');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body).flashcard_id).toBe('card-1');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// Reviews
+// ══════════════════════════════════════════════════════════════
+
+describe('submitReview', () => {
+  it('POSTs /reviews with required payload', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'rv-1' });
+    await submitReview({
+      session_id: 'ses-1',
+      item_id: 'card-1',
+      instrument_type: 'flashcard',
+      grade: 3,
+      response_time_ms: 1500,
+    });
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/reviews');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.session_id).toBe('ses-1');
+    expect(body.item_id).toBe('card-1');
+    expect(body.instrument_type).toBe('flashcard');
+    expect(body.grade).toBe(3);
+    expect(body.response_time_ms).toBe(1500);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// submitReviewBatch
+// ══════════════════════════════════════════════════════════════
+
+describe('submitReviewBatch', () => {
+  it('POSTs /review-batch with session_id + reviews array', async () => {
+    const reviews: BatchReviewItem[] = [
+      { item_id: 'c1', instrument_type: 'flashcard', grade: 4, subtopic_id: 'sub-1' },
+      { item_id: 'c2', instrument_type: 'flashcard', grade: 2 },
+    ];
+    mockApiCall.mockResolvedValueOnce({
+      processed: 2,
+      reviews_created: 2,
+      fsrs_updated: 2,
+      bkt_updated: 2,
+    });
+    const result = await submitReviewBatch('ses-1', reviews);
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/review-batch');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.session_id).toBe('ses-1');
+    expect(body.reviews).toHaveLength(2);
+    expect(body.reviews[0].subtopic_id).toBe('sub-1');
+    // Must NOT include fsrs_update / bkt_update (PATH B → computed server-side)
+    expect(body.reviews[0]).not.toHaveProperty('fsrs_update');
+    expect(body.reviews[0]).not.toHaveProperty('bkt_update');
+    expect(result.processed).toBe(2);
+  });
+
+  it('propagates errors so caller can fall back', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('500 boom'));
+    await expect(submitReviewBatch('ses-1', [])).rejects.toThrow('500 boom');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// fallbackToIndividualPosts
+// ══════════════════════════════════════════════════════════════
+
+describe('fallbackToIndividualPosts', () => {
+  it('fires one POST /reviews per batch item', async () => {
+    mockApiCall.mockResolvedValue({ id: 'rv-x' });
+    const items: BatchReviewItem[] = [
+      { item_id: 'c1', instrument_type: 'flashcard', grade: 3 },
+      { item_id: 'c2', instrument_type: 'flashcard', grade: 4 },
+      { item_id: 'c3', instrument_type: 'flashcard', grade: 1 },
+    ];
+    await fallbackToIndividualPosts('ses-1', items);
+    expect(mockApiCall).toHaveBeenCalledTimes(3);
+    for (const call of mockApiCall.mock.calls) {
+      expect(call[0]).toBe('/reviews');
+      const body = JSON.parse(call[1].body);
+      expect(body.session_id).toBe('ses-1');
+      expect(body.instrument_type).toBe('flashcard');
+    }
+  });
+
+  it('does not reject when an individual POST fails (allSettled + catch)', async () => {
+    mockApiCall
+      .mockRejectedValueOnce(new Error('net'))
+      .mockResolvedValueOnce({ id: 'ok' });
+    const items: BatchReviewItem[] = [
+      { item_id: 'c1', instrument_type: 'flashcard', grade: 3 },
+      { item_id: 'c2', instrument_type: 'flashcard', grade: 4 },
+    ];
+    await expect(
+      fallbackToIndividualPosts('ses-1', items),
+    ).resolves.toBeUndefined();
+    expect(mockApiCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves instantly for empty items array', async () => {
+    await expect(fallbackToIndividualPosts('ses-1', [])).resolves.toBeUndefined();
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/services/__tests__/trashApi.test.ts
+++ b/src/app/services/__tests__/trashApi.test.ts
@@ -1,0 +1,147 @@
+// ============================================================
+// Axon -- Tests for trashApi.ts
+//
+// getTrash(type?)       -> GET  /trash   (no query param when type='all')
+// restoreItem(table, id)-> POST /restore/:table/:id
+//
+// Mocks: @/app/lib/api (apiCall)
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiCall = vi.fn();
+vi.mock('@/app/lib/api', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}));
+
+import { getTrash, restoreItem } from '@/app/services/trashApi';
+
+beforeEach(() => {
+  mockApiCall.mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════
+// getTrash
+// ══════════════════════════════════════════════════════════════
+
+describe('getTrash — URL construction', () => {
+  it('defaults to type="all" and omits the ?type= query param', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash();
+    const url: string = mockApiCall.mock.calls[0][0];
+    expect(url).toBe('/trash');
+    expect(url).not.toContain('type=');
+  });
+
+  it('also omits the query param when explicitly called with "all"', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('all');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash');
+  });
+
+  it('adds ?type=summaries when filtering', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('summaries');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash?type=summaries');
+  });
+
+  it('supports type=keywords', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('keywords');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash?type=keywords');
+  });
+
+  it('supports type=flashcards', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('flashcards');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash?type=flashcards');
+  });
+
+  it('supports type=quiz-questions', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('quiz-questions');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash?type=quiz-questions');
+  });
+
+  it('supports type=videos', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getTrash('videos');
+    expect(mockApiCall.mock.calls[0][0]).toBe('/trash?type=videos');
+  });
+});
+
+describe('getTrash — response shape', () => {
+  it('returns response.items when present', async () => {
+    const items = [
+      {
+        id: 'a',
+        type: 'summary',
+        title: 't',
+        deleted_at: '2026-04-18T00:00:00Z',
+      },
+    ];
+    mockApiCall.mockResolvedValueOnce({ items });
+    expect(await getTrash()).toEqual(items);
+  });
+
+  it('returns [] when response has no items key', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    expect(await getTrash()).toEqual([]);
+  });
+
+  it('returns [] when response.items is undefined', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: undefined });
+    expect(await getTrash()).toEqual([]);
+  });
+
+  it('propagates errors from apiCall', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('net down'));
+    await expect(getTrash()).rejects.toThrow('net down');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// restoreItem
+// ══════════════════════════════════════════════════════════════
+
+describe('restoreItem', () => {
+  it('calls POST /restore/:table/:id', async () => {
+    mockApiCall.mockResolvedValueOnce({ restored: true, item: {} });
+    await restoreItem('summaries', 'abc-123');
+    const [url, opts] = mockApiCall.mock.calls[0];
+    expect(url).toBe('/restore/summaries/abc-123');
+    expect(opts).toEqual({ method: 'POST' });
+  });
+
+  it('returns the API response unchanged', async () => {
+    const response = {
+      restored: true,
+      item: { id: 'abc-123', title: 'Restored' },
+    };
+    mockApiCall.mockResolvedValueOnce(response);
+    expect(await restoreItem('summaries', 'abc-123')).toEqual(response);
+  });
+
+  it('works for all documented table names', async () => {
+    for (const table of [
+      'summaries',
+      'keywords',
+      'flashcards',
+      'quiz-questions',
+      'videos',
+    ]) {
+      mockApiCall.mockResolvedValueOnce({ restored: true, item: {} });
+      await restoreItem(table, 'id-1');
+      expect(mockApiCall).toHaveBeenLastCalledWith(`/restore/${table}/id-1`, {
+        method: 'POST',
+      });
+    }
+  });
+
+  it('propagates errors from apiCall', async () => {
+    mockApiCall.mockRejectedValueOnce(new Error('403 denied'));
+    await expect(restoreItem('summaries', 'abc')).rejects.toThrow(
+      '403 denied',
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,15 +31,16 @@ export default defineConfig({
       '.git',
       'src/__tests__/e2e-adaptive-flashcard-session.test.tsx',
     ],
-    pool: 'threads',
+    pool: 'forks',
     poolOptions: {
-      threads: {
-        singleThread: false,
+      forks: {
+        singleFork: false,
         isolate: true,
       },
     },
     testTimeout: 10_000,
     hookTimeout: 10_000,
+    teardownTimeout: 5_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,15 @@ export default defineConfig({
       '.git',
       'src/__tests__/e2e-adaptive-flashcard-session.test.tsx',
     ],
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        singleThread: false,
+        isolate: true,
+      },
+    },
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'html'],


### PR DESCRIPTION
## Summary

First batch of tests covering critical untested areas identified in `TEST-COVERAGE-ANALYSIS.md`.

- **Flashcards** (5 files, ~80 tests): `adaptiveGenerationApi`, `flashcardMappingApi`, `reviewsApi`, `useFlashcardCoverage`, `useSmartGeneration`.
- **Summaries** (5 files, ~117 tests): `studentSummariesApi`, `studySessionApi`, `stickyNotesApi`, `useReadingTimeTracker`, `useStudentSummaryReader`.
- **Quiz** (coming): services + `quiz-utils` — in worktree, pending merge (~124 tests).
- **Infra core** (coming): `session-stats`, `concurrency`, `flashcard-utils`, `searchApi`, `platformApi`, etc. — agent still running.

All tests use `vi.mock('@/app/lib/api')` for services and `renderHook()` for hooks. No production code modified.

## Coverage delta (so far)

- 197 new tests in this commit, all passing.
- Target at end of PR: ~500+ new tests, lifting `src/app/services/` and `src/app/lib/` from ~15% to ~60% coverage.

## Test plan

- [x] `npm test` on new files passes locally
- [ ] Merge pending worktree commits (quiz + infra)
- [ ] Full suite `npm test` passes
- [ ] `quality-gate` audit green

https://claude.ai/code/session_01D68wuFR5ZzBFJVSrBHpXH4