### PR TITLE
docs(readme): add npm run build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@
   Run `npm i` to install the dependencies.
 
   Run `npm run dev` to start the development server.
+
+  Run `npm run build` to produce a production build in `dist/`.
   


### PR DESCRIPTION
## Summary
- Tiny README addition documenting `npm run build` alongside the existing dev instruction.
- Opened as a small end-to-end smoke test of the workflow (commit → push → draft PR).

## Test plan
- [ ] CI passes on the branch
- [ ] Draft PR renders correctly and is reviewable

https://claude.ai/code/session_01EMPRQHHy1snXkrBq2wLF6K

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMPRQHHy1snXkrBq2wLF6K)_