### PR TITLE
fix(deps): bump postcss to 8.5.12 (closes GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,9 +7117,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves the moderate-severity advisory blocking the Security Scan workflow on every PR.

## What

- `postcss` 8.5.8 → 8.5.12 (lockfile only, 3-line diff)
- npm audit clean: `found 0 vulnerabilities`

## Why

[GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — PostCSS does not escape `</style>` in CSS Stringify output. Low real-world impact for Axon (PostCSS is build-time only via Vite/Tailwind), but the advisory was failing every PR's `Dependency Audit` check.

## Testing

- `npm audit --audit-level=moderate` returns exit 0
- No production code touched, only lockfile