### PR TITLE
ci(pr-fix): hotfix 2 — GH_REPO env for pre-checkout gh calls

### DIFF
--- a/.github/workflows/pr-fix.yml
+++ b/.github/workflows/pr-fix.yml
@@ -45,6 +45,7 @@ jobs:
     timeout-minutes: 25
     env:
       GH_TOKEN: ${{ secrets.GH_PAT || github.token }}  # PAT so commits trigger workflows
+      GH_REPO: ${{ github.repository }}  # lets gh commands work before checkout (no .git yet)
 
     steps:
       - name: Resolve PR metadata

--- a/.github/workflows/pr-fix.yml
+++ b/.github/workflows/pr-fix.yml
@@ -18,7 +18,11 @@ permissions:
 
 concurrency:
   group: pr-fix-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true  # a new @claude-fix cancels the previous attempt
+  # `false`, not `true`: bot-triggered issue_comment events (Vercel, Cloudflare,
+  # gemini-code-assist) fire on the same PR number and would CANCEL the real
+  # @claude-fix run if set to true. They skip fast via the `if` filter (~5s),
+  # so queuing them behind real runs costs almost nothing.
+  cancel-in-progress: false
 
 jobs:
   fix:


### PR DESCRIPTION
Fixes "fatal: not a git repository" at mergeable-state poll step. Sets GH_REPO env at job level.