### PR TITLE
ci(pr-fix): use PAT for push + poll workflows before auto-merge

### DIFF
--- a/.github/workflows/pr-fix.yml
+++ b/.github/workflows/pr-fix.yml
@@ -65,7 +65,9 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          # PAT instead of GITHUB_TOKEN so bot commits trigger downstream workflows
+          # (GITHUB_TOKEN pushes don't trigger workflow runs by design).
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Configure git identity
         run: |
@@ -261,20 +263,41 @@ jobs:
             REASONS+=("bot LOC ${LOC} > 100")
           fi
 
-          # Gate 4: test-gate workflow latest run on this PR head SHA = success
+          # Gate 4+5: wait for required workflows to COMPLETE, then check conclusion.
+          # FE workflows that run on pull_request sync: PR Opened Review, Sprint Preflight, Code Quality Audit.
+          # (Note: Test Gate / Frontend Tests only run on push to main, not PR branches.)
           HEAD_SHA=$(git rev-parse HEAD)
-          TEST_CONC=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=10" \
-            --jq '.workflow_runs[] | select(.name == "Test Gate") | .conclusion' | head -1)
-          if [ "$TEST_CONC" != "success" ]; then
-            REASONS+=("test-gate != success ($TEST_CONC)")
-          fi
+          REQUIRED_WORKFLOWS=("PR Opened Review" "Sprint Preflight" "Code Quality Audit")
+          MAX_WAIT=900   # 15 min
+          ELAPSED=0
+          POLL=30
+          while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+            ALL_DONE=1
+            gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=30" > /tmp/runs.json
+            for WF in "${REQUIRED_WORKFLOWS[@]}"; do
+              STATUS=$(jq -r --arg wf "$WF" '.workflow_runs[] | select(.name == $wf) | .status' /tmp/runs.json | head -1)
+              STATUS="${STATUS:-missing}"
+              if [ "$STATUS" != "completed" ]; then
+                ALL_DONE=0
+                echo "  waiting: $WF = $STATUS (elapsed ${ELAPSED}s)"
+              fi
+            done
+            if [ "$ALL_DONE" -eq 1 ]; then
+              echo "All required workflows completed after ${ELAPSED}s"
+              break
+            fi
+            sleep "$POLL"
+            ELAPSED=$((ELAPSED + POLL))
+          done
 
-          # Gate 5: code-quality-audit latest run = success
-          AUDIT_CONC=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=10" \
-            --jq '.workflow_runs[] | select(.name == "Code Quality Audit") | .conclusion' | head -1)
-          if [ "$AUDIT_CONC" != "success" ]; then
-            REASONS+=("code-quality-audit != success ($AUDIT_CONC)")
-          fi
+          # Now check conclusions
+          gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=30" > /tmp/runs.json
+          for WF in "${REQUIRED_WORKFLOWS[@]}"; do
+            CONC=$(jq -r --arg wf "$WF" '.workflow_runs[] | select(.name == $wf) | .conclusion' /tmp/runs.json | head -1)
+            if [ "$CONC" != "success" ]; then
+              REASONS+=("$WF != success (${CONC:-missing-or-timeout})")
+            fi
+          done
 
           # Gate 6: PR mergeable
           MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq '.mergeable')


### PR DESCRIPTION
## Summary
Fixes 2 issues found in the live test on FE PR #593 (run 24863505902):

1. **Push with PAT** — GITHUB_TOKEN pushes don't trigger workflows (GitHub's anti-loop). Bot commit `333fb1d` didn't trigger Test Gate / Code Quality Audit / PR Opened Review, so auto-merge gates found empty results.
2. **Poll workflows to completion** — gate step was checking immediately after push, before downstream workflows had a chance to queue. Now polls every 30s for up to 15 min.
3. **Correct workflow names for FE** — `test-gate.yml` only runs on push to main, not PR sync. Replaced with the actual PR-sync workflows.

## Required
- Secret `GH_PAT` must be set in repo (already done via API, points to Matraca130's PAT).

## Test plan
- [ ] Merge this PR to main
- [ ] Trigger pr-fix on any PR with review comments
- [ ] Verify bot commit appears and downstream workflows ("PR Opened Review" etc.) RUN (they didn't before)
- [ ] With label `auto-merge-ok`, verify auto-merge completes after gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)