### PR TITLE
test(ci): validate pr-fix v2 full flow

### DIFF
--- a/src/app/lib/auto-fix-marker-v2.ts
+++ b/src/app/lib/auto-fix-marker-v2.ts
@@ -1,0 +1,2 @@
+// Test file for validating pr-fix v2 workflow. Safe to remove.
+export const AUTO_FIX_V2_MARKER: any = 'v2';

--- a/src/app/lib/auto-fix-marker-v2.ts
+++ b/src/app/lib/auto-fix-marker-v2.ts
@@ -1,2 +1,2 @@
 // Test file for validating pr-fix v2 workflow. Safe to remove.
-export const AUTO_FIX_V2_MARKER: any = 'v2';
+export const AUTO_FIX_V2_MARKER: string = 'v2';


### PR DESCRIPTION
Fresh test of pr-fix v2 (linear flow). `AUTO_FIX_V2_MARKER` has `any` type that should be replaced with `string` via `@claude-fix` comment below.

Expected: full flow in 5-8 min, auto-merge via label.