### PR TITLE
ci: auto-label pipeline (bug-hunter → claude-fix without manual trigger)

### DIFF
--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -22,6 +22,6 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
+          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. IMMEDIATELY after creating the issue, run `gh issue edit <new-number> --add-label claude-fix` so the claude-fix workflow auto-picks it up. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
             --dangerously-skip-permissions \
-            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*)"
+            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue edit:*)"

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -14,7 +14,13 @@ jobs:
   fix:
     if: >-
       github.event.label.name == 'claude-fix' &&
-      github.event.sender.login == 'Matraca130'
+      (
+        github.event.sender.login == 'Matraca130' ||
+        (
+          github.event.sender.login == 'github-actions[bot]' &&
+          contains(github.event.issue.labels.*.name, 'bug-hunter')
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 25
 


### PR DESCRIPTION
Wires bug-hunter to automatically apply the `claude-fix` label on each issue it creates, so claude-fix picks up the work without manual labeling.

## Changes
1. **bug-hunter.yml** — after `gh issue create`, runs `gh issue edit --add-label claude-fix`.
2. **claude-fix.yml** — gate widened: accepts `github-actions[bot]` as sender only when the issue also has the `bug-hunter` label, so only legitimate bug-hunter issues can auto-trigger. Manual trigger by @Matraca130 still works on any issue.

## Flow
```
bug-hunter (hourly)  ──►  issue [bug-hunter, claude-fix]
                                    ↓ auto
claude-fix           ──►  PR (trivial) / plan (complex)
                                    ↓
audit                ──►  findings
                                    ↓
@Matraca130          ──►  review + merge
```

## Quota warning
Hourly × 3 repos × 5 issues × Opus = **~360 runs/day max**. Monitor the Max window; reduce cron to 3-6h if rate-limits hit.