### PR TITLE
ci: add pr-fix workflow — auto-apply TRIVIAL review feedback + 6-gate auto-merge

### DIFF
--- a/.github/workflows/pr-fix.yml
+++ b/.github/workflows/pr-fix.yml
@@ -1,0 +1,297 @@
+name: PR Fix (review comments → auto-fix → optional auto-merge)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  id-token: write
+
+concurrency:
+  group: pr-fix-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    if: >-
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@claude-fix') &&
+        github.event.comment.user.login == 'Matraca130'
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'changes_requested' &&
+        github.event.sender.login != 'claude-fix[bot]'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUM="${{ github.event.issue.number || github.event.pull_request.number }}"
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          PR_JSON=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json headRefName,headRefOid,labels,state,isDraft)
+          HEAD_REF=$(echo "$PR_JSON" | jq -r .headRefName)
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r .headRefOid)
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name' | tr '\n' ',' || echo "")
+          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
+
+      - name: Guard — PR not draft, not blocked
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABELS: ${{ steps.pr.outputs.labels }}
+        run: |
+          if echo "$LABELS" | grep -qE "(^|,)(blocked|do-not-merge)($|,)"; then
+            echo "::error::PR has blocking label — aborting."
+            exit 1
+          fi
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "claude-fix[bot]"
+          git config user.email "claude-fix[bot]@users.noreply.github.com"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit
+
+      - name: Capture baseline metrics
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          # Baseline: count tsc errors on main for delta comparison
+          git fetch origin main --depth=1
+          # Count tsc errors on PR head — we'll compare delta after fix
+          npx tsc --noEmit 2>&1 | grep -cE "error TS[0-9]+:" > /tmp/tsc-before.txt || echo "0" > /tmp/tsc-before.txt
+          echo "tsc_before=$(cat /tmp/tsc-before.txt)" >> "$GITHUB_OUTPUT"
+          # Snapshot HEAD for LOC delta
+          echo "sha_before=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Collect review comments
+        id: comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          # Inline review comments (with file:line)
+          gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | {user: .user.login, path, line, body}' > /tmp/review-comments.jsonl || echo "" > /tmp/review-comments.jsonl
+          # Issue-style comments (body-only)
+          gh api "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | {user: .user.login, body}' > /tmp/issue-comments.jsonl || echo "" > /tmp/issue-comments.jsonl
+          echo "Review comments: $(wc -l < /tmp/review-comments.jsonl)"
+          echo "Issue comments: $(wc -l < /tmp/issue-comments.jsonl)"
+
+      - name: Run Claude fix (guarded by code-reviewer agent)
+        id: fix
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          TSC_BEFORE: ${{ steps.baseline.outputs.tsc_before }}
+          SHA_BEFORE: ${{ steps.baseline.outputs.sha_before }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
+          prompt: |
+            You are fixing review comments on PR #${{ steps.pr.outputs.number }} in repo ${{ github.repository }}.
+
+            ## Context files
+            - `/tmp/review-comments.jsonl` — inline review comments (one JSON per line: user, path, line, body)
+            - `/tmp/issue-comments.jsonl` — general PR comments (user, body)
+
+            ## Workflow — STRICT. Follow exactly.
+
+            ### Step 1: Read comments
+            `cat /tmp/review-comments.jsonl /tmp/issue-comments.jsonl`
+
+            ### Step 2: Classify each finding
+            For each reviewer comment (from `claude[bot]`, `gemini-code-assist[bot]`, or the repo owner), classify:
+            - **TRIVIAL**: ≤3 files affected, ≤100 LOC delta, no architectural decisions, no API-breaking, no changes to types used across >5 files.
+            - **COMPLEX**: anything else. Skip entirely.
+
+            Build a plan listing TRIVIAL findings you will address. Do NOT fix COMPLEX ones.
+
+            ### Step 3: Apply TRIVIAL fixes
+            For each TRIVIAL finding, edit the file with the precise fix suggested by the reviewer. Keep the existing code style.
+
+            **Hard guardrails:**
+            - Do NOT run `git reset`, `git stash`, `git checkout <branch>`, `git restore`, `git clean`. ONLY `git add`, `git commit`, `git push`, `git status`, `git diff`, `git log`.
+            - Do NOT modify `.github/workflows/**`, `.env*`, any file matching `*secret*` or `*credential*`.
+            - Do NOT change public API signatures. If a fix would, skip it.
+            - Do NOT run deploy/publish/release commands.
+
+            ### Step 4: Regression validation (MUST DO — abort if fails)
+            Before committing, run:
+            ```bash
+            # Type-check delta — must not introduce NEW errors in files you touched
+            CHANGED=$(git diff --name-only | grep -E '\.(ts|tsx)$' || true)
+            if [ -n "$CHANGED" ]; then
+              npx tsc --noEmit 2>&1 | tee /tmp/tsc-after.txt
+              NEW_ERRS=0
+              for f in $CHANGED; do
+                B=$(grep -cE "error TS[0-9]+:" /tmp/tsc-after.txt 2>/dev/null | head -1 || echo 0)
+                # Compare against baseline per-file — if grep shows our file has errors post-fix, increment
+                if grep -q "$f" /tmp/tsc-after.txt; then
+                  NEW_ERRS=$((NEW_ERRS+1))
+                fi
+              done
+              if [ "$NEW_ERRS" -gt 0 ]; then
+                echo "::error::Type check introduced new errors in touched files. Aborting."
+                git checkout -- . 2>/dev/null || true  # only safe revert allowed
+                exit 1
+              fi
+            fi
+
+            # Tests — run relevant subset if possible, else full
+            npm test -- --run 2>&1 | tail -30 || {
+              echo "::error::Tests failed post-fix. Aborting."
+              git checkout -- . 2>/dev/null || true
+              exit 1
+            }
+            ```
+
+            ### Step 5: Validate with code-reviewer agent
+            Spawn the code-reviewer subagent (if available in this environment) via Task to double-check the diff:
+            ```
+            Task(subagent_type="code-reviewer", description="Validate fix before commit", prompt="Review this diff for regressions, breaking changes, new CRITICAL/HIGH issues. Focus: did the fix introduce anything worse than what it fixed? Return PASS or FAIL with reasoning.")
+            ```
+            If not available, manually verify the diff is minimal, self-contained, and addresses the cited reviewer comments.
+
+            If FAIL → revert with `git checkout -- .` (only allowed form of revert) and post a PR comment explaining. DO NOT commit.
+
+            ### Step 6: LOC guardrail
+            ```bash
+            LOC_CHANGED=$(git diff --shortstat | grep -oE "[0-9]+ insertion" | head -1 | grep -oE "[0-9]+" || echo 0)
+            LOC_DELETED=$(git diff --shortstat | grep -oE "[0-9]+ deletion" | head -1 | grep -oE "[0-9]+" || echo 0)
+            TOTAL=$((LOC_CHANGED + LOC_DELETED))
+            if [ "$TOTAL" -gt 100 ]; then
+              echo "::error::Bot diff exceeds 100 LOC ($TOTAL). Fix too large for auto-apply — reverting."
+              git checkout -- . 2>/dev/null || true
+              exit 1
+            fi
+            ```
+
+            ### Step 7: Commit + push
+            ```bash
+            git add -A
+            git commit -m "fix(auto): apply review feedback from PR #${{ steps.pr.outputs.number }}
+
+            Applied TRIVIAL fixes from claude[bot] / gemini-code-assist[bot] review:
+            - <list each fix 1-liner>
+
+            Tests and type-check passed post-fix. Bot-authored via pr-fix workflow.
+
+            Co-Authored-By: claude-fix[bot] <claude-fix[bot]@users.noreply.github.com>"
+            git push origin HEAD:$HEAD_REF
+            ```
+
+            ### Step 8: Summary comment on PR
+            Post via `gh pr comment $PR_NUMBER --body "..."`:
+            ```
+            ## 🤖 Auto-fix applied
+
+            **Fixed (TRIVIAL, ≤100 LOC):** <count>
+            - <per-finding one-liner>
+
+            **Skipped (COMPLEX, needs human):** <count>
+            - <per-finding one-liner + why skipped>
+
+            **Gates:** type-check ✅ | tests ✅ | code-reviewer ✅ | LOC ≤100 ✅
+
+            Commit: <sha>
+            ```
+          claude_args: "--model claude-opus-4-7 --allowedTools Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(git checkout -- .),Bash(git fetch:*),Bash(npm:*),Bash(npx:*),Bash(cat:*),Bash(grep:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(gh:*),Bash(jq:*),Read,Edit,Write,Grep,Glob"
+
+      - name: Auto-merge gate (6 conditions)
+        id: automerge
+        if: steps.fix.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          LABELS: ${{ steps.pr.outputs.labels }}
+          SHA_BEFORE: ${{ steps.baseline.outputs.sha_before }}
+        run: |
+          REASONS=()
+
+          # Gate 1: label auto-merge-ok present
+          if ! echo "$LABELS" | grep -qE "(^|,)auto-merge-ok(,|$)"; then
+            REASONS+=("label 'auto-merge-ok' missing")
+          fi
+
+          # Gate 2: no blocking labels (already checked above, re-verify)
+          if echo "$LABELS" | grep -qE "(^|,)(blocked|do-not-merge)(,|$)"; then
+            REASONS+=("blocking label present")
+          fi
+
+          # Gate 3: LOC of bot commits
+          LOC=$(git log "$SHA_BEFORE..HEAD" --author="claude-fix\[bot\]" --numstat \
+                --pretty=format:"" | awk '{a+=$1; d+=$2} END {print a+d+0}')
+          if [ "${LOC:-0}" -gt 100 ]; then
+            REASONS+=("bot LOC ${LOC} > 100")
+          fi
+
+          # Gate 4: test-gate workflow latest run on this PR head SHA = success
+          HEAD_SHA=$(git rev-parse HEAD)
+          TEST_CONC=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=10" \
+            --jq '.workflow_runs[] | select(.name == "Test Gate") | .conclusion' | head -1)
+          if [ "$TEST_CONC" != "success" ]; then
+            REASONS+=("test-gate != success ($TEST_CONC)")
+          fi
+
+          # Gate 5: code-quality-audit latest run = success
+          AUDIT_CONC=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=10" \
+            --jq '.workflow_runs[] | select(.name == "Code Quality Audit") | .conclusion' | head -1)
+          if [ "$AUDIT_CONC" != "success" ]; then
+            REASONS+=("code-quality-audit != success ($AUDIT_CONC)")
+          fi
+
+          # Gate 6: PR mergeable
+          MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq '.mergeable')
+          if [ "$MERGEABLE" != "MERGEABLE" ]; then
+            REASONS+=("PR not mergeable ($MERGEABLE)")
+          fi
+
+          if [ ${#REASONS[@]} -eq 0 ]; then
+            echo "All gates passed — auto-merging."
+            gh pr merge "$PR_NUMBER" --squash --delete-branch
+            gh pr comment "$PR_NUMBER" --body "✅ Auto-merged after 6-gate validation. Commit by \`claude-fix[bot]\`."
+          else
+            REASONS_STR=$(printf '%s\n' "${REASONS[@]}" | sed 's/^/- /')
+            echo "Auto-merge skipped. Gates unmet:"
+            echo "$REASONS_STR"
+            gh pr comment "$PR_NUMBER" --body "🔸 Auto-merge skipped. Gates unmet:
+          $REASONS_STR
+
+          Fix was applied, merge when ready."
+          fi


### PR DESCRIPTION
## Summary
Adds automated fix loop that reads existing review comments and applies TRIVIAL fixes, with optional auto-merge after 6 safety gates.

**Complements** `code-quality-audit.yml` (which already does the review with `code-reviewer`-style analysis) — this workflow is the **fix** half of the loop. Does NOT duplicate review.

## Triggers
- `issue_comment` with `@claude-fix` mention (by repo owner only)
- `pull_request_review` with state `changes_requested` (from non-bot reviewers)

## Flow
1. Checkout PR head, configure git as `claude-fix[bot]`
2. Read review comments via GitHub API (`pulls/{N}/comments` + `issues/{N}/comments`)
3. Classify each comment: **TRIVIAL** (≤3 files, ≤100 LOC, no arch change, no API break) vs **COMPLEX** (skip)
4. Apply TRIVIAL fixes with Edit/Write
5. **Regression validation BEFORE commit (MUST pass)**:
   - Type check on touched files — no new errors
   - Tests — `npm test` must pass
   - `code-reviewer` subagent validation (if available) — PASS verdict required
   - LOC guard — bot diff ≤100 lines
6. If all pass → commit + push to PR branch
7. **Auto-merge gate (6 conditions, all required)**:
   a. Label `auto-merge-ok` present
   b. No `blocked`/`do-not-merge` label
   c. Bot's total LOC ≤100
   d. `Test Gate` workflow success on head SHA
   e. `Code Quality Audit` workflow success on head SHA
   f. PR mergeable state
8. If all 6 pass → `gh pr merge --squash --delete-branch` + summary comment. Else → post comment listing unmet gates, leave merge to human.

## Hard guardrails
- **No destructive git**: only `git add`, `git commit`, `git push`, `git checkout -- <file>` (single-file revert). No `reset`/`stash`/`checkout <branch>`/`restore`/`clean` — addresses the incident of this sprint where parallel agents ran `git reset` and lost work.
- **No touch**: `.github/workflows/**`, `.env*`, `*secret*`, `*credential*`
- **No API changes**: public signatures immutable
- **No deploy/publish/release** commands
- **Anti-loop**: commits by `claude-fix[bot]` → workflow filters out sender, cannot self-trigger
- Timeout 25 min

## Out of scope (not attempted — flagged for human)
- Architectural decisions (e.g., JWT storage, auth strategy)
- API contract / breaking changes
- Multi-file refactors (>3 files)
- Pre-existing findings unrelated to the PR
- Findings requiring new dependencies

## Test plan
- [ ] Merge this PR to main
- [ ] Add label `auto-merge-ok` on an open PR with pending review comments
- [ ] Comment `@claude-fix` on that PR → workflow triggers
- [ ] Verify: fixes applied, tests pass, commit pushed as `claude-fix[bot]`
- [ ] Verify: auto-merge runs if all 6 gates pass; if not, summary comment lists unmet gates
- [ ] Verify: large PRs (>100 LOC bot diff) do NOT auto-merge
- [ ] Verify: PRs with `blocked` label abort early

🤖 Generated with [Claude Code](https://claude.com/claude-code)