### PR TITLE
ci: fix bug-hunter → claude-fix chain via workflow_dispatch

### DIFF
--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -22,6 +23,6 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. IMMEDIATELY after creating the issue, run `gh issue edit <new-number> --add-label claude-fix` so the claude-fix workflow auto-picks it up. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
+          claude -p "Scan this frontend repo (TypeScript + React + Vite) for bugs: type unsafety (any, unsafe casts), React anti-patterns (missing keys, stale closures, effect deps), dead code, missing error handling, XSS vectors, leaked secrets, broken imports. For each confirmed bug open a GitHub issue: title 'bug: <short desc>', label 'bug-hunter', body with file:line and fix suggestion. IMMEDIATELY after creating the issue: (1) run 'gh issue edit <new-number> --add-label claude-fix' for tracking, then (2) run 'gh workflow run claude-fix.yml -f issue_number=<new-number>' — the workflow_dispatch call is what actually triggers the auto-fix pipeline, because labels added by GITHUB_TOKEN do NOT trigger downstream workflows but workflow_dispatch events DO. Check existing open issues with label bug-hunter first and skip duplicates. Max 5 new issues per run. Be strict - only report real bugs, no nits." \
             --dangerously-skip-permissions \
-            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue edit:*)"
+            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh workflow run:*)"

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -3,6 +3,12 @@ name: Claude Fix (issue → PR)
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to fix"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,12 +19,15 @@ permissions:
 jobs:
   fix:
     if: >-
-      github.event.label.name == 'claude-fix' &&
+      github.event_name == 'workflow_dispatch' ||
       (
-        github.event.sender.login == 'Matraca130' ||
+        github.event.label.name == 'claude-fix' &&
         (
-          github.event.sender.login == 'github-actions[bot]' &&
-          contains(github.event.issue.labels.*.name, 'bug-hunter')
+          github.event.sender.login == 'Matraca130' ||
+          (
+            github.event.sender.login == 'github-actions[bot]' &&
+            contains(github.event.issue.labels.*.name, 'bug-hunter')
+          )
         )
       )
     runs-on: ubuntu-latest
@@ -35,18 +44,36 @@ jobs:
           git config user.name "claude-fix[bot]"
           git config user.email "ariverol@teiainstitute.org"
 
+      - name: Resolve issue metadata
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
+        run: |
+          ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json number,title,body,url)
+          TITLE=$(echo "$ISSUE_JSON" | jq -r .title)
+          URL=$(echo "$ISSUE_JSON" | jq -r .url)
+          echo "number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<ISSUE_BODY_EOF"
+            echo "$ISSUE_JSON" | jq -r .body
+            echo "ISSUE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Fix
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          ISSUE_TITLE: ${{ steps.issue.outputs.title }}
+          ISSUE_BODY: ${{ steps.issue.outputs.body }}
+          ISSUE_URL: ${{ steps.issue.outputs.url }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You have been assigned issue #${{ github.event.issue.number }}: "${{ github.event.issue.title }}".
+            You have been assigned issue #${{ steps.issue.outputs.number }}: "${{ steps.issue.outputs.title }}".
 
             Full issue body is available in the env var `$ISSUE_BODY`. Read it first with `echo "$ISSUE_BODY"` in a Bash step.
 


### PR DESCRIPTION
## Problema

Issues con label `claude-fix` creados por el bot `github-actions[bot]` (vía `bug-hunter.yml`) no disparaban `claude-fix.yml`. Se acumularon 10+ issues etiquetados sin que se abriera ningún PR (ej. #545–554).

## Causa raíz

`bug-hunter.yml` usa `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` para etiquetar issues. GitHub tiene una protección anti-recursión documentada:

> Eventos disparados por `GITHUB_TOKEN` **no crean nuevos workflow runs** — excepto `workflow_dispatch` y `repository_dispatch`.

Entonces el `issues.labeled` event que dispararía `claude-fix.yml` simplemente se descarta.

## Fix

Se aprovecha la excepción de `workflow_dispatch`:

- **`claude-fix.yml`**: se agrega trigger `workflow_dispatch` con input `issue_number`. Cuando llega por esa vía, un step nuevo (`Resolve issue metadata`) hace `gh issue view <N> --json ...` y expone title/body/url como outputs para el action de Claude. El trigger `issues.labeled` se mantiene para etiquetado manual por humanos.
- **`bug-hunter.yml`**: se concede `actions: write`, el prompt de Claude ahora ejecuta `gh workflow run claude-fix.yml -f issue_number=<N>` después de etiquetar, y se extiende `allowedTools` para permitir `gh workflow run`.

## Por qué no Opción A (PAT)

Considerada, pero requiere que el usuario genere un PAT + configure un nuevo secret de repo (`BOT_PAT`). Esta solución no necesita ningún secret adicional — todo el auth existente (`GITHUB_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN`) sigue siendo suficiente.

## Plan de prueba

- [ ] Mergear PR
- [ ] Ejecutar `bug-hunter.yml` manualmente via Actions UI (workflow_dispatch)
- [ ] Verificar que el step de Claude hace `gh workflow run claude-fix.yml -f issue_number=<N>`
- [ ] Confirmar que `claude-fix.yml` aparece encolado en Actions con el input correcto
- [ ] Verificar que el PR de fix se crea con el issue vinculado
- [ ] Backfill: para los issues #545–554 ya existentes, disparar manualmente `claude-fix.yml` desde Actions UI una vez (o dejarlos para que el siguiente run de bug-hunter los reprocese vía duplicate-detection).

## Notas

- Si `secrets.CLAUDE_CODE_OAUTH_TOKEN` no está configurado en el repo, el action `anthropics/claude-code-action@v1` fallará con error de auth — pero ese es un problema separado y visible en logs.
- La condición `if:` del job conserva el filtro original para eventos `issues.labeled` (solo `Matraca130` o bug-hunter bot). Para `workflow_dispatch` se trusta al caller (solo usuarios con `actions: write` pueden disparar).

https://claude.ai/code/session_011EGgR1FUNyTxC2kX6krD4y

---
_Generated by [Claude Code](https://claude.ai/code/session_011EGgR1FUNyTxC2kX6krD4y)_