### PR TITLE
ci(bug-hunter): run every 2h and open a draft PR with findings

### DIFF
--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -1,7 +1,7 @@
 name: Bug Hunter
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -9,19 +9,155 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install -g @anthropic-ai/claude-code
+
+      - name: Skip if an open bug-hunter PR already exists
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --state open --label bug-hunter --json number --jq 'length')
+          echo "existing=$existing" >> "$GITHUB_OUTPUT"
+          if [ "$existing" != "0" ]; then
+            echo "An open bug-hunter PR already exists — skipping this run."
+          fi
+
+      - name: Ensure bug-hunter label exists
+        if: steps.dedupe.outputs.existing == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create bug-hunter \
+            --description "Automated findings from the Bug Hunter workflow" \
+            --color B60205 2>/dev/null || true
+
+      - name: Configure git
+        if: steps.dedupe.outputs.existing == '0'
+        run: |
+          git config user.name  "claude-bug-hunter[bot]"
+          git config user.email "claude-bug-hunter@users.noreply.github.com"
+
+      - name: Create working branch
+        if: steps.dedupe.outputs.existing == '0'
+        id: branch
+        run: |
+          ts=$(date -u +%Y%m%d-%H%M)
+          branch="claude/bug-hunter-${ts}-${GITHUB_RUN_NUMBER}"
+          git checkout -b "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "ts=$ts"         >> "$GITHUB_OUTPUT"
+
+      - name: Install Claude Code
+        if: steps.dedupe.outputs.existing == '0'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run Claude bug hunter
+        if: steps.dedupe.outputs.existing == '0'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_PATH: .bug-hunter/report-${{ steps.branch.outputs.ts }}.md
         run: |
-          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
+          mkdir -p .bug-hunter
+          claude -p "You are the Bug Hunter running inside GitHub Actions on the Axon frontend (React + TypeScript + Vite).
+
+          GOAL: Produce a markdown report at \`${REPORT_PATH}\` listing CONFIRMED bugs. Nothing else gets committed on this run — no auto-fixes.
+
+          SCOPE (look for REAL bugs, not nits):
+          - Type unsafety: \`any\`, unsafe casts, missing null checks on values that can be null.
+          - React anti-patterns: missing keys, stale closures, incorrect effect deps, setState in render, conditional hooks.
+          - Dead code / broken imports / unreachable branches.
+          - Missing error handling on async flows, swallowed rejections, unawaited promises.
+          - Security: XSS via \`dangerouslySetInnerHTML\` without sanitization, leaked secrets, unsafe \`eval\`, prototype pollution.
+          - API contract bugs: wrong HTTP verb, missing auth header per CLAUDE.md rules (Authorization = anon key, X-Access-Token = user JWT).
+          - Design-system violations that change behavior (not just style): focus rings that trap keyboard users, interactive elements with no accessible name.
+
+          RULES:
+          - Be strict. If uncertain, skip it. No style nits, no \"consider refactoring\" suggestions.
+          - Each finding MUST cite \`path/to/file.ts:LINE\` and include a 1-3 line code excerpt.
+          - Max 10 findings. Rank by severity (critical → low).
+          - If ZERO bugs found, write the report with the single line: \`No bugs found in this run.\` (the workflow will skip the PR).
+
+          REPORT FORMAT:
+          # Bug Hunter Report — <UTC timestamp>
+
+          ## Summary
+          <one paragraph: counts by severity>
+
+          ## Findings
+          ### 1. <short title> — severity: critical|high|medium|low
+          - **File:** \`src/...:LINE\`
+          - **Category:** type-safety | react | security | error-handling | api-contract | dead-code
+          - **Problem:** <what is wrong and why it is a bug>
+          - **Evidence:**
+          \`\`\`ts
+          <excerpt>
+          \`\`\`
+          - **Suggested fix:** <concise>
+
+          (repeat for each finding)
+
+          Write the file using the Write tool. Do not modify any other files. Do not run git commands." \
             --dangerously-skip-permissions \
-            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*)"
+            --allowedTools "Read,Glob,Grep,Write,Bash(ls:*),Bash(wc:*),Bash(date:*)"
+
+      - name: Check report and decide whether to open a PR
+        if: steps.dedupe.outputs.existing == '0'
+        id: report
+        run: |
+          report="$(ls -1 .bug-hunter/report-*.md 2>/dev/null | head -n1 || true)"
+          if [ -z "$report" ] || [ ! -s "$report" ]; then
+            echo "No report produced — skipping PR."
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -q "^No bugs found in this run.$" "$report"; then
+            echo "Report says no bugs — skipping PR."
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "report_path=$report"       >> "$GITHUB_OUTPUT"
+          echo "has_findings=true"         >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push report
+        if: steps.dedupe.outputs.existing == '0' && steps.report.outputs.has_findings == 'true'
+        run: |
+          git add .bug-hunter/
+          git commit -m "chore(bug-hunter): report ${{ steps.branch.outputs.ts }}"
+          git push -u origin "${{ steps.branch.outputs.branch }}"
+
+      - name: Open draft PR
+        if: steps.dedupe.outputs.existing == '0' && steps.report.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_PATH: ${{ steps.report.outputs.report_path }}
+          BRANCH:      ${{ steps.branch.outputs.branch }}
+          TS:          ${{ steps.branch.outputs.ts }}
+        run: |
+          {
+            echo "Automated report from the Bug Hunter workflow (UTC $TS)."
+            echo
+            echo "Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "---"
+            echo
+            cat "$REPORT_PATH"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --draft \
+            --base main \
+            --head "$BRANCH" \
+            --title "bug-hunter: findings ${TS}" \
+            --label bug-hunter \
+            --body-file /tmp/pr-body.md


### PR DESCRIPTION
## Summary

Reconfigures `.github/workflows/bug-hunter.yml` so Claude runs unattended every 2 hours and produces reviewable output instead of just issues.

- **Schedule:** `cron: '0 */2 * * *'` (was every 3h). Manual `workflow_dispatch` preserved.
- **Output:** Claude writes a markdown report to `.bug-hunter/report-<ts>.md`; the workflow commits it on a fresh branch `claude/bug-hunter-<ts>-<run#>` and opens a **draft** PR labeled `bug-hunter`.
- **Deduplication:** if an open `bug-hunter` PR already exists, the run exits early — no PR spam while a previous report is pending review.
- **No-bugs short-circuit:** if the report contains only `No bugs found in this run.`, no commit and no PR are created.
- **Blast radius:** Claude is restricted to `Read,Glob,Grep,Write` plus a handful of read-only Bash commands. It cannot run `git` or edit source files — only write the report. The workflow itself handles branch/commit/push/PR.
- **Permissions:** `contents: write`, `pull-requests: write`, `issues: write` (needed to push the branch, open the PR, and create the `bug-hunter` label if missing).
- **Auth:** uses existing `secrets.CLAUDE_CODE_OAUTH_TOKEN` (OAuth of this account) and the default `GITHUB_TOKEN`.

## Scope of the audit prompt

Claude looks only for confirmed bugs, not nits: type unsafety, React anti-patterns (keys, stale closures, effect deps, conditional hooks), dead code, missing error handling on async flows, XSS / leaked secrets, API-contract violations (Authorization vs. X-Access-Token per `CLAUDE.md`), accessibility regressions that break behavior. Max 10 findings per run, ranked by severity, each with `file:line` and a code excerpt.

## Prerequisite

Secret `CLAUDE_CODE_OAUTH_TOKEN` must exist at repo level (Settings → Secrets and variables → Actions). If it's not there yet, the scheduled runs will fail until it's added.

## Test plan

- [ ] Merge this PR (or cherry-pick the workflow change) so `main` has the new cron.
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` to repo secrets if missing.
- [ ] Trigger manually from the Actions tab (`workflow_dispatch`) to validate end-to-end on demand before waiting 2h.
- [ ] Confirm a draft PR appears labeled `bug-hunter` with the report inline, OR that the job logs report "No bugs found" and exits cleanly.
- [ ] Verify the dedupe step: run twice with an open `bug-hunter` PR; the second run should skip early.

https://claude.ai/code/session_01PFf4FvRq1Z3aKXreUYfhxM