### PR TITLE
fix: batch bug-fixes from open-issue audit (13 issues)

### DIFF
--- a/src/app/components/ai/ai-assistant/AxonAIAssistant.tsx
+++ b/src/app/components/ai/ai-assistant/AxonAIAssistant.tsx
@@ -128,7 +128,20 @@ function AxonAIAssistantComponent({ isOpen, onClose, summaryId }: AxonAIAssistan
     finally { setIsLoading(false); }
   };
 
-  const copyText = (text: string, id: string) => { navigator.clipboard.writeText(text); setCopiedId(id); setTimeout(() => setCopiedId(null), 2000); };
+  const copyText = (text: string, id: string) => {
+    // Await the promise so the "Copied" indicator only flips when the write
+    // actually succeeded. Handle rejection (denied permission, non-secure
+    // context, iframe sandbox) via the existing in-panel system-message UX
+    // instead of letting an unhandled rejection bubble up.
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        setCopiedId(id);
+        setTimeout(() => setCopiedId(null), 2000);
+      })
+      .catch(() => {
+        addMessage('system', 'No se pudo copiar al portapapeles', true);
+      });
+  };
 
   const handleRagFeedback = async (msgId: string, feedback: 'positive' | 'negative') => {
     const logId = messageLogIds.get(msgId);

--- a/src/app/components/professor/FlashcardImageUpload.tsx
+++ b/src/app/components/professor/FlashcardImageUpload.tsx
@@ -79,24 +79,26 @@ export function FlashcardImageUpload({
     const localPreview = URL.createObjectURL(file);
     setPreviewUrl(localPreview);
 
+    // Declared outside try so finally can always clear it — on upload error
+    // the interval otherwise keeps firing forever and animates the progress bar
+    // in a loop until the component unmounts.
+    let progressInterval: ReturnType<typeof setInterval> | null = null;
     try {
-      // Simulate progress since we can't track real upload progress with fetch
-      const progressInterval = setInterval(() => {
+      progressInterval = setInterval(() => {
         setProgress(prev => Math.min(prev + 15, 85));
       }, 200);
 
       // Build FormData (NOT JSON)
-const formData = new FormData();
-formData.append('file', file);
-formData.append('folder', 'flashcards');
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('folder', 'flashcards');
 
-const result = await apiCall<{ path: string }>('/storage/upload', {
-  method: 'POST',
-  body: formData,
-  // ⚠️ NO pongas Content-Type — el browser lo pone solo con el boundary
-});
+      const result = await apiCall<{ path: string }>('/storage/upload', {
+        method: 'POST',
+        body: formData,
+        // ⚠️ NO pongas Content-Type — el browser lo pone solo con el boundary
+      });
 
-      clearInterval(progressInterval);
       setProgress(100);
 
       // Construct public URL
@@ -112,6 +114,7 @@ const result = await apiCall<{ path: string }>('/storage/upload', {
       URL.revokeObjectURL(localPreview);
       setPreviewUrl(null);
     } finally {
+      if (progressInterval) clearInterval(progressInterval);
       setUploading(false);
       setProgress(0);
     }

--- a/src/app/components/professor/QuizExportImport.tsx
+++ b/src/app/components/professor/QuizExportImport.tsx
@@ -102,10 +102,15 @@ export function QuizExportImport({
   }, [exportJson, quizTitle]);
 
   const handleCopy = useCallback(() => {
+    // navigator.clipboard.writeText rejects when the page is not in a secure
+    // context or the user denies clipboard permission — without .catch the
+    // rejection bubbles up as unhandled and the user sees no feedback.
     navigator.clipboard.writeText(exportJson).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
       toast.success('Copiado al portapapeles');
+    }).catch(() => {
+      toast.error('No se pudo copiar al portapapeles');
     });
   }, [exportJson]);
 

--- a/src/app/components/roles/pages/professor/ProfessorModelViewerPage.tsx
+++ b/src/app/components/roles/pages/professor/ProfessorModelViewerPage.tsx
@@ -32,23 +32,27 @@ export function ProfessorModelViewerPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showPartsPanel, setShowPartsPanel] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
 
   // ── Fetch model record ──
-  const fetchModel = useCallback(async () => {
+  // Guarded with a `cancelled` flag so rapid modelId changes or unmount
+  // before the network completes do not fire setState on an unmounted
+  // component and do not let an older, slower request overwrite a newer one.
+  useEffect(() => {
     if (!modelId) return;
+    let cancelled = false;
     setLoading(true);
     setError(null);
-    try {
-      const data = await getModel3DById(modelId);
-      setModel(data);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Error al cargar el modelo');
-    } finally {
-      setLoading(false);
-    }
-  }, [modelId]);
+    getModel3DById(modelId)
+      .then(data => { if (!cancelled) setModel(data); })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Error al cargar el modelo');
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [modelId, retryTick]);
 
-  useEffect(() => { fetchModel(); }, [fetchModel]);
+  const handleRetry = useCallback(() => setRetryTick(t => t + 1), []);
 
   // ── Loading state ──
   if (loading) {
@@ -81,7 +85,7 @@ export function ProfessorModelViewerPage() {
               Volver al curriculum
             </button>
             <button
-              onClick={fetchModel}
+              onClick={handleRetry}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-[#5cbdaa] bg-[#2a8c7a]/10 border border-[#2a8c7a]/20 rounded-lg hover:bg-[#2a8c7a]/20 transition-colors"
             >
               Reintentar

--- a/src/app/components/roles/pages/student/ReviewSessionView.tsx
+++ b/src/app/components/roles/pages/student/ReviewSessionView.tsx
@@ -81,18 +81,6 @@ export function ReviewSessionView({ onClose, masteryMap }: ReviewSessionViewProp
   const stopTimer = useCallback(() => { if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; } }, []);
   const formattedTime = useMemo(() => { const m = Math.floor(elapsedSeconds / 60); const s = elapsedSeconds % 60; return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`; }, [elapsedSeconds]);
 
-  useEffect(() => {
-    if (phase !== 'reviewing') return;
-    function handleKeyDown(e: KeyboardEvent) {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-      if (e.key === ' ' || e.key === 'Spacebar') { e.preventDefault(); if (!isFlipped) setIsFlipped(true); }
-      else if (isFlipped && e.key >= '1' && e.key <= '5') { e.preventDefault(); handleGrade(parseInt(e.key, 10)); }
-    }
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [phase, isFlipped, handleGrade]);
-
   // Load due cards
   useEffect(() => {
     let cancelled = false;
@@ -151,6 +139,21 @@ export function ReviewSessionView({ onClose, masteryMap }: ReviewSessionViewProp
       })();
     }
   }, [sessionId, currentItem, currentIdx, queue, queueReview, submitBatch, stopTimer, masteryMap, recordXP, endXP, institutionId, markSessionComplete]);
+
+  // Keyboard shortcuts — MUST be declared AFTER handleGrade, otherwise the
+  // deps array reads `handleGrade` from the Temporal Dead Zone and throws
+  // ReferenceError on every render (#452).
+  useEffect(() => {
+    if (phase !== 'reviewing') return;
+    function handleKeyDown(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key === ' ' || e.key === 'Spacebar') { e.preventDefault(); if (!isFlipped) setIsFlipped(true); }
+      else if (isFlipped && e.key >= '1' && e.key <= '5') { e.preventDefault(); handleGrade(parseInt(e.key, 10)); }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [phase, isFlipped, handleGrade]);
 
   const gradeDistribution = useMemo(() => { const dist = [0, 0, 0, 0, 0]; for (const g of gradesRef.current) { if (g >= 1 && g <= 5) dist[g - 1]++; } return dist; }, [grades]);
   const correctPercentage = useMemo(() => { if (grades.length === 0) return 0; return Math.round((grades.filter(g => g >= 3).length / grades.length) * 100); }, [grades]);

--- a/src/app/components/shared/ErrorBoundary.tsx
+++ b/src/app/components/shared/ErrorBoundary.tsx
@@ -76,10 +76,14 @@ function PageFallback({
         <button
           onClick={() => {
             supabase.auth.signOut().catch(() => {});
-            localStorage.removeItem('axon_active_membership');
-            localStorage.removeItem('axon_access_token');
-            localStorage.removeItem('axon_user');
-            localStorage.removeItem('axon_memberships');
+            // Guarded: if the original error came from localStorage (private mode)
+            // the recovery button must NOT crash here — proceed to redirect.
+            try {
+              localStorage.removeItem('axon_active_membership');
+              localStorage.removeItem('axon_access_token');
+              localStorage.removeItem('axon_user');
+              localStorage.removeItem('axon_memberships');
+            } catch { /* private browsing — proceed */ }
             onReset();
             window.location.href = '/login';
           }}

--- a/src/app/components/student/QuizCountdownTimer.tsx
+++ b/src/app/components/student/QuizCountdownTimer.tsx
@@ -25,10 +25,15 @@ export const QuizCountdownTimer = React.memo(function QuizCountdownTimer({
   useEffect(() => { setRemaining(timeLimitSec); hasFiredRef.current = false; }, [resetKey, timeLimitSec]);
 
   useEffect(() => {
-    if (paused || remaining <= 0) return;
+    // Deps intentionally exclude `remaining`: including it would tear down
+    // and recreate the interval on every tick, causing timer drift. The
+    // functional updater already reads the latest value from closure, and
+    // the zero-guard lives inside the updater so no effect re-run is needed.
+    if (paused) return;
     const interval = setInterval(() => {
       setRemaining(prev => {
-        const next = Math.max(0, prev - 1);
+        if (prev <= 0) return 0;
+        const next = prev - 1;
         if (next === 0 && !hasFiredRef.current) {
           hasFiredRef.current = true;
           setTimeout(() => onTimeoutRef.current(), 0);
@@ -37,7 +42,7 @@ export const QuizCountdownTimer = React.memo(function QuizCountdownTimer({
       });
     }, 1000);
     return () => clearInterval(interval);
-  }, [paused, remaining]);
+  }, [paused]);
 
   const pct = timeLimitSec > 0 ? remaining / timeLimitSec : 0;
   const mins = Math.floor(remaining / 60);

--- a/src/app/components/student/useQuizGamificationFeedback.ts
+++ b/src/app/components/student/useQuizGamificationFeedback.ts
@@ -76,30 +76,46 @@ export function useQuizGamificationFeedback(): QuizGamificationFeedback {
   useEffect(() => {
     if (firedRef.current) return;
     firedRef.current = true;
+    let cancelled = false;
+    let initialDelayId: ReturnType<typeof setTimeout> | undefined;
+    let finalizeDelayId: ReturnType<typeof setTimeout> | undefined;
 
     (async () => {
       try {
         // Wait for backend afterWrite hooks to complete
         // (quiz_attempt → award XP → update profile)
-        await new Promise((r) => setTimeout(r, 800));
+        await new Promise<void>((r) => { initialDelayId = setTimeout(r, 800); });
+        if (cancelled) return;
 
         // Step 1: Refresh profile — this triggers xpDelta and
         // levelUpEvent detection inside useGamificationProfile
         await gamification.refresh();
+        if (cancelled) return;
 
         // Step 2: Check for new badges earned from this quiz
         await gamification.triggerBadgeCheck();
       } catch (err) {
-        logger.error('[QuizGamificationFeedback] Post-quiz feedback error (non-blocking):', err);
+        if (!cancelled) {
+          logger.error('[QuizGamificationFeedback] Post-quiz feedback error (non-blocking):', err);
+        }
       } finally {
-        // Mark as done — sync effects below will pick up the data
-        // Small delay to ensure React has batched the state updates
-        setTimeout(() => {
-          setIsLoading(false);
-          setIsConfirmed(true);
-        }, 100);
+        // Mark as done — sync effects below will pick up the data.
+        // Small delay to ensure React has batched the state updates.
+        if (!cancelled) {
+          finalizeDelayId = setTimeout(() => {
+            if (cancelled) return;
+            setIsLoading(false);
+            setIsConfirmed(true);
+          }, 100);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+      if (initialDelayId) clearTimeout(initialDelayId);
+      if (finalizeDelayId) clearTimeout(finalizeDelayId);
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Intentionally empty — fire once on mount
 

--- a/src/app/components/viewer3d/ModelPartMesh.tsx
+++ b/src/app/components/viewer3d/ModelPartMesh.tsx
@@ -105,12 +105,19 @@ export function getStoredLayers(modelId: string): ModelLayerConfig[] {
 
 /** Write-through to localStorage (keeps cache fresh) */
 export function setStoredParts(modelId: string, parts: ModelPartConfig[]): void {
-  localStorage.setItem(PARTS_KEY(modelId), JSON.stringify(parts));
+  // Part JSON can reach hundreds of KB; browsers enforce a ~5 MB localStorage
+  // quota and throw SecurityError in private mode. A cache miss on next load
+  // is acceptable — do NOT let cache writes fail the 3D viewer load.
+  try {
+    localStorage.setItem(PARTS_KEY(modelId), JSON.stringify(parts));
+  } catch { /* quota exceeded or private browsing — cache write is best-effort */ }
 }
 
 /** Write-through to localStorage (keeps cache fresh) */
 export function setStoredLayers(modelId: string, layers: ModelLayerConfig[]): void {
-  localStorage.setItem(LAYERS_KEY(modelId), JSON.stringify(layers));
+  try {
+    localStorage.setItem(LAYERS_KEY(modelId), JSON.stringify(layers));
+  } catch { /* quota exceeded or private browsing — cache write is best-effort */ }
 }
 
 /**

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -34,12 +34,16 @@ let _accessToken: string | null = null;
 
 export function setAccessToken(t: string | null) {
   _accessToken = t;
-  // Sync to localStorage for backward compat (apiConfig.ts getRealToken)
-  if (t) {
-    localStorage.setItem('axon_access_token', t);
-  } else {
-    localStorage.removeItem('axon_access_token');
-  }
+  // Sync to localStorage for backward compat (apiConfig.ts getRealToken).
+  // Wrap in try/catch: Safari/Firefox private mode throws SecurityError on any
+  // localStorage access. Module-level token is still set correctly either way.
+  try {
+    if (t) {
+      localStorage.setItem('axon_access_token', t);
+    } else {
+      localStorage.removeItem('axon_access_token');
+    }
+  } catch { /* private browsing — ignore */ }
 }
 
 export function getAccessToken(): string | null {
@@ -61,11 +65,13 @@ function handleUnauthorized(): void {
   // Clear module-level token
   _accessToken = null;
 
-  // Clear localStorage auth data
-  localStorage.removeItem('axon_access_token');
-  localStorage.removeItem('axon_active_membership');
-  localStorage.removeItem('axon_user');
-  localStorage.removeItem('axon_memberships');
+  // Clear localStorage auth data (guarded for private-browsing SecurityError)
+  try {
+    localStorage.removeItem('axon_access_token');
+    localStorage.removeItem('axon_active_membership');
+    localStorage.removeItem('axon_user');
+    localStorage.removeItem('axon_memberships');
+  } catch { /* private browsing — proceed with redirect anyway */ }
 
   // Sign out from Supabase (fire-and-forget)
   supabase.auth.signOut().catch(() => {});
@@ -122,11 +128,13 @@ export async function apiCall<T = any>(
     // Timeout via AbortController
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     let controller: AbortController | undefined;
+    let onExternalAbort: (() => void) | undefined;
 
     if (timeoutMs > 0) {
       controller = new AbortController();
       if (fetchOptions.signal) {
-        fetchOptions.signal.addEventListener('abort', () => controller!.abort());
+        onExternalAbort = () => controller!.abort();
+        fetchOptions.signal.addEventListener('abort', onExternalAbort);
       }
       timeoutId = setTimeout(() => controller!.abort(), timeoutMs);
     }
@@ -138,25 +146,36 @@ export async function apiCall<T = any>(
         signal: controller?.signal || fetchOptions.signal,
       });
 
-      const text = await res.text();
-
-      let json: any;
-      try {
-        json = JSON.parse(text);
-      } catch {
-        if (import.meta.env.DEV) {
-          console.error(`[API] Non-JSON response from ${path}:`, text.substring(0, 300));
-        }
-        throw new Error(`Invalid response from server (${res.status})`);
-      }
-
-      // 401 → token expired/revoked → sign out and redirect
+      // 401 → token expired/revoked → sign out and redirect.
+      // Evaluate this BEFORE body parse so empty 401 bodies still trigger logout.
       if (res.status === 401) {
         if (import.meta.env.DEV) {
           console.warn(`[API] 401 Unauthorized at ${path} — signing out`);
         }
         handleUnauthorized();
         throw new Error('Session expired');
+      }
+
+      const text = await res.text();
+
+      // Empty-body 2xx (e.g. 204 No Content) is a legitimate success response;
+      // attempting to JSON.parse('') would throw and turn the success into an error.
+      if (res.ok && text.length === 0) {
+        return undefined as T;
+      }
+
+      let json: any;
+      if (text.length === 0) {
+        json = null;
+      } else {
+        try {
+          json = JSON.parse(text);
+        } catch {
+          if (import.meta.env.DEV) {
+            console.error(`[API] Non-JSON response from ${path}:`, text.substring(0, 300));
+          }
+          throw new Error(`Invalid response from server (${res.status})`);
+        }
       }
 
       if (!res.ok) {
@@ -185,6 +204,11 @@ export async function apiCall<T = any>(
       throw err;
     } finally {
       if (timeoutId) clearTimeout(timeoutId);
+      // Detach the abort bridge so we don't leak listeners on reused signals
+      // (React Query, long-lived useEffect cleanup controllers, etc.)
+      if (onExternalAbort && fetchOptions.signal) {
+        fetchOptions.signal.removeEventListener('abort', onExternalAbort);
+      }
     }
   };
 
@@ -230,8 +254,10 @@ export async function* apiCallStream<T = any>(
   }
 
   const controller = new AbortController();
+  let onExternalAbort: (() => void) | undefined;
   if (fetchOptions.signal) {
-    fetchOptions.signal.addEventListener('abort', () => controller.abort());
+    onExternalAbort = () => controller.abort();
+    fetchOptions.signal.addEventListener('abort', onExternalAbort);
   }
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -312,6 +338,9 @@ export async function* apiCallStream<T = any>(
     throw err;
   } finally {
     clearTimeout(timeoutId);
+    if (onExternalAbort && fetchOptions.signal) {
+      fetchOptions.signal.removeEventListener('abort', onExternalAbort);
+    }
   }
 }
 

--- a/src/app/utils/lazyRetry.ts
+++ b/src/app/utils/lazyRetry.ts
@@ -12,6 +12,29 @@
 
 const RETRY_KEY = 'axon-chunk-retry';
 
+// In-memory fallback for private-browsing contexts where sessionStorage throws
+// SecurityError. We still want loop-prevention across this chunk-retry flow
+// even when storage is unavailable (the reload clears it anyway).
+let _memRetry = false;
+
+function getRetried(): boolean {
+  try {
+    return sessionStorage.getItem(RETRY_KEY) === '1';
+  } catch {
+    return _memRetry;
+  }
+}
+
+function setRetried(): void {
+  _memRetry = true;
+  try { sessionStorage.setItem(RETRY_KEY, '1'); } catch { /* private mode */ }
+}
+
+function clearRetried(): void {
+  _memRetry = false;
+  try { sessionStorage.removeItem(RETRY_KEY); } catch { /* private mode */ }
+}
+
 /**
  * Wraps a dynamic import with stale-chunk detection and auto-reload.
  *
@@ -33,15 +56,14 @@ export function lazyRetry<T>(importFn: () => Promise<T>): Promise<T> {
       throw error;
     }
 
-    // Prevent infinite reload loop: only retry once per session
-    const hasRetried = sessionStorage.getItem(RETRY_KEY);
-    if (hasRetried) {
-      sessionStorage.removeItem(RETRY_KEY);
+    // Prevent infinite reload loop: only retry once per session.
+    if (getRetried()) {
+      clearRetried();
       throw error;
     }
 
     // Mark that we're retrying and reload to get new chunk manifest
-    sessionStorage.setItem(RETRY_KEY, '1');
+    setRetried();
     if (import.meta.env.DEV) {
       console.warn('[lazyRetry] Stale chunk detected, reloading...', error.message);
     }


### PR DESCRIPTION
## Summary

Audited the 50 open issues in the repo and fixed 11 of them plus verified 2 more that were already silently resolved in the codebase.

Each edit is narrowly scoped to the file cited in its issue — no refactors, no unrelated cleanup.

## Closes

- Closes #471 — `setAccessToken` wraps `localStorage.{set,remove}Item` in try/catch so Safari/Firefox private-mode `SecurityError` no longer aborts login. Same guard applied to `handleUnauthorized` cleanup.
- Closes #472 — `ErrorBoundary` "Volver al inicio" button guards the localStorage cleanup so the recovery path doesn't crash on the very failure it's recovering from.
- Closes #473 — `setStoredParts` / `setStoredLayers` made best-effort so `QuotaExceededError` on the 3D viewer cache does not fail the viewer load.
- Closes #474 — `lazyRetry` wraps sessionStorage in try/catch with an in-memory fallback so chunk-recovery reload still fires in private mode.
- Closes #459 — `apiCall` short-circuits empty-body 2xx (e.g. 204 No Content) to `undefined` instead of throwing `Invalid response from server`. The 401 check was also hoisted above body-parse so empty-body 401s still trigger logout.
- Closes #466 — `apiCall` and `apiCallStream` capture the external-signal abort bridge and remove it in `finally`, preventing listener accumulation on long-lived caller signals.
- Closes #452 — `ReviewSessionView`: moved `handleGrade` useCallback above the keyboard-shortcut `useEffect` that referenced it in deps. The old order triggered `ReferenceError: Cannot access 'handleGrade' before initialization` on every render (TDZ).
- Closes #502 — `QuizCountdownTimer`: removed `remaining` from the interval effect deps. Previously the interval was torn down and recreated on every tick (timer drift). Zero-guard moved inside the functional updater.
- Closes #496 — `FlashcardImageUpload`: `clearInterval` moved to `finally` so upload errors no longer leave the progress bar animating forever.
- Closes #499 — `QuizExportImport.handleCopy`: added `.catch` so clipboard permission failures produce a toast instead of an unhandled rejection.
- Closes #504 — `AxonAIAssistant.copyText`: await `clipboard.writeText` so "Copied" only flips on real success; failures surface via the existing in-panel system message.
- Closes #505 — `ProfessorModelViewerPage`: replaced `useCallback + useEffect(fn)` with a cancellation-guarded effect plus a retryTick handler. Prevents stale setState on unmount and older requests overwriting newer results on rapid `modelId` changes.
- Closes #506 — `useQuizGamificationFeedback`: track a `cancelled` flag and clear both internal timers in cleanup. Post-quiz feedback no longer sets state on unmounted components or fires wasted `refresh()` / `triggerBadgeCheck()` network calls after navigation.

## Already fixed in the codebase (closed separately, not in this PR)

- #464 `noteHtml.ts` — already uses `DOMParser.parseFromString` instead of `innerHTML`; no inline-handler execution surface.
- #490 `ChunkRenderer` — already pipes `chunk.content` through `sanitizeHtml` (DOMPurify with strict allowlist + explicit `FORBID_ATTR: ['onerror', 'onload', ...]`).

## Validation

- `npx tsc --noEmit` — clean (only pre-existing tsconfig deprecation warnings).
- `npm run build` — succeeds.
- `npx vitest run src/app/lib/__tests__/api.test.ts src/app/utils/__tests__/lazyRetry.test.ts` — 38/38 pass. No existing test touches the other changed files.

## Test plan
- [ ] Manual: open app in Safari private mode and confirm login no longer hangs (#471).
- [ ] Manual: trigger an ErrorBoundary in private mode, click "Volver al inicio", confirm redirect to `/login` (#472).
- [ ] Manual: open a 3D model with parts cache near quota, confirm viewer loads (#473).
- [ ] Manual: trigger stale-chunk error in Safari private mode, confirm page reloads once (#474).
- [ ] Manual: call a 204-returning DELETE and confirm no `Invalid response from server` toast (#459).
- [ ] Manual: enter the ReviewSessionView and confirm no ReferenceError in console (#452).
- [ ] Manual: start a quiz with a timer and confirm it counts down smoothly (#502).
- [ ] Manual: upload a flashcard image that triggers a backend error — progress bar should stop (#496).
- [ ] Manual: copy in QuizExportImport / AxonAIAssistant with clipboard permission denied — expect toast/system-message, not silent success (#499, #504).
- [ ] Manual: navigate away from 3D viewer mid-load and post-quiz results mid-refresh — no React "state update on unmounted component" warnings (#505, #506).