### PR TITLE
ci: audit — allow claude-bot PRs (allowed_bots)

### DIFF
--- a/.github/workflows/code-quality-audit.yml
+++ b/.github/workflows/code-quality-audit.yml
@@ -25,6 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
           prompt: |
             You are the code-quality-auditor. Audit the changes in PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}").
 


### PR DESCRIPTION
Fix follow-up to the claude-fix workflow: audit was rejecting PRs opened by claude[bot] with 'Workflow initiated by non-human actor'. Adding `allowed_bots: "claude"` so auto-fixed PRs pass through the quality auditor.