### PR TITLE
ci(bug-hunter): run hourly instead of every 3h

### DIFF
--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -1,7 +1,7 @@
 name: Bug Hunter
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changes `.github/workflows/bug-hunter.yml` cron from every-3h to every-1h. Catches regressions faster at ~3x the quota cost.