### PR TITLE
chore: preserve WIP stash from claude/automated-security-scanning-3sIF3 (DRAFT, do not merge)

### DIFF
--- a/.stash-backups/README.md
+++ b/.stash-backups/README.md
@@ -1,0 +1,10 @@
+# Stash backups
+
+Patches exported from `git stash` to preserve WIP state across machines.
+
+## stash0-2026-04-19.patch
+
+- Original label: `WIP on claude/automated-security-scanning-3sIF3: 281c7cdd chore: update package-lock.json after npm install`
+- Scope: 1338 files, ~219k ins / 219k del — mostly line-ending noise (CRLF↔LF); real content may be mixed in.
+- Recovery: `git apply --3way .stash-backups/stash0-2026-04-19.patch` (or `git apply --reject ...` if conflicts).
+- Saved: 2026-04-19 during push-everything cleanup; the local stash entry was NOT dropped.


### PR DESCRIPTION
## Intent
Safety backup of local stash that was at risk of being lost. Exported `stash@{0}` as a patch file in `.stash-backups/` so it lives on GitHub.

## Source
- Original label: `WIP on claude/automated-security-scanning-3sIF3: 281c7cdd chore: update package-lock.json after npm install`
- Parent branch no longer exists locally.

## Content
- 1338 files, ~219k ins / 219k del
- Signal-to-noise: mostly CRLF<->LF line-ending churn from a batch editor. Some .claude/ agent memory files may contain real edits mixed in.

## How to recover
See `.stash-backups/README.md` in this branch. TL;DR:
- `git apply --3way .stash-backups/stash0-2026-04-19.patch`
- or `git apply --reject .stash-backups/stash0-2026-04-19.patch` if conflicts.

## Do NOT merge
This is a safety net. Review the patch, extract anything useful, then close without merging.